### PR TITLE
fix: Report tool_progress heartbeats against the tool call they describe

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -184,6 +184,12 @@ const DEFAULT_CONTEXT_WINDOW = 200000;
  *  pre-empt a slow-but-healthy interrupt. */
 const DEFAULT_FORCE_CANCEL_GRACE_MS = 30_000;
 
+/** `tool_progress` heartbeats report under a derived `<tool_use_id>-heartbeat-<n>`
+ *  rather than the id of the call they describe. The beat carries `heartbeat: true`,
+ *  but that flag alone can't recover the original id, so the suffix has to be
+ *  stripped. Revisit if the SDK stops deriving the id this way. */
+const HEARTBEAT_ID_SUFFIX = /-heartbeat-\d+$/;
+
 /** Error surfaced when the SDK declares a turn over (`session_state_changed:
  *  idle`, its authoritative turn-over signal) without ever emitting the turn's
  *  `result` — a model stream that dropped mid-turn, or an async agent that
@@ -3708,11 +3714,22 @@ export class ClaudeAcpAgent {
             break;
           }
           case "tool_progress": {
+            // Heartbeat beats arrive under a synthetic `<tool_use_id>-heartbeat-<n>`
+            // that no `tool_call` was ever emitted for, so forwarding it verbatim
+            // leaves the client resolving an id it has never seen (the same trap
+            // `ensureToolCallEmitted` documents for #851). Report the beat against
+            // the call it describes instead.
+            const toolCallId = message.tool_use_id.replace(HEARTBEAT_ID_SUFFIX, "");
+            // Ids leave `emittedToolCalls` at `tool_result`, so this also stops a
+            // beat that races past completion from reopening a finished call.
+            if (!session.emittedToolCalls.has(toolCallId)) {
+              break;
+            }
             await sendUpdate({
               sessionId: message.session_id,
               update: {
                 sessionUpdate: "tool_call_update",
-                toolCallId: message.tool_use_id,
+                toolCallId,
                 status: "in_progress",
                 _meta: {
                   claudeCode: {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -184,12 +184,6 @@ const DEFAULT_CONTEXT_WINDOW = 200000;
  *  pre-empt a slow-but-healthy interrupt. */
 const DEFAULT_FORCE_CANCEL_GRACE_MS = 30_000;
 
-/** `tool_progress` heartbeats report under a derived `<tool_use_id>-heartbeat-<n>`
- *  rather than the id of the call they describe. The beat carries `heartbeat: true`,
- *  but that flag alone can't recover the original id, so the suffix has to be
- *  stripped. Revisit if the SDK stops deriving the id this way. */
-const HEARTBEAT_ID_SUFFIX = /-heartbeat-\d+$/;
-
 /** Error surfaced when the SDK declares a turn over (`session_state_changed:
  *  idle`, its authoritative turn-over signal) without ever emitting the turn's
  *  `result` — a model stream that dropped mid-turn, or an async agent that
@@ -3714,15 +3708,23 @@ export class ClaudeAcpAgent {
             break;
           }
           case "tool_progress": {
-            // Heartbeat beats arrive under a synthetic `<tool_use_id>-heartbeat-<n>`
-            // that no `tool_call` was ever emitted for, so forwarding it verbatim
-            // leaves the client resolving an id it has never seen (the same trap
-            // `ensureToolCallEmitted` documents for #851). Report the beat against
-            // the call it describes instead.
-            const toolCallId = message.tool_use_id.replace(HEARTBEAT_ID_SUFFIX, "");
+            // Not every beat reports under the id of a tool call the client has
+            // seen: heartbeats derive `<tool_use_id>-heartbeat-<n>`, and the
+            // `agent_api_retry` beats behind `subagentRetry` report under
+            // `agent_<assistant_message_id>`. Forwarding those verbatim leaves the
+            // client resolving an id it has never been told about (the same trap
+            // `ensureToolCallEmitted` documents for #851). The SDK stamps
+            // `parent_tool_use_id` with the executing tool's real id whenever the
+            // beat doesn't carry one of its own, so fall back to it rather than
+            // pattern-matching each synthetic id shape. Beats that do report a real
+            // id (a subagent's `bash_progress`, whose parent is the spawning Agent
+            // call) keep resolving to that id.
+            const toolCallId = session.emittedToolCalls.has(message.tool_use_id)
+              ? message.tool_use_id
+              : message.parent_tool_use_id;
             // Ids leave `emittedToolCalls` at `tool_result`, so this also stops a
             // beat that races past completion from reopening a finished call.
-            if (!session.emittedToolCalls.has(toolCallId)) {
+            if (toolCallId === null || !session.emittedToolCalls.has(toolCallId)) {
               break;
             }
             await sendUpdate({

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -11067,3 +11067,119 @@ describe("agent selection config option", () => {
     });
   });
 });
+
+describe("tool_progress heartbeats", () => {
+  // Heartbeat beats identify themselves with a derived
+  // `<tool_use_id>-heartbeat-<n>` that never had a `tool_call` of its own.
+  // Forwarding that id verbatim made clients synthesize a phantom tool call per
+  // beat, one every ~30s for the life of the tool.
+  type ToolCallUpdate = Extract<
+    SessionNotification["update"],
+    { sessionUpdate: "tool_call_update" }
+  >;
+
+  /** Run a turn carrying `messages`, with `inFlight` tool calls already emitted,
+   *  and return the tool_call_updates it produced. */
+  async function run(messages: any[], inFlight: string[]) {
+    const updates: SessionNotification[] = [];
+    const mockClient = {
+      sessionUpdate: async (n: SessionNotification) => {
+        updates.push(n);
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const { value, done } = await input[Symbol.asyncIterator]().next();
+      if (!done && value) {
+        yield {
+          type: "user",
+          message: value.message,
+          parent_tool_use_id: null,
+          uuid: value.uuid,
+          session_id: "test-session",
+          isReplay: true,
+        };
+      }
+      yield* messages;
+      yield {
+        type: "result",
+        subtype: "success",
+        stop_reason: null,
+        is_error: false,
+        result: "",
+        usage: {},
+        uuid: randomUUID(),
+        session_id: "test-session",
+      };
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+    }
+    agent.sessions["test-session"] = mockSessionState({
+      query: wrapQuery(messageGenerator()),
+      input,
+      emittedToolCalls: new Set(inFlight),
+    });
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+    return updates
+      .map((n) => n.update)
+      .filter((u): u is ToolCallUpdate => u.sessionUpdate === "tool_call_update");
+  }
+
+  function beat(toolUseId: string, extra: Record<string, any> = {}) {
+    return {
+      type: "tool_progress",
+      tool_use_id: toolUseId,
+      tool_name: "Bash",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 30,
+      heartbeat: true,
+      uuid: randomUUID(),
+      session_id: "test-session",
+      ...extra,
+    };
+  }
+
+  it("reports every beat against the tool call it describes", async () => {
+    const sent = await run(
+      [beat("toolu_abc-heartbeat-0"), beat("toolu_abc-heartbeat-1")],
+      ["toolu_abc"],
+    );
+
+    expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_abc", "toolu_abc"]);
+    expect(sent[0].status).toBe("in_progress");
+  });
+
+  // Covers a call that was never emitted and one whose tool_result already
+  // removed it, so a straggling beat can't reopen a call seen to finish.
+  it("drops a beat for a tool call that is not in flight", async () => {
+    expect(await run([beat("toolu_ghost-heartbeat-0")], [])).toHaveLength(0);
+  });
+
+  it("preserves the elapsed time and subagent meta", async () => {
+    const sent = await run(
+      [
+        beat("toolu_task-heartbeat-0", {
+          elapsed_time_seconds: 90,
+          tool_name: "Task",
+          subagent_type: "code-reviewer",
+        }),
+      ],
+      ["toolu_task"],
+    );
+
+    expect(sent[0].toolCallId).toBe("toolu_task");
+    expect((sent[0]._meta as any).claudeCode).toMatchObject({
+      toolName: "Task",
+      toolResponse: { elapsedTimeSeconds: 90, subagentType: "code-reviewer" },
+    });
+  });
+
+  it("leaves an unsuffixed progress message alone", async () => {
+    const sent = await run([beat("toolu_plain", { heartbeat: undefined })], ["toolu_plain"]);
+
+    expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_plain"]);
+  });
+});

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -11128,12 +11128,18 @@ describe("tool_progress heartbeats", () => {
       .filter((u): u is ToolCallUpdate => u.sessionUpdate === "tool_call_update");
   }
 
-  function beat(toolUseId: string, extra: Record<string, any> = {}) {
+  /** A heartbeat as the SDK emits it: a derived `tool_use_id`, with
+   *  `parent_tool_use_id` stamped with the real id of the executing tool. */
+  function beat(
+    toolUseId: string,
+    parentToolUseId: string | null,
+    extra: Record<string, any> = {},
+  ) {
     return {
       type: "tool_progress",
       tool_use_id: toolUseId,
       tool_name: "Bash",
-      parent_tool_use_id: null,
+      parent_tool_use_id: parentToolUseId,
       elapsed_time_seconds: 30,
       heartbeat: true,
       uuid: randomUUID(),
@@ -11144,7 +11150,7 @@ describe("tool_progress heartbeats", () => {
 
   it("reports every beat against the tool call it describes", async () => {
     const sent = await run(
-      [beat("toolu_abc-heartbeat-0"), beat("toolu_abc-heartbeat-1")],
+      [beat("toolu_abc-heartbeat-0", "toolu_abc"), beat("toolu_abc-heartbeat-1", "toolu_abc")],
       ["toolu_abc"],
     );
 
@@ -11155,17 +11161,48 @@ describe("tool_progress heartbeats", () => {
   // Covers a call that was never emitted and one whose tool_result already
   // removed it, so a straggling beat can't reopen a call seen to finish.
   it("drops a beat for a tool call that is not in flight", async () => {
-    expect(await run([beat("toolu_ghost-heartbeat-0")], [])).toHaveLength(0);
+    expect(await run([beat("toolu_ghost-heartbeat-0", "toolu_ghost")], [])).toHaveLength(0);
   });
 
-  it("preserves the elapsed time and subagent meta", async () => {
+  it("preserves the elapsed time", async () => {
+    const sent = await run(
+      [beat("toolu_abc-heartbeat-2", "toolu_abc", { elapsed_time_seconds: 90 })],
+      ["toolu_abc"],
+    );
+
+    expect(sent[0].toolCallId).toBe("toolu_abc");
+    expect((sent[0]._meta as any).claudeCode).toMatchObject({
+      toolName: "Bash",
+      toolResponse: { elapsedTimeSeconds: 90 },
+    });
+  });
+
+  // `agent_api_retry` beats — the only source of `subagentType`/`subagentRetry`
+  // — are not heartbeats and don't use the `-heartbeat-<n>` id shape: they
+  // report under `agent_<assistant_message_id>`, with the retrying Agent call's
+  // real id in `parent_tool_use_id`. Resolving via the suffix alone dropped
+  // them, leaving a stalled spawn with no explanation.
+  it("reports a subagent retry beat against the Agent call that is retrying", async () => {
     const sent = await run(
       [
-        beat("toolu_task-heartbeat-0", {
-          elapsed_time_seconds: 90,
+        {
+          type: "tool_progress",
+          tool_use_id: "agent_msg_01xyz",
           tool_name: "Task",
+          parent_tool_use_id: "toolu_task",
+          elapsed_time_seconds: 0,
           subagent_type: "code-reviewer",
-        }),
+          subagent_retry: {
+            agent_id: "agent-1",
+            attempt: 2,
+            max_retries: 5,
+            retry_delay_ms: 4000,
+            error_status: 529,
+            error_category: "overloaded",
+          },
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
       ],
       ["toolu_task"],
     );
@@ -11173,13 +11210,22 @@ describe("tool_progress heartbeats", () => {
     expect(sent[0].toolCallId).toBe("toolu_task");
     expect((sent[0]._meta as any).claudeCode).toMatchObject({
       toolName: "Task",
-      toolResponse: { elapsedTimeSeconds: 90, subagentType: "code-reviewer" },
+      toolResponse: {
+        subagentType: "code-reviewer",
+        subagentRetry: { attempt: 2, max_retries: 5, error_status: 529 },
+      },
     });
   });
 
-  it("leaves an unsuffixed progress message alone", async () => {
-    const sent = await run([beat("toolu_plain", { heartbeat: undefined })], ["toolu_plain"]);
+  // A subagent's own `bash_progress` reports the inner tool's real id, with the
+  // spawning Agent call as its parent. The real id wins so the beat lands on the
+  // nested call rather than being hoisted onto the Agent card.
+  it("leaves a beat that reports a real tool call alone", async () => {
+    const sent = await run(
+      [beat("toolu_inner", "toolu_task", { heartbeat: undefined })],
+      ["toolu_task", "toolu_inner"],
+    );
 
-    expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_plain"]);
+    expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_inner"]);
   });
 });


### PR DESCRIPTION
Heartbeat beats reach the bridge under a derived
`<tool_use_id>-heartbeat-<n>` id that no `tool_call` was ever emitted for, and the handler forwarded it verbatim. Clients that expect a `tool_call_update` to reference a tool call they have been told about saw a reference they could not resolve, and since the counter makes every beat a fresh id, nothing deduplicated them: a ten-minute Bash call produced roughly twenty phantom entries. Zed renders each as a failed "Tool call not found" card; compozy/compozy#257 and agent-of-empires/agent-of-empires#3084 report the same shape.

Strip the derived suffix so the beat is reported against the call it describes, and drop it when that call is not in `emittedToolCalls`. Ids enter that set at `tool_use` and leave it at `tool_result`, so the guard covers both an id that was never announced and a straggling beat that races past completion, which would otherwise flip a call the client has seen finish back to `in_progress`.

The SDK sets `heartbeat: true` on these messages, but that flag alone cannot recover the original id, and `parent_tool_use_id` is the subagent parent rather than the call being reported on, so the suffix still has to be stripped.

`tool_progress` had no test coverage. Add cases for the retarget across a climbing counter, the not-in-flight drop, meta pass-through, and an unsuffixed id being left alone.

Fixes #913