### PR TITLE
fix: Empty thinking text in thought chunks on current Claude models

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3880,20 +3880,27 @@ async function fetchContextUsedTokens(query: Query, logger: Logger): Promise<num
 /** Translate the legacy `MAX_THINKING_TOKENS` env var into the SDK's `thinking`
  *  option. The `maxThinkingTokens` option it used to feed is deprecated and
  *  reduced to on/off on current models, so map the value to explicit thinking
- *  config instead: unset → `undefined` (SDK default, adaptive on models that
+ *  config instead: unset → adaptive (matching the SDK default on models that
  *  support it); `0` → disabled; a positive integer → a fixed token budget.
- *  Anything else is ignored with a warning. */
+ *  Anything else is ignored with a warning.
+ *
+ *  Recent models default `display` to "omitted", which streams thinking blocks
+ *  whose text is empty (signature-only) — clients receive agent_thought_chunk
+ *  notifications with no content. Request "summarized" explicitly so thought
+ *  chunks carry visible text. */
 function resolveThinkingConfig(
   raw: string | undefined,
   logger: Logger,
 ): ThinkingConfig | undefined {
-  if (raw === undefined) return undefined;
+  if (raw === undefined) return { type: "adaptive", display: "summarized" };
   const parsed = Number.parseInt(raw, 10);
   if (Number.isNaN(parsed) || parsed < 0) {
     logger.error(`Ignoring MAX_THINKING_TOKENS: expected a non-negative integer, got '${raw}'.`);
-    return undefined;
+    return { type: "adaptive", display: "summarized" };
   }
-  return parsed === 0 ? { type: "disabled" } : { type: "enabled", budgetTokens: parsed };
+  return parsed === 0
+    ? { type: "disabled" }
+    : { type: "enabled", budgetTokens: parsed, display: "summarized" };
 }
 
 function parseModelConfig(

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -493,9 +493,12 @@ describe("createSession options merging", () => {
       }
     });
 
-    it("leaves thinking unset (SDK default) when env var is absent", async () => {
+    it("defaults to adaptive thinking with summarized display when env var is absent", async () => {
+      // Recent models default `display` to "omitted", which streams thinking
+      // blocks with empty text — request "summarized" so agent_thought_chunk
+      // notifications carry visible content.
       await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
-      expect(capturedOptions!.thinking).toBeUndefined();
+      expect(capturedOptions!.thinking).toEqual({ type: "adaptive", display: "summarized" });
       // The deprecated option must not be set either.
       expect(capturedOptions!.maxThinkingTokens).toBeUndefined();
     });
@@ -506,16 +509,20 @@ describe("createSession options merging", () => {
       expect(capturedOptions!.thinking).toEqual({ type: "disabled" });
     });
 
-    it("maps a positive value to a fixed thinking budget", async () => {
+    it("maps a positive value to a fixed thinking budget with summarized display", async () => {
       process.env.MAX_THINKING_TOKENS = "12000";
       await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
-      expect(capturedOptions!.thinking).toEqual({ type: "enabled", budgetTokens: 12000 });
+      expect(capturedOptions!.thinking).toEqual({
+        type: "enabled",
+        budgetTokens: 12000,
+        display: "summarized",
+      });
     });
 
-    it("ignores a non-numeric value", async () => {
+    it("falls back to the adaptive default on a non-numeric value", async () => {
       process.env.MAX_THINKING_TOKENS = "lots";
       await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
-      expect(capturedOptions!.thinking).toBeUndefined();
+      expect(capturedOptions!.thinking).toEqual({ type: "adaptive", display: "summarized" });
     });
 
     it("lets a user-provided thinking option override the env default", async () => {


### PR DESCRIPTION
Recent Claude models default the API's `thinking.display` field to "omitted". Thinking blocks still stream, but signature-only: the block opens, a single signature_delta arrives, and no thinking_delta ever carries text. The agent then emits agent_thought_chunk notifications whose text is always empty, so ACP clients render blank thought sections — regardless of effort level or MAX_THINKING_TOKENS.

Request `display: "summarized"` explicitly so thought chunks carry visible summary text again:

- unset MAX_THINKING_TOKENS → {type: "adaptive", display: "summarized"} (adaptive matches the SDK default on current models, but is now sent explicitly where previously no thinking config was sent at all)
- positive budget → display added to the enabled config
- 0 (disabled) unchanged

A thinking config provided via _meta.claudeCode.options still overrides this default wholesale, so embedders retain full control.

Verified over ACP traffic with an Emacs agent-shell client on claude-fable-5, claude-opus-4-8, and claude-sonnet-4-6: before, every agent_thought_chunk had empty text; after, summarized reasoning streams and renders.

Related: #297