### PR TITLE
fix: Restore summarized thinking display on Opus 4.7

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1544,6 +1544,11 @@ export class ClaudeAcpAgent implements Agent {
     const options: Options = {
       systemPrompt,
       settingSources: ["user", "project", "local"],
+      // Opus 4.7 silently changed `thinking.display` to default `"omitted"`,
+      // so thinking blocks stream with an empty `thinking` field. Opt back into
+      // summarized thinking to restore the prior Opus 4.6 behavior. Overridable
+      // via `userProvidedOptions.thinking` below.
+      thinking: { type: "adaptive", display: "summarized" },
       ...(maxThinkingTokens !== undefined && { maxThinkingTokens }),
       ...userProvidedOptions,
       env: {


### PR DESCRIPTION
## Summary

Opus 4.7 silently changed the default for `thinking.display` from `"summarized"` to `"omitted"`. As a result, thinking blocks still stream but their `thinking` field arrives empty, so users no longer see Claude's reasoning surfaced in the ACP `agent_thought_chunk` notifications that flow from this SDK.

This PR sets `Options.thinking = { type: "adaptive", display: "summarized" }` as the default when constructing the session's SDK `Options`, restoring the behavior that existed on Opus 4.6. The default is applied before the `...userProvidedOptions` spread, so callers supplying their own `thinking` config via `_meta.claudeCode.options.thinking` still override it.

Anthropic docs:
- [Adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) — on Opus 4.7, `adaptive` is the only supported thinking mode.
- [Controlling thinking display](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#controlling-thinking-display) — explicitly notes that `display` must be set to `"summarized"` on Opus 4.7 to get summarized thinking back.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:run` passes (184 tests)
- [ ] Manual verification: start a session on Opus 4.7, prompt a reasoning-heavy question, confirm `agent_thought_chunk` notifications arrive with non-empty text