### PR TITLE
wait for the first tool_use chunk in canUseTool

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -275,6 +275,11 @@ type Session = {
    *  `tool_result` time so a long-running session doesn't accumulate every
    *  tool call for its whole lifetime. */
   toolUseCache: ToolUseCache;
+  /**
+   * This lets canUseTool wait for the first tool call message from the SDK
+   * to ensure it emits a tool_call_update only after the first tool_call message.
+   */
+  waitingForToolCall: WaitingForToolCall;
   /** Maps the ACP `messageId` we expose to clients (see `messageIdForGrouping`)
    *  to the SDK message uuid that the Agent SDK's rewind/resume APIs key on
    *  (`Query.rewindFiles` takes a user-message uuid; `resumeSessionAt` takes an
@@ -388,6 +393,8 @@ export type ToolUpdateMeta = {
     signal: string | null;
   };
 };
+
+export type WaitingForToolCall = Map<string, () => void>;
 
 export type ToolUseCache = {
   [key: string]: {
@@ -1689,6 +1696,7 @@ export class ClaudeAcpAgent {
                     "assistant",
                     params.sessionId,
                     session.toolUseCache,
+                    session.waitingForToolCall,
                     this.client,
                     this.logger,
                   )) {
@@ -1859,6 +1867,7 @@ export class ClaudeAcpAgent {
               message,
               params.sessionId,
               session.toolUseCache,
+              session.waitingForToolCall,
               this.client,
               this.logger,
               {
@@ -1959,6 +1968,7 @@ export class ClaudeAcpAgent {
                   message.message.role,
                   params.sessionId,
                   session.toolUseCache,
+                  session.waitingForToolCall,
                   this.client,
                   this.logger,
                   {
@@ -2089,6 +2099,7 @@ export class ClaudeAcpAgent {
               message.message.role,
               params.sessionId,
               session.toolUseCache,
+              session.waitingForToolCall,
               this.client,
               this.logger,
               {
@@ -2456,6 +2467,7 @@ export class ClaudeAcpAgent {
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const messages = await getSessionMessages(sessionId);
 
     for (const message of messages) {
@@ -2484,6 +2496,7 @@ export class ClaudeAcpAgent {
         message.message.role,
         sessionId,
         toolUseCache,
+        waitingForToolCall,
         this.client,
         this.logger,
         {
@@ -2532,8 +2545,6 @@ export class ClaudeAcpAgent {
 
   canUseTool(sessionId: string): CanUseTool {
     return async (toolName, toolInput, { signal, suggestions, toolUseID }) => {
-      const alwaysAllowLabel = describeAlwaysAllow(suggestions, toolName);
-      const supportsTerminalOutput = this.clientCapabilities?._meta?.["terminal_output"] === true;
       const session = this.sessions[sessionId];
       if (!session) {
         return {
@@ -2541,6 +2552,13 @@ export class ClaudeAcpAgent {
           message: "Session not found",
         };
       }
+      if (!session.toolUseCache[toolUseID]) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        session.waitingForToolCall.set(toolUseID, resolve);
+        await promise;
+      }
+      const alwaysAllowLabel = describeAlwaysAllow(suggestions, toolName);
+      const supportsTerminalOutput = this.clientCapabilities?._meta?.["terminal_output"] === true;
 
       // AskUserQuestion is surfaced to us as a normal permission check (the SDK
       // routes it through canUseTool whenever a callback is registered, rather
@@ -3401,6 +3419,7 @@ export class ClaudeAcpAgent {
         ) ?? DEFAULT_CONTEXT_WINDOW,
       taskState,
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
 
@@ -4126,6 +4145,7 @@ export function toAcpNotifications(
   role: "assistant" | "user",
   sessionId: string,
   toolUseCache: ToolUseCache,
+  waitingForToolCall: WaitingForToolCall,
   client: AcpClient,
   logger: Logger,
   options?: {
@@ -4295,6 +4315,13 @@ export function toAcpNotifications(
               ...toolInfoFromToolUse(chunk, supportsTerminalOutput, options?.cwd),
             };
           } else {
+            if (waitingForToolCall.has(chunk.id)) {
+              // If a canUseTool is waiting for the first tool_use chunk,
+              // we can resolve it now.
+              const resolve = waitingForToolCall.get(chunk.id)!;
+              resolve();
+              waitingForToolCall.delete(chunk.id);
+            }
             // First encounter (streaming content_block_start or replay) —
             // send as tool_call with terminal_info for Bash tools.
             update = {
@@ -4452,6 +4479,7 @@ export function streamEventToAcpNotifications(
   message: SDKPartialAssistantMessage,
   sessionId: string,
   toolUseCache: ToolUseCache,
+  waitingForToolCall: WaitingForToolCall,
   client: AcpClient,
   logger: Logger,
   options?: {
@@ -4469,6 +4497,7 @@ export function streamEventToAcpNotifications(
         "assistant",
         sessionId,
         toolUseCache,
+        waitingForToolCall,
         client,
         logger,
         {
@@ -4485,6 +4514,7 @@ export function streamEventToAcpNotifications(
         "assistant",
         sessionId,
         toolUseCache,
+        waitingForToolCall,
         client,
         logger,
         {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -118,6 +118,7 @@ function mockSessionState(overrides: Record<string, any> = {}) {
     contextWindowSize: 200000,
     taskState: new Map(),
     toolUseCache: {},
+    waitingForToolCall: new Map(),
     messageIdToUuid: new Map(),
     ...overrides,
   } as any;
@@ -872,6 +873,7 @@ describe("tool conversions", () => {
         received.message.role,
         "test",
         {},
+        new Map(),
         {} as AcpClient,
         console,
       ),
@@ -1814,10 +1816,50 @@ describe("permission request cancellation", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     } as any;
     return agent.sessions[sessionId]!;
   }
+
+  it("waits for the first tool_call before requesting permission", async () => {
+    const requestPermission = vi.fn(async () => ({
+      outcome: { outcome: "selected", optionId: "allow" },
+    }));
+    const mockClient = {
+      sessionUpdate: async () => {},
+      requestPermission,
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+    const session = injectSession(agent, "session-1");
+
+    const pending = agent.canUseTool("session-1")("Bash", { command: "echo hello" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "tool-1",
+    } as any);
+
+    await Promise.resolve();
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(session.waitingForToolCall.has("tool-1")).toBe(true);
+
+    const notifications = toAcpNotifications(
+      [{ type: "tool_use", id: "tool-1", name: "Bash", input: { command: "echo hello" } }],
+      "assistant",
+      "session-1",
+      session.toolUseCache,
+      session.waitingForToolCall,
+      mockClient,
+      console,
+    );
+
+    expect(notifications[0].update.sessionUpdate).toBe("tool_call");
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    await expect(pending).resolves.toMatchObject({ behavior: "allow" });
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(session.waitingForToolCall.has("tool-1")).toBe(false);
+  });
 
   it("forwards the tool-call signal so a pending permission request is cancelled on abort", async () => {
     let receivedSignal: AbortSignal | undefined;
@@ -1835,7 +1877,13 @@ describe("permission request cancellation", () => {
       },
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
-    injectSession(agent, "session-1");
+    const session = injectSession(agent, "session-1");
+    session.toolUseCache["tool-1"] = {
+      type: "tool_use",
+      id: "tool-1",
+      name: "Bash",
+      input: { command: "ls" },
+    };
 
     const controller = new AbortController();
     const pending = agent.canUseTool("session-1")("Bash", { command: "ls" }, {
@@ -1860,7 +1908,13 @@ describe("permission request cancellation", () => {
       requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
-    injectSession(agent, "session-1");
+    const session = injectSession(agent, "session-1");
+    session.toolUseCache["tool-1"] = {
+      type: "tool_use",
+      id: "tool-1",
+      name: "Bash",
+      input: { command: "ls" },
+    };
 
     await expect(
       agent.canUseTool("session-1")("Bash", { command: "ls" }, {
@@ -2564,6 +2618,7 @@ describe("session/close", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
     return agent.sessions[sessionId]!;
@@ -2649,6 +2704,7 @@ describe("session/delete", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
     return agent.sessions[sessionId]!;
@@ -2751,6 +2807,7 @@ describe("getOrCreateSession param change detection", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
     return agent.sessions[sessionId]!;
@@ -4965,6 +5022,7 @@ describe("post-error recovery", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
     return { interrupt };
@@ -5535,6 +5593,7 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       toolUseCache: {},
+      waitingForToolCall: new Map(),
       messageIdToUuid: new Map(),
     };
     return { interrupt };
@@ -5666,9 +5725,8 @@ describe("streamEventToAcpNotifications", () => {
       pingMessage,
       "test-session",
       {},
-      { sessionUpdate: async () => {} } as unknown as Parameters<
-        typeof streamEventToAcpNotifications
-      >[3],
+      new Map(),
+      { sessionUpdate: async () => {} } as unknown as AcpClient,
       logger,
     );
 
@@ -5690,9 +5748,17 @@ describe("streamEventToAcpNotifications", () => {
       },
     } as Parameters<typeof streamEventToAcpNotifications>[0];
 
-    const result = streamEventToAcpNotifications(message, "test", {}, {} as AcpClient, console, {
-      messageId,
-    });
+    const result = streamEventToAcpNotifications(
+      message,
+      "test",
+      {},
+      new Map(),
+      {} as AcpClient,
+      console,
+      {
+        messageId,
+      },
+    );
 
     expect(result).toEqual([
       {
@@ -5716,6 +5782,7 @@ describe("toAcpNotifications messageId", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
       { messageId },
@@ -5739,6 +5806,7 @@ describe("toAcpNotifications messageId", () => {
       "user",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
       { messageId },
@@ -5753,6 +5821,7 @@ describe("toAcpNotifications messageId", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
       { messageId },
@@ -5764,7 +5833,15 @@ describe("toAcpNotifications messageId", () => {
   });
 
   it("omits messageId when none is supplied", () => {
-    const result = toAcpNotifications("hello", "assistant", "test", {}, {} as AcpClient, console);
+    const result = toAcpNotifications(
+      "hello",
+      "assistant",
+      "test",
+      {},
+      new Map(),
+      {} as AcpClient,
+      console,
+    );
     expect(result[0].update).not.toHaveProperty("messageId");
   });
 
@@ -5781,6 +5858,7 @@ describe("toAcpNotifications messageId", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
       { messageId, registerHooks: false },
@@ -5797,6 +5875,7 @@ describe("toAcpNotifications thinking chunks", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
     );
@@ -5818,6 +5897,7 @@ describe("toAcpNotifications thinking chunks", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
     );
@@ -5831,6 +5911,7 @@ describe("toAcpNotifications thinking chunks", () => {
       "assistant",
       "test",
       {},
+      new Map(),
       {} as AcpClient,
       console,
     );
@@ -5988,6 +6069,7 @@ describe("agent selection config option", () => {
         contextWindowSize: 200000,
         taskState: new Map(),
         toolUseCache: {},
+        waitingForToolCall: new Map(),
         messageIdToUuid: new Map(),
       };
       return { session: agent.sessions[sessionId]!, applyFlagSettings };

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -124,6 +124,8 @@ describe("session config options", () => {
       ),
       configOptions: structuredClone(MOCK_CONFIG_OPTIONS),
       contextWindowSize: 200000,
+      toolUseCache: {},
+      waitingForToolCall: new Map(),
     };
   }
 
@@ -1112,6 +1114,12 @@ describe("session config options", () => {
           { id: "dontAsk", name: "Don't Ask", description: "Deny if not pre-approved" },
         ],
       };
+      session.toolUseCache["toolu_1"] = {
+        type: "tool_use",
+        id: "toolu_1",
+        name: "ExitPlanMode",
+        input: { plan: "do stuff" },
+      };
 
       const canUseTool = (agent as any).canUseTool(SESSION_ID);
       const signal = new AbortController().signal;
@@ -1144,6 +1152,12 @@ describe("session config options", () => {
         ],
       };
       permissionResponse = { outcome: { outcome: "selected", optionId: "auto" } };
+      session.toolUseCache["toolu_2"] = {
+        type: "tool_use",
+        id: "toolu_2",
+        name: "ExitPlanMode",
+        input: { plan: "do stuff" },
+      };
 
       const canUseTool = (agent as any).canUseTool(SESSION_ID);
       const result = await canUseTool(
@@ -1170,6 +1184,12 @@ describe("session config options", () => {
           { id: "plan", name: "Plan Mode", description: "Planning mode" },
           { id: "dontAsk", name: "Don't Ask", description: "Deny if not pre-approved" },
         ],
+      };
+      session.toolUseCache["toolu_3"] = {
+        type: "tool_use",
+        id: "toolu_3",
+        name: "ExitPlanMode",
+        input: { plan: "do stuff" },
       };
 
       const canUseTool = (agent as any).canUseTool(SESSION_ID);

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -10,7 +10,13 @@ import {
   BetaBashCodeExecutionResultBlock,
   BetaBashCodeExecutionToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
-import { AcpClient, toAcpNotifications, ToolUseCache, Logger } from "../acp-agent.js";
+import {
+  AcpClient,
+  toAcpNotifications,
+  ToolUseCache,
+  Logger,
+  WaitingForToolCall,
+} from "../acp-agent.js";
 import {
   toolUpdateFromToolResult,
   createPostToolUseHook,
@@ -37,6 +43,7 @@ describe("rawOutput in tool call updates", () => {
         input: { command: "echo hello" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const toolResult: ToolResultBlockParam = {
       type: "tool_result",
@@ -50,6 +57,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -72,6 +80,7 @@ describe("rawOutput in tool call updates", () => {
         input: { file_path: "/test/file.txt" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     // ToolResultBlockParam content can be string or array of TextBlockParam
     const toolResult: ToolResultBlockParam = {
@@ -86,6 +95,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -108,6 +118,7 @@ describe("rawOutput in tool call updates", () => {
         input: { query: "test" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     // BetaMCPToolResultBlock content can be string or Array<BetaTextBlock>
     const toolResult: BetaMCPToolResultBlock = {
@@ -122,6 +133,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -144,6 +156,7 @@ describe("rawOutput in tool call updates", () => {
         input: { term: "test" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     // BetaTextBlock requires citations field
     const arrayContent: BetaTextBlock[] = [
@@ -163,6 +176,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -185,6 +199,7 @@ describe("rawOutput in tool call updates", () => {
         input: { query: "test search" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     // BetaWebSearchResultBlock from SDK
     const searchResults: BetaWebSearchResultBlock[] = [
@@ -208,6 +223,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -230,6 +246,7 @@ describe("rawOutput in tool call updates", () => {
         input: { command: "ls -la" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     // BetaBashCodeExecutionResultBlock from SDK
     const bashResult: BetaBashCodeExecutionResultBlock = {
@@ -251,6 +268,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -273,6 +291,7 @@ describe("rawOutput in tool call updates", () => {
         input: { command: "invalid_command" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const toolResult: ToolResultBlockParam = {
       type: "tool_result",
@@ -286,6 +305,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -308,6 +328,7 @@ describe("rawOutput in tool call updates", () => {
         input: { todos: [{ content: "Test task", status: "pending" }] },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const toolResult: ToolResultBlockParam = {
       type: "tool_result",
@@ -321,6 +342,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -351,11 +373,14 @@ describe("rawOutput in tool call updates", () => {
       is_error: false,
     };
 
+    const waitingForToolCall: WaitingForToolCall = new Map();
+
     const notifications = toAcpNotifications(
       [toolResult],
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -383,6 +408,7 @@ describe("rawOutput in tool call updates", () => {
         input: { file_path: "/test/image.png" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const imageBlock: ImageBlockParam = {
       type: "image",
@@ -401,6 +427,7 @@ describe("rawOutput in tool call updates", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -779,6 +806,7 @@ describe("Bash terminal output", () => {
     // Reset before each test: toAcpNotifications prunes the cache entry once it
     // maps the tool_result, so a shared object would be empty by the 2nd test.
     let toolUseCache: ToolUseCache;
+    const waitingForToolCall: WaitingForToolCall = new Map();
     beforeEach(() => {
       toolUseCache = {
         toolu_bash: {
@@ -814,6 +842,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClient,
         mockLogger,
         { clientCapabilities },
@@ -854,6 +883,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClient,
         mockLogger,
       );
@@ -880,6 +910,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClient,
         mockLogger,
         { clientCapabilities },
@@ -895,6 +926,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClient,
         mockLogger,
         { clientCapabilities: { _meta: { terminal_output: true } } },
@@ -915,6 +947,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCacheWithoutSupport,
+        waitingForToolCall,
         mockClient,
         mockLogger,
       );
@@ -947,6 +980,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClient,
         mockLogger,
         { clientCapabilities },
@@ -969,6 +1003,7 @@ describe("Bash terminal output", () => {
   describe("toolUseCache pruning", () => {
     it("retains the tool_use entry until its result, then prunes it", () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
       const toolUse = {
         type: "tool_use" as const,
         id: "toolu_read",
@@ -977,7 +1012,15 @@ describe("Bash terminal output", () => {
       };
 
       // tool_use is cached and kept (the matching result hasn't arrived yet).
-      toAcpNotifications([toolUse], "assistant", "s", toolUseCache, mockClient, mockLogger);
+      toAcpNotifications(
+        [toolUse],
+        "assistant",
+        "s",
+        toolUseCache,
+        waitingForToolCall,
+        mockClient,
+        mockLogger,
+      );
       expect(toolUseCache.toolu_read).toBeDefined();
 
       // tool_result resolves it, so the entry is pruned to bound memory.
@@ -986,7 +1029,15 @@ describe("Bash terminal output", () => {
         tool_use_id: "toolu_read",
         content: [{ type: "text", text: "hello" }],
       };
-      toAcpNotifications([toolResult], "assistant", "s", toolUseCache, mockClient, mockLogger);
+      toAcpNotifications(
+        [toolResult],
+        "assistant",
+        "s",
+        toolUseCache,
+        waitingForToolCall,
+        mockClient,
+        mockLogger,
+      );
       expect(toolUseCache.toolu_read).toBeUndefined();
     });
   });
@@ -994,6 +1045,7 @@ describe("Bash terminal output", () => {
   describe("post-tool-use hook sends diff content for Edit tool", () => {
     it("should include content and locations from structuredPatch in hook update", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
 
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
@@ -1019,6 +1071,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1073,6 +1126,7 @@ describe("Bash terminal output", () => {
 
     it("should include multiple diff blocks for replaceAll with multiple hunks", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
 
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
@@ -1098,6 +1152,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1158,6 +1213,7 @@ describe("Bash terminal output", () => {
 
     it("should not include content/locations for non-Edit tools", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
 
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
@@ -1178,6 +1234,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1213,6 +1270,7 @@ describe("Bash terminal output", () => {
     // tool_use time and was never corrected after the tool ran.
     it("should emit a real diff for Write of an existing file (type: update)", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
         sessionUpdate: async (notification: any) => {
@@ -1235,6 +1293,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1289,6 +1348,7 @@ describe("Bash terminal output", () => {
 
     it("should still emit a sensible diff for Write of a brand-new file (type: create)", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
         sessionUpdate: async (notification: any) => {
@@ -1311,6 +1371,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1368,6 +1429,7 @@ describe("Bash terminal output", () => {
       };
 
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
 
       // Capture session updates sent by the hook callback
       const hookUpdates: any[] = [];
@@ -1389,6 +1451,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
         { clientCapabilities },
@@ -1418,6 +1481,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
         { clientCapabilities },
@@ -1469,6 +1533,7 @@ describe("Bash terminal output", () => {
 
     it("should not include terminal _meta in hook update when client lacks terminal_output support", async () => {
       const toolUseCache: ToolUseCache = {};
+      const waitingForToolCall: WaitingForToolCall = new Map();
 
       const hookUpdates: any[] = [];
       const mockClientWithUpdate = {
@@ -1490,6 +1555,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
         // No clientCapabilities — terminal_output not supported
@@ -1514,6 +1580,7 @@ describe("Bash terminal output", () => {
         "assistant",
         "test-session",
         toolUseCache,
+        waitingForToolCall,
         mockClientWithUpdate,
         mockLogger,
       );
@@ -1645,6 +1712,7 @@ describe("toAcpNotifications - TodoWrite with undefined input regression", () =>
 
   it("should not throw when TodoWrite tool_use has undefined input", () => {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const notifications = toAcpNotifications(
       [
@@ -1658,6 +1726,7 @@ describe("toAcpNotifications - TodoWrite with undefined input regression", () =>
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -1669,6 +1738,7 @@ describe("toAcpNotifications - TodoWrite with undefined input regression", () =>
 
   it("should still emit plan update when TodoWrite has valid input", () => {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
 
     const notifications = toAcpNotifications(
       [
@@ -1682,6 +1752,7 @@ describe("toAcpNotifications - TodoWrite with undefined input regression", () =>
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
     );
@@ -1780,6 +1851,7 @@ describe("toAcpNotifications - Task* tools", () => {
 
   it("suppresses tool_call for TaskCreate/TaskUpdate/TaskList/TaskGet on tool_use", () => {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const taskState: TaskState = new Map();
 
     const notifications = toAcpNotifications(
@@ -1797,6 +1869,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1808,6 +1881,7 @@ describe("toAcpNotifications - Task* tools", () => {
 
   it("emits a plan snapshot after a TaskCreate tool_result and accumulates state", () => {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const taskState: TaskState = new Map();
 
     toAcpNotifications(
@@ -1822,6 +1896,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1839,6 +1914,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "user",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1863,6 +1939,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "assistant",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1880,6 +1957,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "user",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1896,6 +1974,7 @@ describe("toAcpNotifications - Task* tools", () => {
 
   it("emits a plan snapshot reflecting status changes after a TaskUpdate tool_result", () => {
     const toolUseCache: ToolUseCache = {};
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const taskState: TaskState = new Map([["1", { subject: "First", status: "pending" as const }]]);
     toolUseCache["update-1"] = {
       type: "tool_use",
@@ -1920,6 +1999,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "user",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1937,6 +2017,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "list-1": { type: "tool_use", id: "list-1", name: "TaskList", input: {} },
       "get-1": { type: "tool_use", id: "get-1", name: "TaskGet", input: { taskId: "1" } },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const taskState: TaskState = new Map([
       ["1", { subject: "Existing", status: "in_progress" as const }],
     ]);
@@ -1949,6 +2030,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "user",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },
@@ -1967,6 +2049,7 @@ describe("toAcpNotifications - Task* tools", () => {
         input: { subject: "A", description: "" },
       },
     };
+    const waitingForToolCall: WaitingForToolCall = new Map();
     const taskState: TaskState = new Map();
 
     const notifications = toAcpNotifications(
@@ -1981,6 +2064,7 @@ describe("toAcpNotifications - Task* tools", () => {
       "user",
       "test-session",
       toolUseCache,
+      waitingForToolCall,
       mockClient,
       mockLogger,
       { taskState },


### PR DESCRIPTION
Before, if a subagent requested a tool permission, we'd send the permission request with the tool_call_update before the initial tool_call. This did work in the past, but it seems that the Claude Agent SDK changed the timing of when the canUseTool function runs at some point.

@benbrandt it's not super nice, maybe you have a better idea.