### PR TITLE
fix: tolerate missing text in streamed thinking chunks

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2020,9 +2020,9 @@ export class ClaudeAcpAgent {
               const delta = message.event.delta;
               const chunk =
                 delta.type === "text_delta"
-                  ? { type: "text" as const, text: nonEmptyString(delta.text) }
+                  ? { type: "text" as const, text: delta.text }
                   : delta.type === "thinking_delta"
-                    ? { type: "thinking" as const, text: nonEmptyString(delta.thinking) }
+                    ? { type: "thinking" as const, text: delta.thinking }
                     : undefined;
               // Skip empty deltas (some gateways emit empty thinking chunks —
               // #793): appending "" is a no-op, but pushing a "" entry would
@@ -4966,10 +4966,6 @@ function applyMessageId(
   }
 }
 
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === "string" && value.length > 0 ? value : null;
-}
-
 /** Built-in tools that drive the task list (headless/SDK sessions use these
  *  instead of TodoWrite). Their tool_use/tool_result are surfaced as `plan`
  *  snapshots rather than as tool_calls. */
@@ -5096,13 +5092,12 @@ export function toAcpNotifications(
     switch (chunk.type) {
       case "text":
       case "text_delta": {
-        const text = nonEmptyString(chunk.text);
-        if (text) {
+        if (chunk.text) {
           update = {
             sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
             content: {
               type: "text",
-              text,
+              text: chunk.text,
             },
           };
         }
@@ -5123,13 +5118,12 @@ export function toAcpNotifications(
       case "thinking_delta": {
         // Recent models default `thinking.display` to "omitted", which streams
         // signature-only thinking blocks whose text is empty.
-        const thinking = nonEmptyString(chunk.thinking);
-        if (thinking) {
+        if (chunk.thinking) {
           update = {
             sessionUpdate: "agent_thought_chunk",
             content: {
               type: "text",
-              text: thinking,
+              text: chunk.thinking,
             },
           };
         }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2020,16 +2020,16 @@ export class ClaudeAcpAgent {
               const delta = message.event.delta;
               const chunk =
                 delta.type === "text_delta"
-                  ? { type: "text" as const, text: delta.text }
+                  ? { type: "text" as const, text: nonEmptyString(delta.text) }
                   : delta.type === "thinking_delta"
-                    ? { type: "thinking" as const, text: delta.thinking }
+                    ? { type: "thinking" as const, text: nonEmptyString(delta.thinking) }
                     : undefined;
               // Skip empty deltas (some gateways emit empty thinking chunks —
               // #793): appending "" is a no-op, but pushing a "" entry would
               // create a block the consolidated handler's `text.length > 0`
               // guard can never consume, stalling the diff cursor and
               // re-emitting the next block as a duplicate.
-              if (chunk && chunk.text.length > 0) {
+              if (chunk?.text) {
                 const index = message.event.index;
                 const last = streamedBlocks[streamedBlocks.length - 1];
                 if (last && last.index === index && last.type === chunk.type) {
@@ -4966,6 +4966,10 @@ function applyMessageId(
   }
 }
 
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 /** Built-in tools that drive the task list (headless/SDK sessions use these
  *  instead of TodoWrite). Their tool_use/tool_result are surfaced as `plan`
  *  snapshots rather than as tool_calls. */
@@ -5091,17 +5095,19 @@ export function toAcpNotifications(
     let update: SessionNotification["update"] | null = null;
     switch (chunk.type) {
       case "text":
-      case "text_delta":
-        if (chunk.text.length > 0) {
+      case "text_delta": {
+        const text = nonEmptyString(chunk.text);
+        if (text) {
           update = {
             sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
             content: {
               type: "text",
-              text: chunk.text,
+              text,
             },
           };
         }
         break;
+      }
       case "image":
         update = {
           sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
@@ -5114,19 +5120,21 @@ export function toAcpNotifications(
         };
         break;
       case "thinking":
-      case "thinking_delta":
+      case "thinking_delta": {
         // Recent models default `thinking.display` to "omitted", which streams
         // signature-only thinking blocks whose text is empty.
-        if (chunk.thinking.length > 0) {
+        const thinking = nonEmptyString(chunk.thinking);
+        if (thinking) {
           update = {
             sessionUpdate: "agent_thought_chunk",
             content: {
               type: "text",
-              text: chunk.thinking,
+              text: thinking,
             },
           };
         }
         break;
+      }
       case "tool_use":
       case "server_tool_use":
       case "mcp_tool_use": {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4816,6 +4816,22 @@ describe("assembled assistant text fallback", () => {
     expect(messageChunkTexts(updates)).toEqual(["real answer"]);
   });
 
+  it("dedupes a streamed text block even when a thinking delta omits text", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      messageStart("msg-missing-thinking"),
+      thinkingDelta(undefined as any),
+      textDelta("real answer"),
+      assistantMessage("msg-missing-thinking", [{ type: "text", text: "real answer" }]),
+      result(),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "hi" }] });
+
+    expect(messageChunkTexts(updates)).toEqual(["real answer"]);
+  });
+
   it("does not re-emit the next turn's text after a turn is cancelled mid-stream", async () => {
     // Regression: streamedBlocks is reset inside the consolidated-assistant
     // branch, but a cancelled turn `break`s out before reaching it (the
@@ -6786,6 +6802,36 @@ describe("toAcpNotifications thinking chunks", () => {
   it("skips empty thinking deltas", () => {
     const result = toAcpNotifications(
       [{ type: "thinking_delta", thinking: "", estimated_tokens: 0 }],
+      "assistant",
+      "test",
+      {},
+      {} as AcpClient,
+      console,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips thinking chunks without string content", () => {
+    const result = toAcpNotifications(
+      [
+        { type: "thinking", signature: "abc" },
+        { type: "thinking_delta", estimated_tokens: 0 },
+        { type: "thinking_delta", thinking: null, estimated_tokens: 0 },
+      ] as any,
+      "assistant",
+      "test",
+      {},
+      {} as AcpClient,
+      console,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips text deltas without string content", () => {
+    const result = toAcpNotifications(
+      [{ type: "text_delta" }, { type: "text_delta", text: null }] as any,
       "assistant",
       "test",
       {},


### PR DESCRIPTION
## Summary

This makes streamed text/thinking chunk handling defensive when gateways emit empty or malformed delta payloads.

- Guard `text_delta.text` and `thinking_delta.thinking` before reading `.length`
- Skip missing/non-string text or thinking content the same way empty chunks are already skipped
- Add regression coverage for a missing `thinking` delta before a real text delta
- Add direct `toAcpNotifications` coverage for missing/non-string text and thinking chunks

## Why

The adapter already skips empty thinking chunks, but some Anthropic-compatible gateways can emit signature-only or omitted thinking deltas where `thinking` is absent rather than an empty string. In that case the adapter currently throws:

```text
Cannot read properties of undefined (reading 'length')
```

That aborts the ACP session even though the following text chunks are valid.

This change keeps the existing behavior for valid chunks, while treating missing/non-string chunk text as empty content.

## Test Plan

- `npm run check`
- `npm test -- --run`
- `npm run build`

Also verified manually through a VibeAround Web Chat flow using Claude Code ACP with an Anthropic-compatible custom endpoint; the session completed and returned a normal assistant response.
