### PR TITLE
feat: support rewinding to a message when forking a session

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -398,8 +398,8 @@ type Session = {
    *  naturally yields the turn-boundary uuid when one `msg_…` spans several
    *  content-block messages.
    *
-   *  NOT READ YET — recorded now so the mapping exists if/when we wire up
-   *  fork/rewind. */
+   *  Read by `session/fork` when `_meta.claudeCode.rewindTo` is set — see
+   *  `resolveMessageUuid`. */
   messageIdToUuid: Map<string, string>;
 };
 
@@ -452,6 +452,22 @@ export type NewSessionMeta = {
     emitRawSDKMessages?: boolean | SDKMessageFilter[];
   };
   additionalRoots?: string[];
+};
+
+/**
+ * Extra metadata that can be given when forking a session.
+ */
+export type ForkSessionMeta = {
+  claudeCode?: {
+    /**
+     * ACP message id (the id delivered to clients in `agent_message_chunk`
+     * updates and in replayed history) of the assistant turn to fork from.
+     * The forked session resumes from that message; turns after it are not
+     * part of the fork. Translated internally to the SDK message uuid that
+     * `resumeSessionAt` expects (see `Session.messageIdToUuid`).
+     */
+    rewindTo?: string;
+  };
 };
 
 /**
@@ -1069,6 +1085,7 @@ export class ClaudeAcpAgent {
         _meta: {
           claudeCode: {
             promptQueueing: true,
+            rewind: true,
           },
         },
         promptCapabilities: {
@@ -1117,6 +1134,11 @@ export class ClaudeAcpAgent {
   }
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
+    const rewindTo = (params._meta as ForkSessionMeta | undefined)?.claudeCode?.rewindTo;
+    const resumeSessionAt =
+      rewindTo === undefined
+        ? undefined
+        : await this.resolveMessageUuid(params.sessionId, rewindTo);
     const response = await this.createSession(
       {
         cwd: params.cwd,
@@ -1127,6 +1149,7 @@ export class ClaudeAcpAgent {
       {
         resume: params.sessionId,
         forkSession: true,
+        ...(resumeSessionAt === undefined ? {} : { resumeSessionAt }),
       },
     );
     // Needs to happen after we return the session
@@ -1134,6 +1157,35 @@ export class ClaudeAcpAgent {
       this.sendAvailableCommandsUpdate(response.sessionId);
     }, 0);
     return response;
+  }
+
+  /** Translate the ACP messageId a client was given (see `messageIdForGrouping`)
+   *  into the SDK message uuid that `resumeSessionAt` keys on. Prefers the
+   *  in-memory map maintained by the message loop and history replay; falls
+   *  back to a `getSessionMessages` scan for sessions whose history this
+   *  process hasn't observed (e.g. forking a session straight from disk). */
+  private async resolveMessageUuid(sessionId: string, messageId: string): Promise<string> {
+    const cached = this.sessions[sessionId]?.messageIdToUuid.get(messageId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const messages = await getSessionMessages(sessionId);
+    let uuid: string | undefined;
+    for (const message of messages) {
+      // Last-write-wins mirrors how `messageIdToUuid` is populated: when one
+      // `msg_…` spans several content-block messages, keep the turn-boundary uuid.
+      const mapped = messageIdForGrouping(message);
+      if (mapped === messageId && typeof message.uuid === "string" && message.uuid.length > 0) {
+        uuid = message.uuid;
+      }
+    }
+    if (uuid === undefined) {
+      throw RequestError.invalidParams(
+        { rewindTo: messageId },
+        `No message with id \`${messageId}\` found in session \`${sessionId}\``,
+      );
+    }
+    return uuid;
   }
 
   async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {
@@ -4231,7 +4283,7 @@ export class ClaudeAcpAgent {
 
   private async createSession(
     params: NewSessionRequest,
-    creationOpts: { resume?: string; forkSession?: boolean } = {},
+    creationOpts: { resume?: string; forkSession?: boolean; resumeSessionAt?: string } = {},
   ): Promise<NewSessionResponse> {
     // Validate `cwd` up front. The ACP spec requires an absolute path, and the
     // directory must actually exist on the machine running the agent. Without

--- a/src/tests/fork-rewind.test.ts
+++ b/src/tests/fork-rewind.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { SessionNotification } from "@agentclientprotocol/sdk";
+import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
+
+let capturedOptions: Options | undefined;
+let sessionMessages: unknown[] = [];
+vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
+  const actual = await vi.importActual<typeof import("@anthropic-ai/claude-agent-sdk")>(
+    "@anthropic-ai/claude-agent-sdk",
+  );
+  return {
+    ...actual,
+    getSessionMessages: async () => sessionMessages,
+    query: (args: { prompt: unknown; options: Options }) => {
+      capturedOptions = args.options;
+      return {
+        initializationResult: async () => ({
+          models: [
+            {
+              value: "claude-sonnet-4-6",
+              displayName: "Claude Sonnet",
+              description: "Fast",
+              supportsAutoMode: true,
+            },
+          ],
+        }),
+        setModel: async () => {},
+        setPermissionMode: async () => {},
+        supportedCommands: async () => [],
+        getContextUsage: () => Promise.reject(new Error("no context usage mocked")),
+        [Symbol.asyncIterator]: async function* () {},
+      };
+    },
+  };
+});
+
+vi.mock("../tools.js", async () => {
+  const actual = await vi.importActual<typeof import("../tools.js")>("../tools.js");
+  return {
+    ...actual,
+    registerHookCallback: vi.fn(),
+  };
+});
+
+describe("session/fork rewindTo", () => {
+  let agent: ClaudeAcpAgentType;
+  let ClaudeAcpAgent: typeof ClaudeAcpAgentType;
+
+  function createMockClient(): AcpClient {
+    return {
+      sessionUpdate: async (_notification: SessionNotification) => {},
+      requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      readTextFile: async () => ({ content: "" }),
+      writeTextFile: async () => ({}),
+    } as unknown as AcpClient;
+  }
+
+  beforeEach(async () => {
+    capturedOptions = undefined;
+    sessionMessages = [];
+
+    vi.resetModules();
+    const acpAgent = await import("../acp-agent.js");
+    ClaudeAcpAgent = acpAgent.ClaudeAcpAgent;
+
+    agent = new ClaudeAcpAgent(createMockClient());
+  });
+
+  it("translates _meta.claudeCode.rewindTo into the SDK resumeSessionAt option", async () => {
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+    sessionMessages = [
+      { type: "assistant", uuid: "uuid-turn-1", message: { id: "msg_turn_1" } },
+      { type: "assistant", uuid: "uuid-turn-2", message: { id: "msg_turn_2" } },
+    ];
+
+    await agent.unstable_forkSession({
+      sessionId,
+      cwd: process.cwd(),
+      mcpServers: [],
+      _meta: { claudeCode: { rewindTo: "msg_turn_1" } },
+    });
+
+    expect(capturedOptions!.resumeSessionAt).toBe("uuid-turn-1");
+    expect(capturedOptions!.forkSession).toBe(true);
+    expect(capturedOptions!.resume).toBe(sessionId);
+  });
+
+  it("prefers the in-memory messageId→uuid map over a history read", async () => {
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+    agent.sessions[sessionId].messageIdToUuid.set("msg_live", "uuid-live");
+
+    await agent.unstable_forkSession({
+      sessionId,
+      cwd: process.cwd(),
+      mcpServers: [],
+      _meta: { claudeCode: { rewindTo: "msg_live" } },
+    });
+
+    expect(capturedOptions!.resumeSessionAt).toBe("uuid-live");
+  });
+
+  it("keeps the turn-boundary uuid when one message id spans several messages", async () => {
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+    sessionMessages = [
+      { type: "assistant", uuid: "uuid-block-1", message: { id: "msg_split" } },
+      { type: "assistant", uuid: "uuid-block-2", message: { id: "msg_split" } },
+    ];
+
+    await agent.unstable_forkSession({
+      sessionId,
+      cwd: process.cwd(),
+      mcpServers: [],
+      _meta: { claudeCode: { rewindTo: "msg_split" } },
+    });
+
+    expect(capturedOptions!.resumeSessionAt).toBe("uuid-block-2");
+  });
+
+  it("rejects an unknown rewindTo id with invalid params", async () => {
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+    await expect(
+      agent.unstable_forkSession({
+        sessionId,
+        cwd: process.cwd(),
+        mcpServers: [],
+        _meta: { claudeCode: { rewindTo: "msg_missing" } },
+      }),
+    ).rejects.toThrow(/No message with id `msg_missing`/);
+  });
+
+  it("forks without resumeSessionAt when no rewindTo is given", async () => {
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+    await agent.unstable_forkSession({ sessionId, cwd: process.cwd(), mcpServers: [] });
+
+    expect(capturedOptions!.resumeSessionAt).toBeUndefined();
+    expect(capturedOptions!.forkSession).toBe(true);
+  });
+});


### PR DESCRIPTION
### What

`session/fork` now honors an optional `_meta.claudeCode.rewindTo` — the ACP message id (the `messageId` clients receive in `agent_message_chunk` updates and replayed history) of the assistant turn to fork from. The forked session's history ends at that turn; everything after it is not part of the fork.

Support is advertised as `agentCapabilities._meta.claudeCode.rewind: true` so clients can feature-detect.

### How

This wires up plumbing the codebase already prepared:

- `Session.messageIdToUuid` (previously documented as "NOT READ YET — recorded now so the mapping exists if/when we wire up fork/rewind") translates the client-visible ACP id back to the SDK message uuid.
- The uuid is passed to the Agent SDK as `resumeSessionAt` alongside the existing `forkSession: true` in the query options.
- For sessions whose history this process hasn't observed (e.g. forking straight from disk), a new `resolveMessageUuid` helper falls back to a `getSessionMessages` scan, mirroring `replaySessionHistory`'s mapping logic (last-write-wins keeps the turn-boundary uuid when one `msg_…` spans several content-block messages).
- Unknown ids fail with JSON-RPC invalid params.

No protocol changes: `_meta` is the sanctioned extension point, matching the existing `_meta.claudeCode.options` pattern on `session/new`.

### Why

Clients building conversation-branching UX (rewind to turn N, explore an alternative continuation) currently have no way to express it over ACP even though the underlying SDK supports it (`resumeSessionAt`). Fork-at-anchor is the minimal surface that unlocks it without touching the spec.

### Tests

- `src/tests/fork-rewind.test.ts` (5 cases): meta → `resumeSessionAt` translation via history scan; in-memory map preferred over history read; last-write-wins on split messages; invalid-params on unknown id; plain fork unchanged.
- Full suite: 576 passed | 20 skipped. `tsc` and eslint clean.
- Verified live against Claude Code 2.1.207: planted "favorite color is blue", overwrote with "red", forked with `rewindTo=<turn-1 message id>` — the original session answers "Red", the rewound fork answers "Blue".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
