### PR TITLE
test: isolate CLAUDE_CONFIG_DIR in settings tests to stop user-tier leak

### DIFF
--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -7,13 +7,26 @@ import * as os from "node:os";
 describe("SettingsManager", () => {
   let tempDir: string;
   let settingsManager: SettingsManager;
+  let originalConfigDir: string | undefined;
 
   beforeEach(async () => {
     tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "settings-test-"));
+    // Isolate the user tier. resolveSettings reads the user settings.json from
+    // CLAUDE_CONFIG_DIR at call time; without this it falls back to the real
+    // ~/.claude and the developer's own settings (e.g. availableModels) leak
+    // into the merge, making union-based assertions fail on their machine.
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = path.join(tempDir, "user-config");
+    await fs.promises.mkdir(process.env.CLAUDE_CONFIG_DIR, { recursive: true });
   });
 
   afterEach(async () => {
     settingsManager?.dispose();
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

`src/tests/settings.test.ts` didn't isolate the **user settings tier**, so the `availableModels` merge tests failed on any machine whose real `~/.claude/settings.json` defines `availableModels`.

`SettingsManager.loadAllSettings()` resolves through the SDK's `resolveSettings({ cwd })`, which reads the user `settings.json` from `process.env.CLAUDE_CONFIG_DIR` at call time and falls back to the real `~/.claude` when it's unset. The tests set up only the project/local tiers under a temp `cwd` and left the user tier pointing at the developer's real home, so the developer's own settings merged into the result.

This only surfaced for `availableModels` because that key is **unioned** across tiers — leaked entries get prepended. `model` and `permissions.defaultMode` use override semantics (project tier wins), so they masked the leak. Example failure with `availableModels: ["sonnet","opus","haiku"]` in the user's real settings:

```
- Expected
+ Received
+   "sonnet",
+   "opus",
+   "haiku",
    "claude-haiku-4-5",
    "claude-opus-4-7[1m]",
    "claude-sonnet-4-6[1m]",
```

## Fix

Point `CLAUDE_CONFIG_DIR` at an empty per-test directory in `beforeEach` (and restore it in `afterEach`) so the user tier contributes nothing. This mirrors the isolation already used in `acp-agent-settings.test.ts`.

Test-only change; no production code touched.

## Test Plan

- `settings.test.ts` run plainly with a real `~/.claude` containing `availableModels` → 10 passed (previously 2 failing).
- `settings.test.ts` run with `CLAUDE_CONFIG_DIR` pointed at a directory holding decoy `availableModels`/`model` → 10 passed, confirming `beforeEach` overrides any external user tier.
- Full suite with no env wrapper → 355 passed, 0 failed.
- lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)