### PR TITLE
feat: add AskUserQuestion tool support

### DIFF
--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -734,6 +734,91 @@ describe("tool conversions", () => {
       ],
     });
   });
+
+  describe("AskUserQuestion tool", () => {
+    it("should format tool info correctly", () => {
+      const toolUse = {
+        type: "tool_use",
+        id: "test-ask",
+        name: "AskUserQuestion",
+        input: {
+          questions: [
+            {
+              question: "What is your favorite color?",
+              header: "Color",
+              multiSelect: false,
+              options: [
+                { label: "Blue", description: "Calming" },
+                { label: "Red", description: "Bold" },
+              ],
+            },
+          ],
+        },
+      };
+
+      const info = toolInfoFromToolUse(toolUse);
+      expect(info.title).toBe("Color");
+      expect(info.kind).toBe("other");
+      expect(info.content).toHaveLength(1);
+    });
+
+    it("should handle multiple questions", () => {
+      const toolUse = {
+        type: "tool_use",
+        id: "test-multi",
+        name: "AskUserQuestion",
+        input: {
+          questions: [
+            { question: "Q1?", header: "First", multiSelect: false, options: [] },
+            { question: "Q2?", header: "Second", multiSelect: true, options: [] },
+          ],
+        },
+      };
+
+      const info = toolInfoFromToolUse(toolUse);
+      expect(info.title).toBe("First"); // Uses first question header
+    });
+
+    it("should handle empty questions array", () => {
+      const toolUse = {
+        type: "tool_use",
+        id: "test-empty",
+        name: "AskUserQuestion",
+        input: {
+          questions: [],
+        },
+      };
+
+      const info = toolInfoFromToolUse(toolUse);
+      expect(info.title).toBe("Questions (0)");
+      expect(info.content).toHaveLength(0);
+    });
+
+    it("should handle missing header", () => {
+      const toolUse = {
+        type: "tool_use",
+        id: "test-no-header",
+        name: "AskUserQuestion",
+        input: {
+          questions: [
+            {
+              question: "What do you prefer?",
+              multiSelect: false,
+              options: [{ label: "Option A" }, { label: "Option B" }],
+            },
+          ],
+        },
+      };
+
+      const info = toolInfoFromToolUse(toolUse);
+      expect(info.title).toBe("Questions (1)");
+      const contentItem = info.content[0] as {
+        type: "content";
+        content: { type: string; text: string };
+      };
+      expect(contentItem.content.text).toContain("**Question**: What do you prefer?");
+    });
+  });
 });
 
 describe("escape markdown", () => {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -372,6 +372,24 @@ export function toolInfoFromToolUse(toolUse: any): ToolInfo {
             : [],
       };
 
+    case "AskUserQuestion": {
+      const questions = input?.questions || [];
+      const firstQ = questions[0];
+      return {
+        title: firstQ?.header || `Questions (${questions.length})`,
+        kind: "other",
+        content: questions.map((q: any) => ({
+          type: "content",
+          content: {
+            type: "text",
+            text: `**${q.header || "Question"}**: ${q.question}\nOptions: ${
+              q.options?.map((o: any) => o.label).join(", ") || "None"
+            }`,
+          },
+        })),
+      };
+    }
+
     case "Other": {
       let output;
       try {
@@ -517,6 +535,9 @@ export function toolUpdateFromToolResult(
     case "ExitPlanMode": {
       return { title: "Exited Plan Mode" };
     }
+
+    case "AskUserQuestion":
+      return toAcpContentUpdate(toolResult.content, false);
 
     case "Task":
     case "NotebookEdit":


### PR DESCRIPTION
## Summary

Implements full `AskUserQuestion` tool support in claude-code-acp with backward compatibility via opt-in client capability.

- Clients can declare support via `{ clientCapabilities: { _meta: { askUserQuestion: true } } }`
- Non-supporting clients receive empty answers (graceful degradation), allowing Claude to ask follow-up questions in chat instead
- Rich clients can provide structured answers via `_meta.answers` in the permission response

## Changes

- **src/acp-agent.ts**: Add `supportsAskUserQuestion()` helper and AskUserQuestion handler in `canUseTool()`
- **src/tools.ts**: Add `toolInfoFromToolUse` and `toolUpdateFromToolResult` cases for AskUserQuestion
- **src/tests/acp-agent.test.ts**: Add unit tests for the new functionality

## Protocol

### Client → Server (capability declaration)
```json
{
  "clientCapabilities": {
    "_meta": { "askUserQuestion": true }
  }
}
```

### Server → Client (question request)
```typescript
{
  options: [
    { kind: "allow_once", name: "Blue", optionId: "q0_opt0" },
    { kind: "allow_once", name: "Red", optionId: "q0_opt1" },
    { kind: "allow_once", name: "Other", optionId: "q0_other" },
  ],
  _meta: {
    askUserQuestion: { questions: [...] }
  }
}
```

### Client → Server (answer)
```typescript
{
  outcome: { outcome: "selected", optionId: "q0_opt0" },
  // OR for rich clients:
  _meta: { answers: { "Question text": "Selected answer" } }
}
```

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` compiles without errors
- [x] `npm run test:run` - all tests pass

Closes #150
Related to #136