### PR TITLE
Mark custom answer elicitation fields

### DIFF
--- a/src/elicitation.ts
+++ b/src/elicitation.ts
@@ -147,6 +147,7 @@ function questionCustomFieldKey(index: number): string {
  * extensions (`_claude/...`).
  */
 const OPTION_META_KEY = "_claude/askUserQuestionOption";
+const CUSTOM_ANSWER_META_KEY = "_claude/askUserQuestionCustomAnswer";
 
 /**
  * Render the AskUserQuestion tool's questions as an ACP form elicitation.
@@ -204,6 +205,12 @@ export function askUserQuestionsToCreateRequest(
       type: "string",
       title: "Other",
       description: "Type your own answer instead of choosing an option above (optional).",
+      _meta: {
+        [CUSTOM_ANSWER_META_KEY]: {
+          questionId: questionFieldKey(index),
+          isCustomAnswer: true,
+        },
+      },
     };
   });
 

--- a/src/elicitation.ts
+++ b/src/elicitation.ts
@@ -147,7 +147,14 @@ function questionCustomFieldKey(index: number): string {
  * extensions (`_claude/...`).
  */
 const OPTION_META_KEY = "_claude/askUserQuestionOption";
-const CUSTOM_ANSWER_META_KEY = "_claude/askUserQuestionCustomAnswer";
+
+/**
+ * Shared `_meta` key for marking a per-question free-text field as the custom
+ * answer companion for a select question. This intentionally has no
+ * agent-specific namespace so ACP clients can recognize the same marker across
+ * Codex, Claude, and other AskUserQuestion bridges.
+ */
+const CUSTOM_ANSWER_META_KEY = "_askUserQuestionCustomAnswer";
 
 /**
  * Render the AskUserQuestion tool's questions as an ACP form elicitation.

--- a/src/tests/elicitation.test.ts
+++ b/src/tests/elicitation.test.ts
@@ -265,7 +265,7 @@ describe("askUserQuestionsToCreateRequest", () => {
       type: "string",
       title: "Other",
       _meta: {
-        "_claude/askUserQuestionCustomAnswer": {
+        _askUserQuestionCustomAnswer: {
           questionId: "question_0",
           isCustomAnswer: true,
         },
@@ -275,7 +275,7 @@ describe("askUserQuestionsToCreateRequest", () => {
       type: "string",
       title: "Other",
       _meta: {
-        "_claude/askUserQuestionCustomAnswer": {
+        _askUserQuestionCustomAnswer: {
           questionId: "question_1",
           isCustomAnswer: true,
         },

--- a/src/tests/elicitation.test.ts
+++ b/src/tests/elicitation.test.ts
@@ -264,10 +264,22 @@ describe("askUserQuestionsToCreateRequest", () => {
     expect(schema.properties?.["question_0_custom"]).toMatchObject({
       type: "string",
       title: "Other",
+      _meta: {
+        "_claude/askUserQuestionCustomAnswer": {
+          questionId: "question_0",
+          isCustomAnswer: true,
+        },
+      },
     });
     expect(schema.properties?.["question_1_custom"]).toMatchObject({
       type: "string",
       title: "Other",
+      _meta: {
+        "_claude/askUserQuestionCustomAnswer": {
+          questionId: "question_1",
+          isCustomAnswer: true,
+        },
+      },
     });
   });
 


### PR DESCRIPTION
## Why
AskUserQuestion emits a per-question free-text field that should be rendered as the custom-answer companion for the preceding select question. ACP clients need a stable metadata marker for that relationship instead of guessing from field ids, titles, or descriptions.

## What changed
- Mark each AskUserQuestion custom-answer companion field with `_meta._askUserQuestionCustomAnswer`.
- Use the same non-agent-specific key that Codex and other bridges can emit, so clients can parse one shared marker instead of maintaining per-agent metadata names.
- Keep the existing response folding behavior unchanged.

## Tests
- Updated `includes a per-question optional free-text custom-answer field` to assert the shared `_askUserQuestionCustomAnswer` marker on each companion field.

```sh
npm test -- src/tests/elicitation.test.ts
```