### PR TITLE
fix: Skip empty thinking chunks

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3919,13 +3919,17 @@ export function toAcpNotifications(
         break;
       case "thinking":
       case "thinking_delta":
-        update = {
-          sessionUpdate: "agent_thought_chunk",
-          content: {
-            type: "text",
-            text: chunk.thinking,
-          },
-        };
+        // Recent models default `thinking.display` to "omitted", which streams
+        // signature-only thinking blocks whose text is empty.
+        if (chunk.thinking.length > 0) {
+          update = {
+            sessionUpdate: "agent_thought_chunk",
+            content: {
+              type: "text",
+              text: chunk.thinking,
+            },
+          };
+        }
         break;
       case "tool_use":
       case "server_tool_use":

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -5385,6 +5385,55 @@ describe("toAcpNotifications messageId", () => {
   });
 });
 
+describe("toAcpNotifications thinking chunks", () => {
+  it("emits an agent_thought_chunk for non-empty thinking text", () => {
+    const result = toAcpNotifications(
+      [{ type: "thinking", thinking: "let me reason", signature: "" }],
+      "assistant",
+      "test",
+      {},
+      {} as AcpClient,
+      console,
+    );
+
+    expect(result).toEqual([
+      {
+        sessionId: "test",
+        update: {
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "let me reason" },
+        },
+      },
+    ]);
+  });
+
+  it("skips empty thinking blocks (display: 'omitted' signature-only blocks)", () => {
+    const result = toAcpNotifications(
+      [{ type: "thinking", thinking: "", signature: "abc" }],
+      "assistant",
+      "test",
+      {},
+      {} as AcpClient,
+      console,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips empty thinking deltas", () => {
+    const result = toAcpNotifications(
+      [{ type: "thinking_delta", thinking: "", estimated_tokens: 0 }],
+      "assistant",
+      "test",
+      {},
+      {} as AcpClient,
+      console,
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
 describe("messageIdForGrouping", () => {
   it("uses the Anthropic API message id for assistant messages", () => {
     const message = {


### PR DESCRIPTION
These carried a signature but we don't need that in the updates if it is
empty.
