### PR TITLE
chore: Ignore typescript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "all"
+    ignore:
+      # typescript-eslint caps its typescript peer dependency at <6.1.0,
+      # so major bumps of typescript cannot install until it adds support
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     groups:
       minor:
         update-types:


### PR DESCRIPTION
## Problem

CI fails on the dependabot PR #857 (typescript 6.0.3 → 7.0.2): `npm ci` exits with `ERESOLVE could not resolve`.

## Root cause

`@typescript-eslint/eslint-plugin@8.65.0` (the latest release) declares:

```
peerDependencies: typescript >=4.8.4 <6.1.0
```

TypeScript 7.x is outside that range, so npm cannot resolve the tree. There is no version of typescript-eslint that supports TypeScript 7 yet, so the bump is unmergeable as-is and dependabot will keep retrying (and failing CI) on every future TS major release.

## Fix

Tell dependabot to ignore major version updates of `typescript` until typescript-eslint adds support; minor/patch updates keep flowing through the existing group.

After merging, #857 can be closed (I don't have permission to close it).