### PR TITLE
feat: skip setModel() when model is provided via query Options

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1425,7 +1425,7 @@ export class ClaudeAcpAgent implements Agent {
       );
     }
 
-    const models = await getAvailableModels(q, initializationResult.models, settingsManager);
+    const models = await getAvailableModels(q, initializationResult.models, settingsManager, options.model);
 
     const availableModes = [
       {
@@ -1619,6 +1619,7 @@ async function getAvailableModels(
   query: Query,
   models: ModelInfo[],
   settingsManager: SettingsManager,
+  optionsModel?: string,
 ): Promise<SessionModelState> {
   const settings = settingsManager.getSettings();
 
@@ -1631,7 +1632,18 @@ async function getAvailableModels(
     }
   }
 
-  await query.setModel(currentModel.value);
+  if (optionsModel) {
+    // Model was already passed via query Options at CLI startup time.
+    // Resolve it against available models for currentModelId, but skip
+    // setModel() to avoid triggering a /model command that leaks into
+    // the event stream.
+    const match = resolveModelPreference(models, optionsModel);
+    if (match) {
+      currentModel = match;
+    }
+  } else {
+    await query.setModel(currentModel.value);
+  }
 
   return {
     availableModels: models.map((model) => ({


### PR DESCRIPTION
## Summary

When a client passes `model` through `_meta.claudeCode.options` in `session/new`, the model is already set at CLI startup time via the `query()` Options parameter. The subsequent `setModel()` call in `getAvailableModels()` is unnecessary and causes two issues:

1. **`/model` command leaks into the ACP event stream** — `setModel()` triggers a `/model` CLI command whose output appears as `user_message_chunk` events, polluting the client's UI
2. **Extra round-trip** — adds a synchronous `setModel()` call to every session creation

## Changes

- Add `optionsModel` parameter to `getAvailableModels()` 
- When `optionsModel` is present, resolve it against available models for `currentModelId` reporting but **skip the `setModel()` call**
- Pass `options.model` (which comes from `_meta.claudeCode.options` spread) at the call site

## Effort support

The same `_meta.claudeCode.options` path also supports `effort` — it gets spread into SDK `Options` and takes effect at CLI startup via `query({ options: { effort } })`. No adapter changes needed for effort support; this PR unblocks it by establishing the pattern of passing config through `_meta` instead of post-hoc commands.

This addresses #441 — effort can now be passed through `_meta.claudeCode.options.effort` without waiting for a runtime `setEffort()` API.

## Backward compatibility

Clients that don't pass `_meta.claudeCode.options.model` get the existing behavior — `setModel()` is called as before. Only clients that explicitly provide a model via `_meta` benefit from the optimization.

## Test plan

- [ ] Existing tests pass
- [ ] Client sends `session/new` with `_meta: { claudeCode: { options: { model: "claude-opus-4-6" } } }` → no `/model` command in event stream
- [ ] Client sends `session/new` without `_meta` → existing `setModel()` behavior unchanged
- [ ] Client sends `_meta.claudeCode.options.effort` → effort takes effect at CLI startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)