### PR TITLE
feat: Add _claude/usage extension method for structured rate-limit usage

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -199,6 +199,9 @@ const TURN_NO_RESULT_MESSAGE =
  *  `InitializeResponse._meta.steering.supported`. */
 const STEER_METHOD = "_session/steering";
 
+/** Extension method returning the caller-requested claude.ai rate-limit windows. */
+const USAGE_METHOD = "_claude/usage";
+
 /** How urgently the SDK delivers a steered message relative to the running
  *  turn — an internal Claude implementation detail, not part of the wire
  *  contract. `now` pre-empts the current generation and handles the message
@@ -250,6 +253,28 @@ function parseSteerRequest(params: unknown): SteerRequest {
     sessionId,
     prompt: prompt as PromptRequest["prompt"],
   };
+}
+
+/** Params of a {@link USAGE_METHOD} request: the rate-limit window keys the
+ *  caller wants back, e.g. `["five_hour", "seven_day"]`. */
+export type UsageRequest = {
+  keys: string[];
+};
+
+/** The requested rate-limit windows, each straight from the SDK's structured
+ *  /usage data. A key the SDK does not report is absent from the object. */
+export type UsageResponse = Record<string, unknown>;
+
+/** Validate raw JSON-RPC params into a {@link UsageRequest}. */
+function parseUsageRequest(params: unknown): UsageRequest {
+  if (!params || typeof params !== "object") {
+    throw RequestError.invalidParams(undefined, "usage params must be an object");
+  }
+  const { keys } = params as Record<string, unknown>;
+  if (!Array.isArray(keys) || keys.some((key) => typeof key !== "string")) {
+    throw RequestError.invalidParams(undefined, "usage params require a keys array of strings");
+  }
+  return { keys };
 }
 
 /** Internal model-selection state. Mirrors the shape the ACP SDK exposed as
@@ -1283,6 +1308,40 @@ export class ClaudeAcpAgent {
     this.sessions = {};
     this.client = client;
     this.logger = logger ?? console;
+  }
+
+  /**
+   * Returns the caller-requested rate-limit windows straight from the SDK's
+   * structured /usage data. The caller passes the keys it wants (e.g. `["five_hour",
+   * "seven_day"]`) and gets back `{ [key]: rate_limits[key] }` — key selection and
+   * labelling stay entirely on the caller. An unfed `Pushable` holds the ephemeral
+   * query open long enough to issue the get_usage request.
+   */
+  async readUsage({ keys }: UsageRequest): Promise<UsageResponse> {
+    const usageQuery = query({
+      prompt: new Pushable<SDKUserMessage>(),
+      options: {
+        pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE ?? (await claudeCliPath()),
+      },
+    });
+
+    try {
+      const { rate_limits } =
+        await usageQuery.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET();
+
+      // null whenever plan limits don't apply — API key, Bedrock, Vertex.
+      if (!rate_limits) {
+        return {};
+      }
+
+      const windows = rate_limits as Record<string, unknown>;
+
+      return Object.fromEntries(
+        keys.filter((key) => key in windows).map((key) => [key, windows[key]]),
+      );
+    } finally {
+      usageQuery.close();
+    }
   }
 
   async initialize(request: InitializeRequest): Promise<InitializeResponse> {
@@ -7439,6 +7498,9 @@ export function runAcp() {
     .onNotification(methods.agent.session.cancel, (ctx) => agent.cancel(ctx.params))
     .onRequest<SteerRequest, SteerResponse>(STEER_METHOD, { parse: parseSteerRequest }, (ctx) =>
       agent.steer(ctx.params),
+    )
+    .onRequest<UsageRequest, UsageResponse>(USAGE_METHOD, { parse: parseUsageRequest }, (ctx) =>
+      agent.readUsage(ctx.params),
     )
     .connect(stream);
 

--- a/src/tests/usage.test.ts
+++ b/src/tests/usage.test.ts
@@ -1,0 +1,77 @@
+import { SessionNotification } from "@agentclientprotocol/sdk";
+import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const FIVE_HOUR = { utilization: 42, resets_at: "2026-01-01T00:00:00Z" };
+const SEVEN_DAY = { utilization: 7, resets_at: "2026-01-07T00:00:00Z" };
+
+let rateLimits: Record<string, unknown> | null = null;
+let usageFailure: Error | undefined;
+const close = vi.fn();
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
+  const actual = await vi.importActual<typeof import("@anthropic-ai/claude-agent-sdk")>(
+    "@anthropic-ai/claude-agent-sdk",
+  );
+  const { makeMockQuery } = await import("./helpers.js");
+  return {
+    ...actual,
+    query: () =>
+      makeMockQuery({
+        usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET: async () => {
+          if (usageFailure) {
+            throw usageFailure;
+          }
+          return { rate_limits: rateLimits };
+        },
+        close,
+      }),
+  };
+});
+
+describe("_claude/usage", () => {
+  let agent: ClaudeAcpAgentType;
+
+  beforeEach(async () => {
+    // Skips the CLI lookup readUsage would otherwise do to spawn the query.
+    process.env.CLAUDE_CODE_EXECUTABLE = "/bin/true";
+    rateLimits = { five_hour: FIVE_HOUR, seven_day: SEVEN_DAY };
+    usageFailure = undefined;
+    close.mockClear();
+    vi.resetModules();
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    agent = new ClaudeAcpAgent({
+      sessionUpdate: async (_notification: SessionNotification) => {},
+      requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      readTextFile: async () => ({ content: "" }),
+      writeTextFile: async () => ({}),
+    } as unknown as AcpClient);
+  });
+
+  afterEach(() => void delete process.env.CLAUDE_CODE_EXECUTABLE);
+
+  it("returns only the requested windows, verbatim", async () => {
+    expect(await agent.readUsage({ keys: ["five_hour"] })).toEqual({ five_hour: FIVE_HOUR });
+  });
+
+  it("omits windows the SDK does not report", async () => {
+    rateLimits = { five_hour: FIVE_HOUR };
+
+    expect(await agent.readUsage({ keys: ["five_hour", "seven_day"] })).toEqual({
+      five_hour: FIVE_HOUR,
+    });
+  });
+
+  it("returns nothing when plan limits do not apply", async () => {
+    rateLimits = null;
+
+    expect(await agent.readUsage({ keys: ["five_hour", "seven_day"] })).toEqual({});
+  });
+
+  it("closes the ephemeral query even when the usage request fails", async () => {
+    usageFailure = new Error("no usage for you");
+
+    await expect(agent.readUsage({ keys: ["five_hour"] })).rejects.toThrow("no usage for you");
+    expect(close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds a `_claude/usage` ACP extension method that exposes the SDK's structured `/usage` data, so a client can render plan rate-limit utilization (5-hour, 7-day, …) without scraping the `/usage` slash-command text.

### Shape

A thin passthrough. The caller asks for the windows it wants and gets them back verbatim:

```jsonc
// → _claude/usage
{ "keys": ["five_hour", "seven_day"] }

// ← result
{
  "five_hour": { "utilization": 42, "resets_at": "2026-01-01T00:00:00Z" },
  "seven_day": { "utilization": 7,  "resets_at": "2026-01-07T00:00:00Z" }
}
```

Key selection and labelling stay entirely on the caller, so windows the SDK adds later need no change here.

- Windows the SDK does not report are omitted from the result.
- The result is `{}` when plan limits do not apply — API key, Bedrock, Vertex (`rate_limits: null`).
- An unfed `Pushable` holds an ephemeral query open just long enough to issue the `get_usage` request; it is closed in a `finally`, so a failed request leaks no subprocess.

Params are validated by `parseUsageRequest`, mirroring the existing `parseSteerRequest` — non-object params, or a `keys` that isn't an array of strings, raise `invalidParams`.

### Notes for review

The SDK method behind this is `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET()`, hence an extension method rather than a core one. Two things I'm happy to change on request:

- **Naming** — `_claude/usage` mirrors codex-acp's `_codex/account/rate_limits`.
- **Discovery** — unlike `_session/steering`, this advertises no capability flag. I can gate it behind an `InitializeResponse._meta` entry if you'd prefer clients feature-detect it.

### Testing

`src/tests/usage.test.ts` covers key selection, unreported windows, the no-plan-limits case, and query cleanup when the usage request throws. Full CI run locally — `format:check`, `lint`, `build`, `test:run` (656 passed, 20 skipped) — all green.