### PR TITLE
fix: remove ~15s stall on session/new and model switch by seeding the context window synchronously

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -393,11 +393,24 @@ type Session = {
   emitRawSDKMessages: boolean | SDKMessageFilter[];
   /** Context window size of the session's current model, carried across
    *  prompts so mid-stream usage_update notifications report a correct `size`
-   *  before the turn's first result message arrives. Seeded from the SDK's
-   *  getContextUsage report at session creation (DEFAULT_CONTEXT_WINDOW when
-   *  that and the text heuristic both fail), refreshed the same way on model
-   *  switches, and confirmed by each result's modelUsage. */
+   *  before the turn's first result message arrives. Seeded synchronously at
+   *  session creation and on model switches from the per-model cache or the
+   *  text heuristic (DEFAULT_CONTEXT_WINDOW when both miss), then confirmed —
+   *  and the cache populated — by each result's modelUsage. No `getContextUsage`
+   *  IPC is on these paths: it stalls until the first turn runs (see the
+   *  seeding call sites and `contextWindowCache`). */
   contextWindowSize: number;
+  /** Stable identifier of the LLM backend this session's query was created
+   *  against (apiType + baseUrl, see {@link providerCacheKeyFor}). The context
+   *  window is a property of (model id, provider) — a resolved model id can name
+   *  different windows behind different providers — so this scopes the
+   *  module-global `contextWindowCache` per provider. Captured at session
+   *  creation because the effective provider (`resolveProviderConfig`) can change
+   *  process-wide over the adapter's lifetime, while the query is baked to the
+   *  provider in effect when it was created. Optional only so test/husk session
+   *  literals need not set it; `contextWindowCacheKey` treats an unset value as
+   *  the "default" provider bucket. */
+  providerCacheKey?: string;
   /** Accumulated task list for the session, keyed by task ID. Task IDs are
    *  per-session, so this state must not be shared across sessions. */
   taskState: TaskState;
@@ -2890,12 +2903,29 @@ export class ClaudeAcpAgent {
               const matchingModelUsage = lastAssistantModel
                 ? getMatchingModelUsage(message.modelUsage, lastAssistantModel)
                 : null;
-              // Only overwrite when we have an authoritative value — a miss
-              // (e.g. a turn with no top-level assistant message) would
-              // otherwise discard the window learned on a prior turn and
-              // leave the next prompt's mid-stream updates reporting 200k.
-              if (matchingModelUsage) {
-                session.contextWindowSize = matchingModelUsage.contextWindow;
+              // Only overwrite when we have an authoritative, sane value. A miss
+              // (e.g. a turn with no top-level assistant message), or a
+              // nonsensical non-positive/NaN window (observed from third-party
+              // backends), would otherwise discard the window learned on a prior
+              // turn and leave the next prompt's mid-stream updates reporting a
+              // wrong size. `cacheContextWindow` applies the same `> 0` guard, so
+              // a bad value never reaches the cross-session cache either.
+              if (
+                matchingModelUsage &&
+                typeof matchingModelUsage.usage.contextWindow === "number" &&
+                matchingModelUsage.usage.contextWindow > 0
+              ) {
+                session.contextWindowSize = matchingModelUsage.usage.contextWindow;
+                // Authoritative: fold it into the cross-session cache keyed on
+                // (this session's provider, the resolved model id —
+                // matchingModelUsage.key, e.g. "claude-sonnet-5[1m]") so a later
+                // session/new or switch on the same provider that resolves to
+                // this model seeds the correct window synchronously, with no
+                // getContextUsage IPC.
+                cacheContextWindow(
+                  contextWindowCacheKey(session.providerCacheKey, matchingModelUsage.key),
+                  matchingModelUsage.usage.contextWindow,
+                );
               }
 
               // Send usage_update notification
@@ -4565,22 +4595,24 @@ export class ClaudeAcpAgent {
       // carries no "1m" token.
       const newModelInfo = session.modelInfos.find((m) => m.value === value);
       if (session.models.currentModelId !== value) {
-        // The cached context window was learned for the previous model. The
-        // SDK is already running the new model here (user-driven switches call
-        // `query.setModel` before this, and the refusal-fallback sync only
-        // reconciles a switch the SDK already made), so ask it for the new
-        // window; fall back to the text heuristic so mid-stream updates
-        // between now and the next `result` reflect the user's selection
-        // instead of the old model's window.
-        session.contextWindowSize =
-          (await fetchContextWindowSize(session.query, this.logger)) ??
-          inferContextWindowFromModel(
-            value,
-            newModelInfo?.resolvedModel,
-            newModelInfo?.displayName,
-            newModelInfo?.description,
-          ) ??
-          DEFAULT_CONTEXT_WINDOW;
+        // Seed the new model's context window WITHOUT any IPC on the switch
+        // path: cached authoritative value if we've already learned it (from a
+        // prior turn's `result.modelUsage`), else the text heuristic, else the
+        // default. We deliberately do NOT call `getContextUsage` here — that
+        // control request stalls ~15s until the session's first prompt turn
+        // has run, and (because SDK control requests are serialized over one
+        // channel) it would drag the awaited `setModel` down with it. The
+        // authoritative window arrives on the first `result.modelUsage` for the
+        // model and is cached from there; until then a switched-to alias that
+        // has never run a turn shows the heuristic/default window, which
+        // self-corrects on its first response (matches pre-0.59.0 behavior).
+        session.contextWindowSize = immediateContextWindow(
+          contextWindowCacheKey(session.providerCacheKey, newModelInfo?.resolvedModel ?? value),
+          value,
+          newModelInfo?.resolvedModel,
+          newModelInfo?.displayName,
+          newModelInfo?.description,
+        );
       }
       session.models = { ...session.models, currentModelId: value };
 
@@ -5309,28 +5341,39 @@ export class ClaudeAcpAgent {
         effortLevel: initialEffort.currentValue as Settings["effortLevel"],
       });
     }
-    // Seed the context window from the SDK's authoritative report. Text
-    // inference alone misses aliases that resolve to extended-context models
-    // with no "1m" token anywhere in their id or description (e.g. `sonnet` →
-    // claude-sonnet-5, natively ~1M): those streamed `usage_update.size:
-    // 200000` until the first result's modelUsage corrected it — again on
-    // every process restart or session re-creation, since the learned window
-    // lives only on the Session (issue #596).
+    // Seed the context window WITHOUT any IPC on the session/new path. Use the
+    // cached authoritative window if we've already learned it for this model (a
+    // prior turn's `result.modelUsage`, cross-session), else the text
+    // heuristic, else the default. We deliberately do NOT call `getContextUsage`
+    // here: it stalls ~15s until the session's first prompt turn runs (that
+    // control request is not serviced pre-turn), so awaiting it — as 0.59.0 did
+    // — made session/new take ~15s. The authoritative window arrives on the
+    // first `result.modelUsage` and is cached from there.
+    //
+    // Text inference alone misses aliases that resolve to extended-context
+    // models with no "1m" token anywhere in their id or description (e.g.
+    // `sonnet` → claude-sonnet-5, natively ~1M): those stream
+    // `usage_update.size: 200000` until the first result's modelUsage corrects
+    // it — but the cache means only the FIRST session to ever run a turn on such
+    // a model eats that window, not every process restart (issue #596).
     //
     // The inference fallback is deliberately keyed to the allowlisted entry: a
     // fallback-resolved sibling's resolvedModel/displayName/description can
     // describe a different context lane than the verbatim live id (e.g. an
     // "opus[1m]" row matched for a bare 200k id), so on the fallback path only
     // the id itself is a trustworthy window signal.
-    const contextWindowSize =
-      (await fetchContextWindowSize(q, this.logger)) ??
-      inferContextWindowFromModel(
-        models.currentModelId,
-        allowlistedModelInfo?.resolvedModel,
-        allowlistedModelInfo?.displayName,
-        allowlistedModelInfo?.description,
-      ) ??
-      DEFAULT_CONTEXT_WINDOW;
+    // The window cache is scoped per provider (see `contextWindowCache`).
+    // Capture the provider the query above was created against so both this
+    // pre-turn read and the later result-handler write use the same key even if
+    // the process-wide effective provider changes later.
+    const providerCacheKey = providerCacheKeyFor(this.resolveProviderConfig());
+    const contextWindowSize = immediateContextWindow(
+      contextWindowCacheKey(providerCacheKey, allowlistedModelInfo?.resolvedModel ?? models.currentModelId),
+      models.currentModelId,
+      allowlistedModelInfo?.resolvedModel,
+      allowlistedModelInfo?.displayName,
+      allowlistedModelInfo?.description,
+    );
 
     this.sessions[sessionId] = {
       query: q,
@@ -5355,6 +5398,7 @@ export class ClaudeAcpAgent {
       abortController,
       emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
       contextWindowSize,
+      providerCacheKey,
       taskState,
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -7113,9 +7157,9 @@ function commonPrefixLength(a: string, b: string) {
   return i;
 }
 
-/** Best-effort first guess of a model's context window, used only as a
- *  fallback when the SDK's authoritative `getContextUsage` is unavailable (and
- *  until a `result` message arrives with the `modelUsage` value).
+/** Best-effort first guess of a model's context window, used to seed the
+ *  window synchronously (via `immediateContextWindow`) until a `result` message
+ *  arrives with the authoritative `modelUsage` value.
  *
  *  Anthropic 1M-context variants encode "1m" as a distinct token in the SDK
  *  model ID (e.g., "claude-opus-4-6-1m"), which `\b1m\b` catches without also
@@ -7125,9 +7169,10 @@ function commonPrefixLength(a: string, b: string) {
  *  "claude-opus-4-8[1m]", "Opus 4.7 (1M context)"), so callers pass those too.
  *  This text scan can't catch every model — some resolve to extended-context
  *  models with no "1m" anywhere (e.g. `sonnet` → claude-sonnet-5, natively
- *  ~1M) — which is why `fetchContextWindowSize` is preferred wherever a live
- *  query is available. A miss falls back to the default window and is
- *  corrected by `result.modelUsage` within one turn. */
+ *  ~1M). Such a miss falls back to the default window and is corrected by
+ *  `result.modelUsage` (and cached) within one turn. We do NOT consult the
+ *  SDK's `getContextUsage` to close that gap: it is not serviced before the
+ *  first turn (see `contextWindowCache`). */
 function inferContextWindowFromModel(...texts: Array<string | undefined>): number | null {
   if (texts.some((text) => text != null && /\b1m\b/i.test(text))) return 1_000_000;
   return null;
@@ -7148,26 +7193,77 @@ async function fetchContextUsedTokens(query: Query, logger: Logger): Promise<num
   }
 }
 
-/** Fetch the current model's full context window (`rawMaxTokens`) via the
- *  `getContextUsage` control request — the same source `/context` prints.
- *  This is the only pre-`result` signal that covers semantic aliases whose
- *  text carries no "1m" token (e.g. `sonnet` → claude-sonnet-5, natively
- *  ~1M), so it's the primary window source at session creation and on model
- *  switches; `inferContextWindowFromModel` remains the fallback. A returned
- *  window is still superseded by each `result.modelUsage.contextWindow`.
+/** Cross-session cache of authoritative context windows, keyed by
+ *  `${providerCacheKey}\0${resolvedModelId}` (see {@link contextWindowCacheKey}).
+ *  The window is a property of (model id, provider): a resolved model id (e.g.
+ *  "claude-sonnet-5[1m]", the same spelling as the `result.modelUsage` keys) can
+ *  name different context lanes behind different providers, so the key carries
+ *  both. Caching it module-level lets a later session/new or switch that
+ *  resolves to the same (provider, model) — in this session or any other, within
+ *  the adapter's lifetime — seed the correct window synchronously with no IPC.
+ *  Keying on the resolved id (rather than the picker value) means aliases that
+ *  resolve to the same concrete model share one entry; keying on the provider
+ *  means two providers that reuse an id string for different windows stay
+ *  separated.
  *
- *  (Older CLIs under-reported extended 1M windows here — commit 20ef663
- *  dropped the field for that reason — but the CLI vendored by the pinned
- *  SDK reports them correctly again.) Returns `null` on any control-request
- *  failure or a nonsensical (non-positive) window. */
-async function fetchContextWindowSize(query: Query, logger: Logger): Promise<number | null> {
-  try {
-    const usage = await query.getContextUsage();
-    return usage.rawMaxTokens > 0 ? usage.rawMaxTokens : null;
-  } catch (error) {
-    logger.error("Failed to fetch context window size from SDK:", error);
-    return null;
+ *  Populated authoritatively by each `result.modelUsage` a turn confirms (see
+ *  the consumer's result handler, which caches under the matched modelUsage
+ *  key). We deliberately never populate it from `getContextUsage`: that control
+ *  request is not serviced until the session's first prompt turn has run (it
+ *  stalls ~15s before then, and serializes ahead of an awaited `setModel`), so
+ *  it can neither beat the first `result` nor be issued cheaply before one — see
+ *  the seeding call sites for the full rationale. */
+const contextWindowCache = new Map<string, number>();
+
+/** Stable identifier for the LLM backend a session's query is created against,
+ *  used to scope {@link contextWindowCache} per provider. Derived from the
+ *  non-secret routing fields (apiType + baseUrl, plus Vertex project/region);
+ *  `headers` are excluded (they carry secrets and don't change which backend is
+ *  addressed). `null` (no client-managed routing — the adapter's own default) is
+ *  a stable key of its own. */
+function providerCacheKeyFor(config: ProviderConfig | null): string {
+  if (!config) return "default";
+  const parts = [config.apiType, config.baseUrl];
+  if (config.vertex) parts.push(config.vertex.projectId, config.vertex.region);
+  return parts.join(" ");
+}
+
+/** Compose the `contextWindowCache` key from a session's provider key and a
+ *  resolved model id. Returns undefined when the model id is undefined so the
+ *  cache read/write becomes a no-op (never a `${provider}\0undefined` entry). */
+function contextWindowCacheKey(
+  providerCacheKey: string | undefined,
+  resolvedModelId: string | undefined,
+): string | undefined {
+  if (resolvedModelId === undefined) return undefined;
+  return `${providerCacheKey ?? "default"} ${resolvedModelId}`;
+}
+
+function cacheContextWindow(modelKey: string | undefined, window: number | null | undefined): void {
+  if (modelKey && typeof window === "number" && window > 0) {
+    contextWindowCache.set(modelKey, window);
   }
+}
+
+/** The context window to report *right now* for a model, with NO IPC on the
+ *  critical path: the cached authoritative value if we've learned it (from a
+ *  prior turn's `result.modelUsage`, this or any session with the same provider),
+ *  else the text heuristic on the supplied identity strings, else the default.
+ *  `cacheKey` is the composite (provider, resolved model id) lookup key from
+ *  {@link contextWindowCacheKey} — the same key the write site uses; the
+ *  remaining `inferTexts` feed `inferContextWindowFromModel` exactly as the old
+ *  inline fallback did. The authoritative window arrives on the first
+ *  `result.modelUsage` for the model and is cached from there, superseding a
+ *  heuristic/default miss. */
+function immediateContextWindow(
+  cacheKey: string | undefined,
+  ...inferTexts: Array<string | undefined>
+): number {
+  if (cacheKey !== undefined) {
+    const cached = contextWindowCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+  }
+  return inferContextWindowFromModel(...inferTexts) ?? DEFAULT_CONTEXT_WINDOW;
 }
 
 /** Translate the legacy `MAX_THINKING_TOKENS` env var into the SDK's `thinking`
@@ -7216,6 +7312,11 @@ function getMatchingModelUsage(modelUsage: Record<string, ModelUsage>, currentMo
   }
 
   if (bestKey) {
-    return modelUsage[bestKey];
+    // `bestKey` is the SDK's resolved model id (e.g. "claude-sonnet-5[1m]"),
+    // the same spelling as ModelInfo.resolvedModel — the key we cache the
+    // window under. `currentModel` (the assistant message's `.model`) can be
+    // the bare form (e.g. "claude-sonnet-5"), so callers that want to cache
+    // must use `key`, not `currentModel`.
+    return { key: bestKey, usage: modelUsage[bestKey] };
   }
 }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -395,22 +395,30 @@ type Session = {
    *  prompts so mid-stream usage_update notifications report a correct `size`
    *  before the turn's first result message arrives. Seeded synchronously at
    *  session creation and on model switches from the per-model cache or the
-   *  text heuristic (DEFAULT_CONTEXT_WINDOW when both miss), then confirmed —
-   *  and the cache populated — by each result's modelUsage. No `getContextUsage`
-   *  IPC is on these paths: it stalls until the first turn runs (see the
-   *  seeding call sites and `contextWindowCache`). */
+   *  text heuristic (DEFAULT_CONTEXT_WINDOW when both miss; on session/load the
+   *  resumed session's own `getContextUsage` report wins, see
+   *  `readResumedLiveModel`), then confirmed — and the cache populated — by each
+   *  result's modelUsage. No extra `getContextUsage` IPC is on these paths: on a
+   *  fresh session it stalls until the first turn runs (see the seeding call
+   *  sites and `contextWindowCache`). */
   contextWindowSize: number;
+  /** Whether `contextWindowSize` came from an authoritative source (the
+   *  cross-session cache, a resumed session's `getContextUsage` report, or a
+   *  `result.modelUsage`) rather than the text heuristic / default. Guards the
+   *  mid-stream `message_start` heuristic upgrade: an authoritative window that
+   *  happens to equal DEFAULT_CONTEXT_WINDOW must not be mistaken for "unseeded"
+   *  and clobbered by a "1m" text match. */
+  contextWindowAuthoritative: boolean;
   /** Stable identifier of the LLM backend this session's query was created
-   *  against (apiType + baseUrl, see {@link providerCacheKeyFor}). The context
-   *  window is a property of (model id, provider) — a resolved model id can name
-   *  different windows behind different providers — so this scopes the
-   *  module-global `contextWindowCache` per provider. Captured at session
-   *  creation because the effective provider (`resolveProviderConfig`) can change
-   *  process-wide over the adapter's lifetime, while the query is baked to the
-   *  provider in effect when it was created. Optional only so test/husk session
-   *  literals need not set it; `contextWindowCacheKey` treats an unset value as
-   *  the "default" provider bucket. */
-  providerCacheKey?: string;
+   *  against, derived from the routing-relevant vars of the exact `env` handed
+   *  to the SDK at query creation (see {@link providerCacheKeyFor}). The context
+   *  window is a property of (model id, backend) — the same resolved model id
+   *  can name different windows behind different base URLs, routing headers, or
+   *  credentials — so this scopes the module-global `contextWindowCache` per
+   *  backend. Captured from the query's own env (not re-resolved later) because
+   *  the process-wide provider config can change while a session is being
+   *  created, while the query stays baked to the env it was created with. */
+  providerCacheKey: string;
   /** Accumulated task list for the session, keyed by task ID. Task IDs are
    *  per-session, so this state must not be shared across sessions. */
   taskState: TaskState;
@@ -1587,6 +1595,12 @@ export class ClaudeAcpAgent {
     // those paths.
     this.gatewayAuthRequest = undefined;
     this.providerConfig = undefined;
+    // Learned context windows are per-account state too: 1M-context
+    // entitlement is gated per org/tier, and an OAuth re-login is invisible to
+    // the env-derived provider cache key, so windows learned under the old
+    // login must not seed sessions under the next. Worst case of clearing is
+    // re-learning on each model's next turn.
+    contextWindowCache.clear();
 
     // For the Claude/Console login methods the credentials live in the native
     // CLI's store (keychain or config dir), which only the binary can clear.
@@ -2916,6 +2930,7 @@ export class ClaudeAcpAgent {
                 matchingModelUsage.usage.contextWindow > 0
               ) {
                 session.contextWindowSize = matchingModelUsage.usage.contextWindow;
+                session.contextWindowAuthoritative = true;
                 // Authoritative: fold it into the cross-session cache keyed on
                 // (this session's provider, the resolved model id —
                 // matchingModelUsage.key, e.g. "claude-sonnet-5[1m]") so a later
@@ -2926,6 +2941,19 @@ export class ClaudeAcpAgent {
                   contextWindowCacheKey(session.providerCacheKey, matchingModelUsage.key),
                   matchingModelUsage.usage.contextWindow,
                 );
+                // Also cache under the assistant message's own (bare) spelling.
+                // Seed-time reads fall back to a picker value / verbatim live id
+                // when a row carries no resolvedModel (the synthesized
+                // out-of-allowlist resume row sets it undefined on purpose), and
+                // those spellings match `.model` from the assistant message, not
+                // the decorated modelUsage key — without this entry such rows
+                // could never hit the cache.
+                if (lastAssistantModel && lastAssistantModel !== matchingModelUsage.key) {
+                  cacheContextWindow(
+                    contextWindowCacheKey(session.providerCacheKey, lastAssistantModel),
+                    matchingModelUsage.usage.contextWindow,
+                  );
+                }
               }
 
               // Send usage_update notification
@@ -3197,11 +3225,18 @@ export class ClaudeAcpAgent {
                 const model = message.event.message.model;
                 if (model && model !== "<synthetic>") {
                   lastAssistantModel = model;
-                  // Only upgrade from the default — once the SDK has given us
-                  // an authoritative window (seeded at session creation,
-                  // refreshed on model switches in `applyConfigOptionValue`,
-                  // confirmed by each `result`), trust it over the heuristic.
-                  if (session.contextWindowSize === DEFAULT_CONTEXT_WINDOW) {
+                  // Only upgrade from the heuristic default — once we have an
+                  // authoritative window (cache-seeded at session creation or
+                  // on a model switch, read from the resumed session on
+                  // session/load, confirmed by each `result`), trust it over
+                  // the heuristic. The flag, not the value, is the sentinel: an
+                  // authoritative window can legitimately equal
+                  // DEFAULT_CONTEXT_WINDOW (e.g. a backend serving a 200k lane
+                  // under a "[1m]"-spelled id) and must not be clobbered.
+                  if (
+                    !session.contextWindowAuthoritative &&
+                    session.contextWindowSize === DEFAULT_CONTEXT_WINDOW
+                  ) {
                     const inferred = inferContextWindowFromModel(model);
                     if (inferred !== null) {
                       session.contextWindowSize = inferred;
@@ -4598,21 +4633,18 @@ export class ClaudeAcpAgent {
         // Seed the new model's context window WITHOUT any IPC on the switch
         // path: cached authoritative value if we've already learned it (from a
         // prior turn's `result.modelUsage`), else the text heuristic, else the
-        // default. We deliberately do NOT call `getContextUsage` here — that
-        // control request stalls ~15s until the session's first prompt turn
-        // has run, and (because SDK control requests are serialized over one
-        // channel) it would drag the awaited `setModel` down with it. The
-        // authoritative window arrives on the first `result.modelUsage` for the
-        // model and is cached from there; until then a switched-to alias that
-        // has never run a turn shows the heuristic/default window, which
-        // self-corrects on its first response (matches pre-0.59.0 behavior).
-        session.contextWindowSize = immediateContextWindow(
-          contextWindowCacheKey(session.providerCacheKey, newModelInfo?.resolvedModel ?? value),
-          value,
-          newModelInfo?.resolvedModel,
-          newModelInfo?.displayName,
-          newModelInfo?.description,
-        );
+        // default. We deliberately do NOT call `getContextUsage` here — before
+        // a fresh session's first prompt turn that control request is not
+        // serviced (~15s stall, issues #886/#880), and (because SDK control
+        // requests are serialized over one channel) it would drag the awaited
+        // `setModel` down with it. The authoritative window arrives on the
+        // first `result.modelUsage` for the model and is cached from there;
+        // until then a switched-to alias that has never run a turn shows the
+        // heuristic/default window, which self-corrects on its first response
+        // (matches pre-0.59.0 behavior).
+        const seeded = immediateContextWindow(session.providerCacheKey, value, newModelInfo);
+        session.contextWindowSize = seeded.size;
+        session.contextWindowAuthoritative = seeded.authoritative;
       }
       session.models = { ...session.models, currentModelId: value };
 
@@ -5022,6 +5054,29 @@ export class ClaudeAcpAgent {
     // the same Map that the streaming message handler will read from.
     const taskState: TaskState = new Map();
 
+    // The exact env the query will be created with. Built (and the provider
+    // cache key derived from it, below) in one place so the key always
+    // describes the backend this query actually talks to: `providers/set`,
+    // `providers/disable`, and `logout` mutate the process-wide provider
+    // config concurrently, so re-resolving it after any of the awaits between
+    // here and the session registration could disagree with the env baked
+    // into the query.
+    const env = {
+      ...process.env,
+      ...userProvidedOptions?.env,
+      // Client-managed LLM routing: `providers/set` config wins, else the
+      // legacy gateway auth request. Baked into the query at creation, so it
+      // only affects sessions started after the change (matching the RFD).
+      ...createEnvForProvider(this.resolveProviderConfig()),
+      // Opt-in to session state events like when the agent is idle
+      CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: "1",
+    };
+    // Scopes the context-window cache to this query's backend (see
+    // `contextWindowCache`). Derived from the same `env` object handed to the
+    // SDK, so per-session `_meta` env routing and ambient process-env routing
+    // are distinguished exactly as the CLI will see them.
+    const providerCacheKey = providerCacheKeyFor(env);
+
     const options: Options = {
       systemPrompt,
       settingSources: ["user", "project", "local"],
@@ -5038,16 +5093,7 @@ export class ClaudeAcpAgent {
             ...(modelConfig.availableModels && { availableModels: modelConfig.availableModels }),
           },
         }),
-      env: {
-        ...process.env,
-        ...userProvidedOptions?.env,
-        // Client-managed LLM routing: `providers/set` config wins, else the
-        // legacy gateway auth request. Baked into the query at creation, so it
-        // only affects sessions started after the change (matching the RFD).
-        ...createEnvForProvider(this.resolveProviderConfig()),
-        // Opt-in to session state events like when the agent is idle
-        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: "1",
-      },
+      env,
       // Override certain fields that must be controlled by ACP
       cwd: params.cwd,
       includePartialMessages: true,
@@ -5214,7 +5260,7 @@ export class ClaudeAcpAgent {
         )
       : initializationResult.models;
 
-    const models = await getAvailableModels(
+    const { modelState: models, resumedContextWindow } = await getAvailableModels(
       q,
       allowedModels,
       initializationResult.models,
@@ -5341,42 +5387,37 @@ export class ClaudeAcpAgent {
         effortLevel: initialEffort.currentValue as Settings["effortLevel"],
       });
     }
-    // Seed the context window WITHOUT any IPC on the session/new path. Use the
-    // cached authoritative window if we've already learned it for this model (a
-    // prior turn's `result.modelUsage`, cross-session), else the text
-    // heuristic, else the default. We deliberately do NOT call `getContextUsage`
-    // here: it stalls ~15s until the session's first prompt turn runs (that
-    // control request is not serviced pre-turn), so awaiting it — as 0.59.0 did
-    // — made session/new take ~15s. The authoritative window arrives on the
-    // first `result.modelUsage` and is cached from there.
+    // Seed the context window WITHOUT any extra IPC on the session/new path.
+    // On session/load, the resumed session's own `getContextUsage` report — a
+    // response `getAvailableModels` already awaited to learn the live model
+    // (resumed sessions ARE serviced pre-turn, unlike fresh ones) — is
+    // authoritative and wins. Otherwise: the cached authoritative window if a
+    // prior turn has learned it for this model (`result.modelUsage`,
+    // cross-session), else the text heuristic, else the default. We
+    // deliberately do NOT issue a getContextUsage call here: on a fresh
+    // session that control request is not serviced until the first prompt
+    // turn runs, so awaiting it — as 0.59.0 did — made session/new take ~15s
+    // (issues #886/#880). The authoritative window arrives on the first
+    // `result.modelUsage` and is cached from there.
     //
     // Text inference alone misses aliases that resolve to extended-context
     // models with no "1m" token anywhere in their id or description (e.g.
     // `sonnet` → claude-sonnet-5, natively ~1M): those stream
     // `usage_update.size: 200000` until the first result's modelUsage corrects
     // it — but the cache means only the FIRST session to ever run a turn on such
-    // a model eats that window, not every process restart (issue #596).
+    // a model eats that window, not every fresh session after a process
+    // restart (issue #596; a post-restart session/load is covered by the
+    // resumed report above).
     //
     // The inference fallback is deliberately keyed to the allowlisted entry: a
     // fallback-resolved sibling's resolvedModel/displayName/description can
     // describe a different context lane than the verbatim live id (e.g. an
     // "opus[1m]" row matched for a bare 200k id), so on the fallback path only
     // the id itself is a trustworthy window signal.
-    // The window cache is scoped per provider (see `contextWindowCache`).
-    // Capture the provider the query above was created against so both this
-    // pre-turn read and the later result-handler write use the same key even if
-    // the process-wide effective provider changes later.
-    const providerCacheKey = providerCacheKeyFor(this.resolveProviderConfig());
-    const contextWindowSize = immediateContextWindow(
-      contextWindowCacheKey(
-        providerCacheKey,
-        allowlistedModelInfo?.resolvedModel ?? models.currentModelId,
-      ),
-      models.currentModelId,
-      allowlistedModelInfo?.resolvedModel,
-      allowlistedModelInfo?.displayName,
-      allowlistedModelInfo?.description,
-    );
+    const seededWindow =
+      resumedContextWindow !== null
+        ? { size: resumedContextWindow, authoritative: true }
+        : immediateContextWindow(providerCacheKey, models.currentModelId, allowlistedModelInfo);
 
     this.sessions[sessionId] = {
       query: q,
@@ -5400,7 +5441,8 @@ export class ClaudeAcpAgent {
       fastModeEnabled,
       abortController,
       emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
-      contextWindowSize,
+      contextWindowSize: seededWindow.size,
+      contextWindowAuthoritative: seededWindow.authoritative,
       providerCacheKey,
       taskState,
       toolUseCache: {},
@@ -6165,20 +6207,29 @@ export function applyAvailableModelsAllowlist(
 
 /** Read the model a resumed session is actually running (via the
  *  `getContextUsage` control request — the same source `/context` prints) and
- *  map it onto the picker. Best-effort: a control-request failure is logged
- *  and returns null so callers keep their current choice; failing the whole
- *  session/load over an unreadable report would be worse. */
+ *  map it onto the picker, along with the report's authoritative context
+ *  window (`rawMaxTokens`). Resumed sessions get this request serviced before
+ *  any turn runs in the new process — unlike fresh sessions, where it stalls
+ *  until the first prompt turn (issues #886/#880) — so the same response that
+ *  restores the live model (issue #845) also seeds the window for free,
+ *  covering post-restart reloads of models the text heuristic misses (issue
+ *  #596). Best-effort: a control-request failure is logged and returns nulls
+ *  so callers keep their current choice; failing the whole session/load over
+ *  an unreadable report would be worse. */
 async function readResumedLiveModel(
   query: Query,
   models: ModelInfo[],
   logger: Logger,
-): Promise<ModelInfo | null> {
+): Promise<{ model: ModelInfo | null; contextWindow: number | null }> {
   try {
-    const liveModel = (await query.getContextUsage()).model;
-    return liveModel ? matchResumedModel(models, liveModel) : null;
+    const usage = await query.getContextUsage();
+    return {
+      model: usage.model ? matchResumedModel(models, usage.model) : null,
+      contextWindow: usage.rawMaxTokens > 0 ? usage.rawMaxTokens : null,
+    };
   } catch (error) {
     logger.error("Failed to read the resumed session's live model:", error);
-    return null;
+    return { model: null, contextWindow: null };
   }
 }
 
@@ -6189,11 +6240,16 @@ async function getAvailableModels(
   settingsManager: SettingsManager,
   logger: Logger,
   isResumedSession: boolean,
-): Promise<SessionModelState> {
+): Promise<{ modelState: SessionModelState; resumedContextWindow: number | null }> {
   const settings = settingsManager.getSettings();
 
   let currentModel = models[0];
   let resolvedFromInput: string | undefined;
+  // The context window reported alongside a resumed session's live model.
+  // Only ever non-null on the paths where `currentModel` IS the live model
+  // (no override, or a failed override re-assert), so the window always
+  // describes the model the session actually runs.
+  let resumedContextWindow: number | null = null;
 
   // Model priority (highest to lowest):
   // 1. ANTHROPIC_MODEL environment variable
@@ -6222,7 +6278,9 @@ async function getAvailableModels(
   // the SDK is already running this model, and pushing a picker alias back
   // (e.g. "opus[1m]") could change the live model rather than describe it.
   if (resolvedFromInput === undefined && isResumedSession) {
-    currentModel = (await readResumedLiveModel(query, models, logger)) ?? currentModel;
+    const live = await readResumedLiveModel(query, models, logger);
+    currentModel = live.model ?? currentModel;
+    resumedContextWindow = live.contextWindow;
   }
 
   // Skip the setModel round-trip when we can prove the SDK has already landed
@@ -6255,17 +6313,22 @@ async function getAvailableModels(
       // pin the session isn't running.
       if (!isResumedSession) throw error;
       logger.error(`Failed to re-assert model "${currentModel.value}" on resume:`, error);
-      currentModel = (await readResumedLiveModel(query, models, logger)) ?? currentModel;
+      const live = await readResumedLiveModel(query, models, logger);
+      currentModel = live.model ?? currentModel;
+      resumedContextWindow = live.contextWindow;
     }
   }
 
   return {
-    availableModels: models.map((model) => ({
-      modelId: model.value,
-      name: model.displayName,
-      description: model.description,
-    })),
-    currentModelId: currentModel.value,
+    modelState: {
+      availableModels: models.map((model) => ({
+        modelId: model.value,
+        name: model.displayName,
+        description: model.description,
+      })),
+      currentModelId: currentModel.value,
+    },
+    resumedContextWindow,
   };
 }
 
@@ -7174,8 +7237,10 @@ function commonPrefixLength(a: string, b: string) {
  *  models with no "1m" anywhere (e.g. `sonnet` → claude-sonnet-5, natively
  *  ~1M). Such a miss falls back to the default window and is corrected by
  *  `result.modelUsage` (and cached) within one turn. We do NOT consult the
- *  SDK's `getContextUsage` to close that gap: it is not serviced before the
- *  first turn (see `contextWindowCache`). */
+ *  SDK's `getContextUsage` to close that gap: on a fresh session it is not
+ *  serviced before the first prompt turn (issues #886/#880, see
+ *  `contextWindowCache`; resumed sessions do get it, via
+ *  `readResumedLiveModel`). */
 function inferContextWindowFromModel(...texts: Array<string | undefined>): number | null {
   if (texts.some((text) => text != null && /\b1m\b/i.test(text))) return 1_000_000;
   return null;
@@ -7197,76 +7262,109 @@ async function fetchContextUsedTokens(query: Query, logger: Logger): Promise<num
 }
 
 /** Cross-session cache of authoritative context windows, keyed by
- *  `${providerCacheKey}\0${resolvedModelId}` (see {@link contextWindowCacheKey}).
- *  The window is a property of (model id, provider): a resolved model id (e.g.
- *  "claude-sonnet-5[1m]", the same spelling as the `result.modelUsage` keys) can
- *  name different context lanes behind different providers, so the key carries
- *  both. Caching it module-level lets a later session/new or switch that
- *  resolves to the same (provider, model) — in this session or any other, within
- *  the adapter's lifetime — seed the correct window synchronously with no IPC.
- *  Keying on the resolved id (rather than the picker value) means aliases that
- *  resolve to the same concrete model share one entry; keying on the provider
- *  means two providers that reuse an id string for different windows stay
- *  separated.
+ *  `${providerCacheKey}\0${modelId}` (see {@link contextWindowCacheKey}).
+ *  The window is a property of (model id, backend): the same resolved model id
+ *  (e.g. "claude-sonnet-5[1m]", the spelling of the `result.modelUsage` keys)
+ *  can name different context lanes behind different base URLs, routing
+ *  headers, or credentials, so the key carries both. Caching it module-level
+ *  lets a later session/new or switch that resolves to the same (backend,
+ *  model) — in this session or any other, within the adapter's lifetime — seed
+ *  the correct window synchronously with no IPC. Keying on the resolved id
+ *  (rather than the picker value) means aliases that resolve to the same
+ *  concrete model share one entry; the result handler additionally writes the
+ *  bare assistant-message spelling so seed-time reads that fall back to a
+ *  verbatim live id (rows without `resolvedModel`) can hit too.
  *
  *  Populated authoritatively by each `result.modelUsage` a turn confirms (see
- *  the consumer's result handler, which caches under the matched modelUsage
- *  key). We deliberately never populate it from `getContextUsage`: that control
- *  request is not serviced until the session's first prompt turn has run (it
- *  stalls ~15s before then, and serializes ahead of an awaited `setModel`), so
- *  it can neither beat the first `result` nor be issued cheaply before one — see
- *  the seeding call sites for the full rationale. */
+ *  the consumer's result handler). We deliberately never populate it from a
+ *  fresh session's `getContextUsage`: before that session's first prompt turn
+ *  has run the control request is not serviced (it stalls ~15s, and serializes
+ *  ahead of an awaited `setModel` — issues #886/#880, regressed in 0.59.0), so
+ *  it can neither beat the first `result` nor be issued cheaply before one.
+ *  Resumed sessions are the exception — their report IS serviced pre-turn, and
+ *  the session/load path seeds (but does not cache) the window from the same
+ *  response that restores the live model, see `readResumedLiveModel`.
+ *  Cleared on `logout`: 1M-context entitlement can differ per account/tier, so
+ *  windows learned under one login must not seed sessions under the next. */
 const contextWindowCache = new Map<string, number>();
 
+/** The env vars that determine which LLM backend — and which context lane on
+ *  it — a query's API traffic reaches: endpoint selection (base URLs and the
+ *  Bedrock/Vertex switches with their project/region), routing/beta headers
+ *  (an `anthropic-beta: context-1m-…` header flips the same model id at the
+ *  same endpoint between context lanes), and credential identity (extended
+ *  context is entitlement-gated per account). Used to derive the
+ *  provider-cache key from the exact env a query is created with, so
+ *  `providers/set` config, per-session `_meta` env overrides, and ambient
+ *  process env are all distinguished exactly as the CLI will see them. */
+const PROVIDER_ROUTING_ENV_VARS = [
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_BEDROCK_BASE_URL",
+  "ANTHROPIC_VERTEX_BASE_URL",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "ANTHROPIC_VERTEX_PROJECT_ID",
+  "CLOUD_ML_REGION",
+  "AWS_REGION",
+  "ANTHROPIC_CUSTOM_HEADERS",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+] as const;
+
 /** Stable identifier for the LLM backend a session's query is created against,
- *  used to scope {@link contextWindowCache} per provider. Derived from the
- *  non-secret routing fields (apiType + baseUrl, plus Vertex project/region);
- *  `headers` are excluded (they carry secrets and don't change which backend is
- *  addressed). `null` (no client-managed routing — the adapter's own default) is
- *  a stable key of its own. */
-function providerCacheKeyFor(config: ProviderConfig | null): string {
-  if (!config) return "default";
-  const parts = [config.apiType, config.baseUrl];
-  if (config.vertex) parts.push(config.vertex.projectId, config.vertex.region);
-  return parts.join(" ");
+ *  used to scope {@link contextWindowCache} per backend. Positional `\0`-join
+ *  of {@link PROVIDER_ROUTING_ENV_VARS} values, so no segment can masquerade
+ *  as another and unset vars everywhere yield one stable "default" bucket.
+ *  Header/credential values can be secrets; the key only ever lives as an
+ *  in-memory Map key and is never logged or surfaced. Over-keying is the safe
+ *  side: a var change that didn't really change the backend costs one cache
+ *  miss (heuristic seed until the next result), while under-keying would serve
+ *  one backend's window for another's. */
+function providerCacheKeyFor(env: Record<string, string | undefined>): string {
+  return PROVIDER_ROUTING_ENV_VARS.map((name) => env[name] ?? "").join("\0");
 }
 
 /** Compose the `contextWindowCache` key from a session's provider key and a
- *  resolved model id. Returns undefined when the model id is undefined so the
- *  cache read/write becomes a no-op (never a `${provider}\0undefined` entry). */
-function contextWindowCacheKey(
-  providerCacheKey: string | undefined,
-  resolvedModelId: string | undefined,
-): string | undefined {
-  if (resolvedModelId === undefined) return undefined;
-  return `${providerCacheKey ?? "default"} ${resolvedModelId}`;
+ *  model id. `\0`-joined so the model segment can't collide with a provider
+ *  segment. */
+function contextWindowCacheKey(providerCacheKey: string, modelId: string): string {
+  return `${providerCacheKey}\0${modelId}`;
 }
 
-function cacheContextWindow(modelKey: string | undefined, window: number | null | undefined): void {
-  if (modelKey && typeof window === "number" && window > 0) {
+function cacheContextWindow(modelKey: string, window: number): void {
+  if (window > 0) {
     contextWindowCache.set(modelKey, window);
   }
 }
 
 /** The context window to report *right now* for a model, with NO IPC on the
  *  critical path: the cached authoritative value if we've learned it (from a
- *  prior turn's `result.modelUsage`, this or any session with the same provider),
- *  else the text heuristic on the supplied identity strings, else the default.
- *  `cacheKey` is the composite (provider, resolved model id) lookup key from
- *  {@link contextWindowCacheKey} — the same key the write site uses; the
- *  remaining `inferTexts` feed `inferContextWindowFromModel` exactly as the old
- *  inline fallback did. The authoritative window arrives on the first
- *  `result.modelUsage` for the model and is cached from there, superseding a
- *  heuristic/default miss. */
+ *  prior turn's `result.modelUsage`, this or any session on the same backend),
+ *  else the text heuristic over the model row's identity strings, else the
+ *  default. Derives the cache key itself — `modelInfo?.resolvedModel ?? modelId`,
+ *  the same rule at every seed site — so read keys can't drift from the write
+ *  site's spelling. `authoritative` reports whether the value came from the
+ *  cache: an authoritative window can legitimately equal
+ *  DEFAULT_CONTEXT_WINDOW, so the value alone can't tell the caller. */
 function immediateContextWindow(
-  cacheKey: string | undefined,
-  ...inferTexts: Array<string | undefined>
-): number {
-  if (cacheKey !== undefined) {
-    const cached = contextWindowCache.get(cacheKey);
-    if (cached !== undefined) return cached;
-  }
-  return inferContextWindowFromModel(...inferTexts) ?? DEFAULT_CONTEXT_WINDOW;
+  providerCacheKey: string,
+  modelId: string,
+  modelInfo?: Pick<ModelInfo, "resolvedModel" | "displayName" | "description">,
+): { size: number; authoritative: boolean } {
+  const cached = contextWindowCache.get(
+    contextWindowCacheKey(providerCacheKey, modelInfo?.resolvedModel ?? modelId),
+  );
+  if (cached !== undefined) return { size: cached, authoritative: true };
+  return {
+    size:
+      inferContextWindowFromModel(
+        modelId,
+        modelInfo?.resolvedModel,
+        modelInfo?.displayName,
+        modelInfo?.description,
+      ) ?? DEFAULT_CONTEXT_WINDOW,
+    authoritative: false,
+  };
 }
 
 /** Translate the legacy `MAX_THINKING_TOKENS` env var into the SDK's `thinking`
@@ -7316,10 +7414,11 @@ function getMatchingModelUsage(modelUsage: Record<string, ModelUsage>, currentMo
 
   if (bestKey) {
     // `bestKey` is the SDK's resolved model id (e.g. "claude-sonnet-5[1m]"),
-    // the same spelling as ModelInfo.resolvedModel — the key we cache the
-    // window under. `currentModel` (the assistant message's `.model`) can be
-    // the bare form (e.g. "claude-sonnet-5"), so callers that want to cache
-    // must use `key`, not `currentModel`.
+    // the same spelling as ModelInfo.resolvedModel — the primary key the
+    // window is cached under. `currentModel` (the assistant message's
+    // `.model`) can be the bare form (e.g. "claude-sonnet-5"); the result
+    // handler caches under that spelling too, for seed-time reads that fall
+    // back to a bare id (rows without `resolvedModel`).
     return { key: bestKey, usage: modelUsage[bestKey] };
   }
 }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -5368,7 +5368,10 @@ export class ClaudeAcpAgent {
     // the process-wide effective provider changes later.
     const providerCacheKey = providerCacheKeyFor(this.resolveProviderConfig());
     const contextWindowSize = immediateContextWindow(
-      contextWindowCacheKey(providerCacheKey, allowlistedModelInfo?.resolvedModel ?? models.currentModelId),
+      contextWindowCacheKey(
+        providerCacheKey,
+        allowlistedModelInfo?.resolvedModel ?? models.currentModelId,
+      ),
       models.currentModelId,
       allowlistedModelInfo?.resolvedModel,
       allowlistedModelInfo?.displayName,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -157,6 +157,7 @@ function mockSessionState(overrides: Record<string, any> = {}) {
     abortController: new AbortController(),
     emitRawSDKMessages: false,
     contextWindowSize: 200000,
+    providerCacheKey: "default",
     taskState: new Map(),
     toolUseCache: {},
     emittedToolCalls: new Set(),
@@ -5044,6 +5045,230 @@ describe("usage_update computation", () => {
     expect(usageUpdate.update.used).toBe(0);
     expect(usageUpdate.update.size).toBe(200000);
     expect(session.contextWindowSize).toBe(200000);
+  });
+
+  it("caches the turn's authoritative window under the resolved id and serves it on a later switch, with no getContextUsage IPC", async () => {
+    // End-to-end for the cross-session context-window cache:
+    //  - WRITE: a turn's result.modelUsage is the only authoritative window. The
+    //    assistant message reports the BARE model id ("…-9") while modelUsage is
+    //    keyed by the RESOLVED id ("…-9[1m]"); the cache must be written under the
+    //    resolved key (matched by getMatchingModelUsage), the same spelling as
+    //    ModelInfo.resolvedModel — otherwise a later read never hits.
+    //  - READ: switching to a picker value whose resolvedModel is that key seeds
+    //    the window synchronously from the cache, with NO getContextUsage.
+    // 777_000 is chosen so it can only come from the cache: text inference on the
+    // resolved id "…-9[1m]" would yield 1_000_000 (the "1m" token), the default
+    // is 200_000, and the pre-switch sentinel is 123_456.
+    //
+    // The `contextWindowCache` is module-global and this file does not
+    // vi.resetModules() per test, so it persists across tests. This test stays
+    // isolated by using a unique resolved id ("claude-cachehit-probe-9[1m]") that
+    // no other test writes or reads — the convention here, since a statically
+    // imported module's cache can't be cleared from a test.
+    const RESOLVED_ID = "claude-cachehit-probe-9[1m]";
+    const { agent } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createAssistantMessage({ model: "claude-cachehit-probe-9" }),
+      createResultMessageWithModel({
+        modelUsage: {
+          [RESOLVED_ID]: {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 777_000,
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    const session = agent.sessions["test-session"]!;
+    // The turn learned the window from modelUsage even though the assistant
+    // message carried the bare id — confirms the write matched on the resolved key.
+    expect(session.contextWindowSize).toBe(777_000);
+
+    // Now switch to a picker value that resolves to the cached id. Seed a
+    // sentinel and a getContextUsage spy first: a cache miss would surface as
+    // 1_000_000 (inference on the "1m" id), and any IPC as a spy call.
+    const getContextUsage = vi.fn(async () => ({ rawMaxTokens: 200000 }));
+    (session.query as any).getContextUsage = getContextUsage;
+    session.contextWindowSize = 123_456;
+    session.models = { currentModelId: "default", availableModels: [] };
+    session.modelInfos = [
+      {
+        value: "probe-alias",
+        displayName: "Probe",
+        description: "probe model",
+        resolvedModel: RESOLVED_ID,
+      },
+    ] as any;
+    session.configOptions = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        category: "model",
+        currentValue: "default",
+        options: [{ value: "probe-alias", name: "Probe" }],
+      },
+    ] as any;
+
+    await agent.setSessionConfigOption({
+      sessionId: "test-session",
+      configId: "model",
+      value: "probe-alias",
+    });
+
+    expect(getContextUsage).not.toHaveBeenCalled();
+    expect(session.contextWindowSize).toBe(777_000);
+  });
+
+  it("scopes the window cache per provider: a switch on a different provider does not read another provider's window", async () => {
+    // The window is a property of (model id, provider). A turn on provider-A
+    // learns 500_000 for RESOLVED_ID; a switch to the SAME resolved id on
+    // provider-B must NOT read it (falls to inference → 1_000_000 for the "1m"
+    // id), while a switch on provider-A DOES read it (500_000). All three
+    // outcomes are distinct: cached 500_000 vs inference 1_000_000 vs default.
+    // Uses a unique resolved id ("claude-provkey-probe[1m]") so the module-global
+    // cache (not reset per test in this file) can't cross this test with others.
+    const RESOLVED_ID = "claude-provkey-probe[1m]";
+    const { agent } = createMockAgentWithCapture();
+
+    // Provider-A session learns the authoritative window on a turn.
+    injectSession(agent, [
+      createAssistantMessage({ model: "claude-provkey-probe" }),
+      createResultMessageWithModel({
+        modelUsage: {
+          [RESOLVED_ID]: {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 500_000,
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+    const sessionA = agent.sessions["test-session"]!;
+    sessionA.providerCacheKey = "apiType-A https://a.example";
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+    expect(sessionA.contextWindowSize).toBe(500_000);
+
+    const modelInfos = [
+      { value: "alias", displayName: "Alias", description: "probe model", resolvedModel: RESOLVED_ID },
+    ];
+    const configOptions = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        category: "model",
+        currentValue: "default",
+        options: [{ value: "alias", name: "Alias" }],
+      },
+    ];
+
+    // A DIFFERENT provider seeing the same resolved id must not inherit A's
+    // window — it falls to inference (1_000_000), not the cached 500_000.
+    agent.sessions["session-B"] = mockSessionState({
+      providerCacheKey: "apiType-B https://b.example",
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos,
+      configOptions,
+      query: {
+        setModel: vi.fn(async () => {}),
+        setPermissionMode: vi.fn(async () => {}),
+        applyFlagSettings: vi.fn(async () => {}),
+        getContextUsage: vi.fn(async () => ({ rawMaxTokens: 200000 })),
+        supportedCommands: vi.fn(async () => []),
+      },
+    });
+    await agent.setSessionConfigOption({
+      sessionId: "session-B",
+      configId: "model",
+      value: "alias",
+    });
+    expect(agent.sessions["session-B"]!.contextWindowSize).toBe(1_000_000);
+
+    // The SAME provider (A) switching to that id DOES read the cached window.
+    sessionA.contextWindowSize = 123_456; // sentinel
+    sessionA.models = { currentModelId: "default", availableModels: [] };
+    sessionA.modelInfos = modelInfos as any;
+    sessionA.configOptions = configOptions as any;
+    await agent.setSessionConfigOption({
+      sessionId: "test-session",
+      configId: "model",
+      value: "alias",
+    });
+    expect(sessionA.contextWindowSize).toBe(500_000);
+  });
+
+  it("ignores a nonsensical (non-positive) reported window: keeps the prior window and doesn't poison the cache", async () => {
+    // A result.modelUsage that reports a non-positive contextWindow (observed
+    // from third-party backends) must not overwrite the window learned earlier,
+    // nor be written to the cross-session cache. Unique id keeps this isolated
+    // from other tests sharing the module-global cache (no resetModules here).
+    const RESOLVED_ID = "claude-nonpositive-probe[1m]";
+    const { agent } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createAssistantMessage({ model: "claude-nonpositive-probe" }),
+      createResultMessageWithModel({
+        modelUsage: {
+          [RESOLVED_ID]: {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 0, // nonsensical
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+    const session = agent.sessions["test-session"]!;
+    session.contextWindowSize = 900_000; // a window learned on a prior turn
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // The bad window was ignored — the prior window is preserved.
+    expect(session.contextWindowSize).toBe(900_000);
+
+    // And it never reached the cache: a switch to that id falls to inference
+    // (1_000_000 for the "1m" id), not the bad 0.
+    session.contextWindowSize = 123_456; // sentinel
+    session.models = { currentModelId: "default", availableModels: [] };
+    session.modelInfos = [
+      { value: "alias", displayName: "Alias", description: "probe", resolvedModel: RESOLVED_ID },
+    ] as any;
+    session.configOptions = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        category: "model",
+        currentValue: "default",
+        options: [{ value: "alias", name: "Alias" }],
+      },
+    ] as any;
+    await agent.setSessionConfigOption({
+      sessionId: "test-session",
+      configId: "model",
+      value: "alias",
+    });
+    expect(session.contextWindowSize).toBe(1_000_000);
   });
 });
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -5165,7 +5165,12 @@ describe("usage_update computation", () => {
     expect(sessionA.contextWindowSize).toBe(500_000);
 
     const modelInfos = [
-      { value: "alias", displayName: "Alias", description: "probe model", resolvedModel: RESOLVED_ID },
+      {
+        value: "alias",
+        displayName: "Alias",
+        description: "probe model",
+        resolvedModel: RESOLVED_ID,
+      },
     ];
     const configOptions = [
       {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -157,6 +157,7 @@ function mockSessionState(overrides: Record<string, any> = {}) {
     abortController: new AbortController(),
     emitRawSDKMessages: false,
     contextWindowSize: 200000,
+    contextWindowAuthoritative: false,
     providerCacheKey: "default",
     taskState: new Map(),
     toolUseCache: {},
@@ -1948,6 +1949,8 @@ describe("permission request cancellation", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -3731,6 +3734,8 @@ describe("session/close", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -3821,6 +3826,8 @@ describe("session/delete", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -3928,6 +3935,8 @@ describe("getOrCreateSession param change detection", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -5274,6 +5283,130 @@ describe("usage_update computation", () => {
       value: "alias",
     });
     expect(session.contextWindowSize).toBe(1_000_000);
+  });
+
+  it("does not let the message_start heuristic clobber an authoritative 200k window", async () => {
+    // An authoritative window can legitimately equal DEFAULT_CONTEXT_WINDOW
+    // (e.g. a third-party backend serving a 200k lane under a "[1m]"-spelled
+    // id). The message_start upgrade must key off the authoritative flag, not
+    // the value — otherwise the "1m" text match overwrites the cache-seeded
+    // 200k with 1M mid-stream on every turn.
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createStreamEvent("message_start", {
+        model: "claude-authprobe-1[1m]",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+      // Empty modelUsage: the result settles the turn without supplying a
+      // window of its own, so the assertion isolates the message_start path.
+      createResultMessageWithModel({ modelUsage: {} }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+    const session = agent.sessions["test-session"]!;
+    // Simulate a cache-seeded authoritative window that equals the default.
+    session.contextWindowSize = 200000;
+    session.contextWindowAuthoritative = true;
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(session.contextWindowSize).toBe(200000);
+    const usageUpdates = updates.filter((u: any) => u.update?.sessionUpdate === "usage_update");
+    for (const u of usageUpdates) {
+      expect(u.update.size).toBe(200000);
+    }
+  });
+
+  it("still upgrades a heuristic default window from the message_start model id", async () => {
+    // Companion to the authoritative-200k test: with no authoritative seed the
+    // old behavior stands — a "1m"-carrying live model id upgrades the default
+    // mid-stream so usage_update reports the right size before the result.
+    const { agent } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createStreamEvent("message_start", {
+        model: "claude-authprobe-2[1m]",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+      // Empty modelUsage: settles the turn without a window of its own.
+      createResultMessageWithModel({ modelUsage: {} }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+    const session = agent.sessions["test-session"]!;
+    expect(session.contextWindowAuthoritative).toBe(false);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(session.contextWindowSize).toBe(1_000_000);
+  });
+
+  it("caches the turn's window under the bare assistant-message id too, so resolvedModel-less rows can hit", async () => {
+    // Seed-time reads fall back to the picker value / verbatim live id when a
+    // model row carries no resolvedModel (the synthesized out-of-allowlist
+    // resume row sets it undefined on purpose). Those spellings match the
+    // assistant message's bare `.model`, not the "[1m]"-decorated modelUsage
+    // key, so the result handler must write both spellings — otherwise such
+    // rows silently never hit the cache. 555_000 can only come from the cache:
+    // inference on the bare id (no "1m" token) yields the 200_000 default, and
+    // the pre-switch sentinel is 123_456.
+    const BARE_ID = "claude-bareprobe-7";
+    const { agent } = createMockAgentWithCapture();
+    injectSession(agent, [
+      createAssistantMessage({ model: BARE_ID }),
+      createResultMessageWithModel({
+        modelUsage: {
+          [`${BARE_ID}[1m]`]: {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 555_000,
+            maxOutputTokens: 16384,
+          },
+        },
+      }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+    const session = agent.sessions["test-session"]!;
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+    expect(session.contextWindowSize).toBe(555_000);
+
+    // Switch to a row registered under the bare id with NO resolvedModel —
+    // the shape of the out-of-allowlist resume row.
+    session.contextWindowSize = 123_456; // sentinel
+    session.contextWindowAuthoritative = false;
+    session.models = { currentModelId: "default", availableModels: [] };
+    session.modelInfos = [{ value: BARE_ID, displayName: "Bare", description: "probe" }] as any;
+    session.configOptions = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        category: "model",
+        currentValue: "default",
+        options: [{ value: BARE_ID, name: "Bare" }],
+      },
+    ] as any;
+
+    await agent.setSessionConfigOption({
+      sessionId: "test-session",
+      configId: "model",
+      value: BARE_ID,
+    });
+
+    expect(session.contextWindowSize).toBe(555_000);
+    expect(session.contextWindowAuthoritative).toBe(true);
   });
 });
 
@@ -6626,6 +6759,8 @@ describe("post-error recovery", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -9337,6 +9472,8 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      contextWindowAuthoritative: false,
+      providerCacheKey: "default",
       taskState: new Map(),
       toolUseCache: {},
       emittedToolCalls: new Set(),
@@ -10606,6 +10743,8 @@ describe("agent selection config option", () => {
         abortController: new AbortController(),
         emitRawSDKMessages: false,
         contextWindowSize: 200000,
+        contextWindowAuthoritative: false,
+        providerCacheKey: "default",
         taskState: new Map(),
         toolUseCache: {},
         emittedToolCalls: new Set(),

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -625,34 +625,23 @@ describe("createSession options merging", () => {
       return (agent as unknown as { sessions: Record<string, any> }).sessions[sessionId];
     }
 
-    it("seeds contextWindowSize from the SDK's getContextUsage report", async () => {
-      // Aliases like `sonnet` can resolve to an extended-context model with no
-      // "1m" token anywhere in id/displayName/description, so the authoritative
-      // report must win over text inference (issue #596).
+    it("does not call getContextUsage during session creation", async () => {
+      // getContextUsage stalls until the session's first prompt turn has run
+      // (it is not serviced pre-turn), so session/new must never call it —
+      // awaiting it inline is what regressed session/new latency in 0.59.0.
+      const ctxSpy = vi.fn(async () => ({ rawMaxTokens: 967000 }));
+      contextUsageResult = ctxSpy;
+
+      await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      expect(ctxSpy).not.toHaveBeenCalled();
+    });
+
+    it("seeds contextWindowSize from text inference, falling back to the default when it misses", async () => {
+      // The mock model ("claude-sonnet-4-6" / "Claude Sonnet" / "Fast") carries
+      // no "1m" token anywhere, so inference misses and the window falls back to
+      // the default; the authoritative value arrives later via result.modelUsage.
       contextUsageResult = async () => ({ rawMaxTokens: 967000 });
-
-      const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
-
-      expect(sessionFor(response.sessionId).contextWindowSize).toBe(967000);
-    });
-
-    it("falls back to the default window when getContextUsage fails and inference misses", async () => {
-      // getContextUsage rejects, and the mock model ("claude-sonnet-4-6" /
-      // "Claude Sonnet" / "Fast") has no "1m" hint.
-      contextUsageResult = () => Promise.reject(new Error("no context usage mocked"));
-      // The rejection is deliberate — capture the agent's warning instead of
-      // letting it hit the console.
-      const errorSpy = vi.fn();
-      (agent as any).logger = { log: () => {}, error: errorSpy };
-
-      const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
-
-      expect(sessionFor(response.sessionId).contextWindowSize).toBe(200000);
-      expect(errorSpy).toHaveBeenCalled();
-    });
-
-    it("ignores a nonsensical (non-positive) reported window", async () => {
-      contextUsageResult = async () => ({ rawMaxTokens: 0 });
 
       const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
 

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -7,7 +7,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 let capturedOptions: Options | undefined;
-let contextUsageResult: (() => Promise<{ rawMaxTokens: number }>) | undefined;
+let contextUsageResult: (() => Promise<{ rawMaxTokens: number; model?: string }>) | undefined;
 vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
   const actual = await vi.importActual<typeof import("@anthropic-ai/claude-agent-sdk")>(
     "@anthropic-ai/claude-agent-sdk",
@@ -646,6 +646,80 @@ describe("createSession options merging", () => {
       const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
 
       expect(sessionFor(response.sessionId).contextWindowSize).toBe(200000);
+      expect(sessionFor(response.sessionId).contextWindowAuthoritative).toBe(false);
+    });
+
+    it("session/load seeds the window from the resumed session's getContextUsage report", async () => {
+      // Resumed sessions get getContextUsage serviced pre-turn (issue #845 uses
+      // it to restore the live model), and the same response carries the
+      // authoritative window (`rawMaxTokens`). After a process restart the
+      // module cache is empty and text inference misses natively-1M aliases, so
+      // discarding this in-hand value would replay the issue-#596 flicker on
+      // every reload — the flagship scenario. 888_000 can only come from the
+      // report: inference on the mock model yields null → 200_000 default.
+      contextUsageResult = async () => ({ rawMaxTokens: 888_000, model: "claude-sonnet-4-6" });
+
+      await (
+        agent as unknown as {
+          createSession: (params: object, opts: { resume?: string }) => Promise<unknown>;
+        }
+      ).createSession({ cwd: process.cwd(), mcpServers: [] }, { resume: "resumed-window-probe" });
+
+      const session = sessionFor("resumed-window-probe");
+      expect(session.contextWindowSize).toBe(888_000);
+      expect(session.contextWindowAuthoritative).toBe(true);
+    });
+
+    it("scopes providerCacheKey by per-session env routing", async () => {
+      // The context-window cache key must distinguish backends exactly as the
+      // CLI will see them: a session routed to a proxy via _meta env shares a
+      // model id spelling with default-routed sessions but not a context lane,
+      // so it must land in its own cache bucket (and two default-routed
+      // sessions must share one).
+      const r1 = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+      const r2 = await agent.newSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+        _meta: {
+          claudeCode: {
+            options: { env: { ANTHROPIC_BASE_URL: "https://window-probe-proxy.example" } },
+          },
+        },
+      });
+      const r3 = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      expect(sessionFor(r2.sessionId).providerCacheKey).not.toBe(
+        sessionFor(r1.sessionId).providerCacheKey,
+      );
+      expect(sessionFor(r3.sessionId).providerCacheKey).toBe(
+        sessionFor(r1.sessionId).providerCacheKey,
+      );
+    });
+
+    it("scopes providerCacheKey by provider headers: same endpoint, different headers → different buckets", async () => {
+      // Two providers/set configs sharing apiType+baseUrl but differing in
+      // headers (e.g. an `anthropic-beta: context-1m-…` routing header) can
+      // serve different context lanes for the same model id, so they must not
+      // share a window-cache bucket.
+      await agent.unstable_setProvider({
+        providerId: "main",
+        apiType: "anthropic",
+        baseUrl: "https://gw.example",
+        headers: {},
+      });
+      const plain = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      await agent.unstable_setProvider({
+        providerId: "main",
+        apiType: "anthropic",
+        baseUrl: "https://gw.example",
+        headers: { "anthropic-beta": "context-1m-2025-08-07" },
+      });
+      const beta = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      expect(sessionFor(beta.sessionId).providerCacheKey).not.toBe(
+        sessionFor(plain.sessionId).providerCacheKey,
+      );
     });
   });
 

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -936,30 +936,16 @@ describe("session config options", () => {
       return (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
     }
 
-    it("refreshes contextWindowSize from getContextUsage when the model changes", async () => {
+    it("sets the window from text inference on model switch, without any getContextUsage IPC", async () => {
+      // getContextUsage stalls until the session's first prompt turn, so the
+      // switch path must never call it; the window is seeded from the text
+      // heuristic (here via the new model's resolvedModel) and later confirmed
+      // by result.modelUsage.
       const session = getSession();
       session.query.getContextUsage = vi.fn(async () => ({ rawMaxTokens: 967000 }));
-
-      await agent.setSessionConfigOption({
-        sessionId: SESSION_ID,
-        configId: "model",
-        value: "claude-sonnet-4-6",
-      });
-
-      expect(session.query.getContextUsage).toHaveBeenCalled();
-      expect(session.contextWindowSize).toBe(967000);
-    });
-
-    it("falls back to resolvedModel text inference when getContextUsage fails", async () => {
-      const session = getSession();
-      session.query.getContextUsage = vi.fn().mockRejectedValue(new Error("boom"));
       session.modelInfos = session.modelInfos.map((m: ModelInfo) =>
         m.value === "claude-sonnet-4-6" ? { ...m, resolvedModel: "claude-sonnet-5[1m]" } : m,
       );
-      // The rejection is deliberate — capture the agent's warning instead of
-      // letting it hit the console.
-      const errorSpy = vi.fn();
-      (agent as any).logger = { log: () => {}, error: errorSpy };
 
       await agent.setSessionConfigOption({
         sessionId: SESSION_ID,
@@ -967,18 +953,17 @@ describe("session config options", () => {
         value: "claude-sonnet-4-6",
       });
 
+      expect(session.query.getContextUsage).not.toHaveBeenCalled();
       expect(session.contextWindowSize).toBe(1_000_000);
-      expect(errorSpy).toHaveBeenCalled();
     });
 
-    it("falls back to the default window when the SDK and inference both miss", async () => {
+    it("falls back to the default window when inference misses, without any getContextUsage IPC", async () => {
       const session = getSession();
       session.contextWindowSize = 1_000_000;
-      session.query.getContextUsage = vi.fn().mockRejectedValue(new Error("boom"));
-      // The rejection is deliberate — capture the agent's warning instead of
-      // letting it hit the console.
-      const errorSpy = vi.fn();
-      (agent as any).logger = { log: () => {}, error: errorSpy };
+      // Present but must NOT be called; the switch never consults it.
+      session.query.getContextUsage = vi.fn(async () => ({ rawMaxTokens: 967000 }));
+      // claude-sonnet-4-6 carries no "1m" token in its id, resolvedModel,
+      // displayName, or description, so inference misses → default window.
 
       await agent.setSessionConfigOption({
         sessionId: SESSION_ID,
@@ -986,8 +971,22 @@ describe("session config options", () => {
         value: "claude-sonnet-4-6",
       });
 
+      expect(session.query.getContextUsage).not.toHaveBeenCalled();
       expect(session.contextWindowSize).toBe(200000);
-      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it("does not call getContextUsage even when switching to a fresh model", async () => {
+      const session = getSession();
+      const spy = vi.fn(async () => ({ rawMaxTokens: 967000 }));
+      session.query.getContextUsage = spy;
+
+      await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "model",
+        value: "claude-sonnet-4-6",
+      });
+
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it("keeps the learned window when re-asserting the current model", async () => {


### PR DESCRIPTION
## Summary

`session/new` and switching models via `configOptions` regressed to ~15s each in v0.59.0. This removes the blocking call responsible and seeds the context window synchronously instead, restoring sub-second behavior on both paths.

## Root cause

v0.59.0 added an inline `await query.getContextUsage()` on the session-creation and model-switch paths. That SDK control request is not serviced by the CLI until the session's first prompt turn has run — before then it stalls ~15s. And because SDK control requests are serialized over a single stdin/stdout channel, an awaited `setModel` queued behind the wedged `getContextUsage` inherited the full stall. So both paths blocked ~15s before returning.

Verified with the real CLI (setModel alone pre-prompt: ~1ms; getContextUsage alone pre-prompt: ~16s; getContextUsage-then-setModel: both resolve together at ~16s, confirming the serialization).

## Fix

Drop `getContextUsage` from both hot paths. The context window is seeded synchronously by `immediateContextWindow(...)`:

1. an authoritative value from a per-(provider, model) cache, if learned; else
2. a synchronous text heuristic (`\b1m\b` → 1,000,000); else
3. `DEFAULT_CONTEXT_WINDOW` (200,000).

The authoritative window is learned the moment it's actually available — from each turn's `result.modelUsage` — and written into the cache, so later sessions/switches to the same model seed the correct window immediately with no IPC. A model that has never run a turn shows the heuristic/default window until its first response, matching pre-0.59.0 behavior.

### Cache design

- **Keyed on `(provider, resolved model id)`.** The resolved id (`ModelInfo.resolvedModel`, e.g. `claude-sonnet-5[1m]`) matches the `result.modelUsage` keys, so the write key and the read keys line up. Keying on the resolved id (not the picker value) dedups aliases that resolve to the same model; keying on the provider keeps two providers that reuse an id string for different windows from crossing wires (per-session provider config, #853). The provider is captured at session creation, since the effective provider can change process-wide over the adapter's lifetime.
- **Non-positive/NaN windows are ignored** — they neither overwrite the session's learned window nor enter the cache.

## Impact (measured, real CLI)

| Path | Before | After |
| --- | --- | --- |
| `session/new` | ~17.4s | ~0.9s |
| model switch (before first prompt) | ~15s | ~3ms |
| model switch (after a turn) | ~14.7s | <1ms |

## Tests

- New end-to-end cache test: a turn's authoritative window (learned under the resolved id even when the assistant message reports the bare id) is served on a later switch with no `getContextUsage`.
- New provider-isolation test: the same resolved id on a different provider does not read another provider's cached window; the same provider does.
- New non-positive-window test: a nonsensical `contextWindow` is ignored and never poisons the cache.
- Rewrote the existing context-window tests to the new contract (assert no `getContextUsage` on session/new and switch; window from cache/inference/default).

Closes #886
Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)