### PR TITLE
fix(steering): retain prompt ownership after injection

### DIFF
--- a/examples/steering.ts
+++ b/examples/steering.ts
@@ -15,7 +15,15 @@
  *   2. The client calls the `_session/steering` request with `{ sessionId,
  *      prompt }` while a turn is running.
  *   3. The agent replies with an `outcome`:
- *        - "injected"       the message joined the running turn;
+ *        - "injected"       the message joined the running turn. The ORIGINAL
+ *                           `session/prompt` request stays pending while the
+ *                           SDK interrupts the running generation to handle the
+ *                           injected message; that interrupt's boundary result
+ *                           is folded into the same turn, and only the steered
+ *                           terminal result settles the original prompt — which
+ *                           is the request whose `PromptResponse` the client
+ *                           awaits. Its `usage` is the sum of the interrupted
+ *                           and steered commands;
  *        - "startedNewTurn" the turn had already finished and the legacy
  *                           detached fallback was used;
  *        - "promptRequired" the turn had already finished, but this request
@@ -60,9 +68,11 @@ type SteeringRequest = {
 };
 
 /** Result of a `_session/steering` request. `injected` means the message joined
- *  the running turn; `promptRequired` means the turn had already settled, so the
- *  message was NOT consumed and must be (re)sent through a normal
- *  `session/prompt`. Both are successes. */
+ *  the running turn — the original `session/prompt` remains pending through the
+ *  SDK's interrupted boundary result and the steered final result, and is the
+ *  request whose `PromptResponse` carries the turn's outcome. `promptRequired`
+ *  means the turn had already settled, so the message was NOT consumed and must
+ *  be (re)sent through a normal `session/prompt`. Both are successes. */
 type SteeringResponse =
   | { outcome: "injected" }
   | { outcome: "startedNewTurn" }
@@ -202,8 +212,12 @@ async function main() {
         log(`continuation stopReason: ${continuation.stopReason}`);
       }
 
-      // 5. Await the original turn. With outcome "injected" the steer already
-      //    reshaped the output above; the promptRequired branch owns its own turn.
+      // 5. Await the ORIGINAL turn — the pending session/prompt from step 3. On
+      //    "injected" this is the request that owns the steered outcome: it stays
+      //    pending through the interrupted boundary result and the steered
+      //    terminal result, and settles here with the combined usage. On
+      //    "promptRequired" the original turn settled on its own earlier and the
+      //    continuation branch above owns its separate turn.
       const response = await turn;
       log(`original turn stopReason: ${response.stopReason}`);
       process.stdout.write("\n----- end of agent output -----\n");

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -283,6 +283,14 @@ type Turn = {
   /** uuid stamped on the pushed `SDKUserMessage`; the SDK echoes it back so the
    *  consumer can match the replayed user message to this turn. */
   promptUuid: string;
+  /** Active Steering remains part of this ACP v1 prompt turn until the SDK
+   *  echoes the latest injected UUID and then emits its terminal result. The
+   *  newest accepted steering message overwrites the previous one, so only the
+   *  latest UUID can become the terminal boundary (see steer()). */
+  retainedSteering?: {
+    promptUuid: string;
+    phase: "awaiting_echo" | "active";
+  };
   /** Local-only slash commands (e.g. `/clear`) return a result without an echo,
    *  so the consumer can't promote them via the replay; it falls back to
    *  promoting the queue head when the result arrives. */
@@ -1904,8 +1912,8 @@ export class ClaudeAcpAgent {
     // which is exactly the window in which steering is meaningful. This check
     // and the active-path push below stay in one synchronous section so the
     // turn cannot settle in the gap between deciding to inject and enqueueing.
-    const turnInFlight = (session.turnQueue ?? []).some((turn) => !turn.settled);
-    if (!turnInFlight) {
+    const runningTurn = (session.turnQueue ?? []).find((turn) => !turn.settled);
+    if (!runningTurn) {
       const promptRequest: PromptRequest = {
         sessionId,
         prompt: params.prompt,
@@ -1930,8 +1938,17 @@ export class ClaudeAcpAgent {
     };
     const userMessage = promptToClaude(promptRequest);
     userMessage.uuid = randomUUID();
-    // Deliver into the running turn rather than queuing behind it as a fresh
-    // prompt would.
+    // Record that this injected message belongs to the running turn so the
+    // consumer can recognize its echo and keep the original session/prompt
+    // owning the steered terminal result (issue #934). Assigning a NEW value
+    // on every accepted steer makes the latest UUID the terminal boundary:
+    // an interrupted result before the newest echo can never settle the turn,
+    // and an older echo can never activate it. Deliver into the running turn
+    // rather than queuing behind it as a fresh prompt would.
+    runningTurn.retainedSteering = {
+      promptUuid: userMessage.uuid,
+      phase: "awaiting_echo",
+    };
     userMessage.priority = STEER_PRIORITY;
     session.input.push(userMessage);
     return { outcome: "injected" };
@@ -2027,22 +2044,26 @@ export class ClaudeAcpAgent {
       await this.client.sessionUpdate(notification);
     };
 
-    const resetTurnScratch = () => {
+    // Response-scoped scratch reset: everything tied to the current assistant
+    // response. Splitting this from the turn-level reset lets the injected
+    // steering echo start a fresh response WITHOUT wiping the accumulated usage
+    // the interrupted result already added (issue #934). Like the turn-level
+    // reset, it must NOT clear currentStreamMessageId or streamedBlocks: the
+    // echo can land mid-message, and clearing the streamed-content record then
+    // would drop the blocks that streamed before it and re-emit them as
+    // duplicates (see activateTurn).
+    const resetResponseScratch = () => {
       lastAssistantTotalUsage = null;
       lastAssistantUsage = null;
       lastAssistantModel = null;
       lastAssistantError = undefined;
       lastRefusalExplanation = null;
       compactionInProgress = false;
-      // Do NOT reset currentStreamMessageId or streamedBlocks here. Turn
-      // activation can fire mid-message (the replayed user echo with
-      // --replay-user-messages lands between a message's blocks); clearing the
-      // streamed-content record on activation would drop the blocks that
-      // streamed before the echo, so the consolidated assistant message would
-      // re-emit them as duplicates. streamedBlocks is bounded instead by being
-      // cleared when each consolidated message consumes it. #785 stopped
-      // resetting the streamed-content tracking here but left this line.
       stopReason = "end_turn";
+    };
+
+    const resetTurnScratch = () => {
+      resetResponseScratch();
       session.accumulatedUsage = {
         inputTokens: 0,
         outputTokens: 0,
@@ -2108,6 +2129,17 @@ export class ClaudeAcpAgent {
     const ensureActiveTurn = () => {
       if (session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
+          return;
+        }
+        // A retained-steering held turn still owns the in-flight injected
+        // response: its interrupt boundary result and its steered terminal
+        // result belong to THIS turn, not to a queued command. Settling it
+        // here with the pre-steering outcome would resolve the original
+        // session/prompt before the injected echo — the premature settle
+        // #934 forbids. Keep it held and let the result handler decide (the
+        // superseded break for the interrupt; settleOrDefer for the steered
+        // terminal result, which re-defers while subagents stay live).
+        if (session.activeTurn.retainedSteering) {
           return;
         }
         // A held turn (Turn.deferredSettle) already produced its result, so
@@ -2729,6 +2761,39 @@ export class ClaudeAcpAgent {
                     // turn-over signal, and stale partial-text state would
                     // suppress the next turn's issue-#453 fallback.
                     session.emittedAssistantText = false;
+                  } else if (
+                    isHeldOpen(session.activeTurn) &&
+                    session.activeTurn.retainedSteering !== undefined &&
+                    session.owedTrailingIdles === 0
+                  ) {
+                    // A held turn with a retained steering marker received an
+                    // UNOWED idle: the SDK turned over without delivering the
+                    // retained response it owes — the injected echo (phase
+                    // awaiting_echo) or the steered terminal result (phase
+                    // active). Idle is the SDK's authoritative turn-over
+                    // signal (see the #825 branch below), so a response that
+                    // has not arrived by it will never arrive; the original
+                    // prompt must not hang behind the hold — neither waiting
+                    // out a still-live subagent (settleDeferredIfDrained is a
+                    // no-op then) nor, once the subagent has drained, settling
+                    // with the PRE-steering deferred outcome (wrong usage, no
+                    // steered content). Fail it with the standard no-result
+                    // error, the same contract as the #825 idle-fail (issue
+                    // #934). An idle WITH debt does not match: it belongs to a
+                    // counted result (an autonomous followup's trailer, say),
+                    // and the ordinary held branch absorbs it.
+                    session.activeTurn.retainedSteering = undefined;
+                    this.logger.error(
+                      `Session ${params.sessionId}: SDK went idle while a held turn ` +
+                        `awaited its retained steering response; failing the in-flight ` +
+                        `prompt (issue #934)`,
+                    );
+                    failActive(
+                      RequestError.internalError(
+                        errorKindData("no_result"),
+                        TURN_NO_RESULT_MESSAGE,
+                      ),
+                    );
                   } else if (isHeldOpen(session.activeTurn)) {
                     // A turn held open for its background subagents (see
                     // Turn.deferredSettle). Idles keep their normal cadence
@@ -2745,7 +2810,16 @@ export class ClaudeAcpAgent {
                     if (session.owedTrailingIdles > 0) {
                       session.owedTrailingIdles--;
                     }
-                    settleDeferredIfDrained();
+                    // Skip the drained-settle while retained Steering is in
+                    // flight: an idle during the injection belongs to the
+                    // interrupted/steered cadence, and settling here — on the
+                    // autonomous followup's own trailing idle, say — would
+                    // resolve the held prompt with the PRE-steering deferred
+                    // outcome (issue #934). The steered terminal result
+                    // settles (or re-defers) it instead.
+                    if (!session.activeTurn.retainedSteering) {
+                      settleDeferredIfDrained();
+                    }
                   } else if (session.owedTrailingIdles > 0) {
                     // Absorb a settled turn's trailing idle. Also covers a
                     // cancel that landed between a turn's counted result and
@@ -3158,6 +3232,17 @@ export class ClaudeAcpAgent {
                 ensureActiveTurn();
               }
 
+              // A result received while retained Steering is still awaiting its
+              // injected echo is the INTERRUPTED command's response, not the
+              // steered turn's (issue #934). The SDK cancels the running
+              // generation when it processes the priority:"now" message, and
+              // emits this boundary result before replaying the injected echo.
+              // It must not settle the original prompt, count idle debt, or run
+              // any terminal handling; only its usage is real and retained.
+              const isSupersededSteeringResult =
+                !isAutonomousResult &&
+                session.activeTurn?.retainedSteering?.phase === "awaiting_echo";
+
               // A result closes the stretch of output it terminates: snapshot
               // the delivery record — AFTER ensureActiveTurn, whose held-turn
               // hand-off closes the held stretch, so an echo-less command
@@ -3201,7 +3286,14 @@ export class ClaudeAcpAgent {
               // turn's OWN result — a followup result arriving inside the
               // cancel window still gets its own trailer and must be counted,
               // or that idle would later false-fail the next prompt.
-              if (isAutonomousResult || !session.cancelled || !session.activeTurn) {
+              // A superseded Steering result has NO separate trailing idle: the
+              // interrupt hands control to the injected command and the single
+              // observed idle belongs to the steered terminal result, which
+              // counts it. Counting here would double-charge the debt.
+              if (
+                !isSupersededSteeringResult &&
+                (isAutonomousResult || !session.cancelled || !session.activeTurn)
+              ) {
                 session.owedTrailingIdles++;
               }
 
@@ -3280,6 +3372,36 @@ export class ClaudeAcpAgent {
                 });
               }
 
+              if (isSupersededSteeringResult) {
+                // The interrupted command's usage is accounted for; the steered
+                // generation's own terminal result is what settles the prompt.
+                // Skip cancellation, refusal, error, subtype, and settle handling
+                // — none of them apply to this boundary result. The `finally`
+                // clears the delivery record so the steered output streams fresh.
+                break;
+              }
+
+              // A result past the superseded boundary claims the retained
+              // steering marker once its echo has been replayed (phase
+              // "active"): the injected response is over, so any hold that
+              // follows (a still-live subagent re-defers a steered
+              // refusal/error) must be treated as an ordinary held turn again.
+              // Only a USER-DRIVEN result claims it: an autonomous followup (a
+              // drained subagent's terminal result, a peer/channel/coordinator
+              // cycle) is not the steered turn's response, and clearing the
+              // marker on it would let the next held-turn idle settle the
+              // prompt with the PRE-steering deferred outcome. Clear BEFORE
+              // the terminal early-return lanes — clearing only at the bottom
+              // of the normal path left a stale phase:active marker on a turn
+              // re-held by a steered refusal, which then made ensureActiveTurn
+              // skip the next echo-less result's hand-off (issue #934). A
+              // result still awaiting its echo keeps the marker: an autonomous
+              // subagent followup landing before the echo must not discard the
+              // pending injected boundary.
+              if (!isAutonomousResult && session.activeTurn?.retainedSteering?.phase === "active") {
+                session.activeTurn.retainedSteering = undefined;
+              }
+
               if (session.cancelled) {
                 if (!isAutonomousResult) {
                   stopReason = "cancelled";
@@ -3303,7 +3425,16 @@ export class ClaudeAcpAgent {
               // failActive a live turn (the held one, or the user's next
               // prompt) whose own result recorded a different outcome.
               if (isAutonomousResult) {
-                settleDeferredIfDrained();
+                // An autonomous followup must never settle a held prompt while
+                // Steering is in flight: the retained marker means the injected
+                // response has not yet produced its terminal result, and
+                // settling now would resolve the original prompt with the
+                // PRE-steering deferred outcome — wrong usage, no steered
+                // content (issue #934). The steered terminal result is what
+                // claims the marker and settles (or re-defers) the prompt.
+                if (!session.activeTurn?.retainedSteering) {
+                  settleDeferredIfDrained();
+                }
                 // With no turn in flight OR QUEUED (also after the settle
                 // above), the stretch holds only autonomous prose — close
                 // it, so a replayed next prompt isn't silently suppressed by
@@ -3458,6 +3589,10 @@ export class ClaudeAcpAgent {
               // idle/abort path. settleActive is idempotent, so a duplicate
               // idle is a no-op.
               if (!session.cancelled) {
+                // The retained marker was already claimed and cleared above
+                // (before the early-return lanes); the steered terminal result
+                // (phase "active") reaches here with it gone, so a held turn
+                // handoff-settles like any ordinary deferred turn.
                 settleOrDefer({ stopReason, usage: sessionUsage(session) });
               }
             } finally {
@@ -3667,6 +3802,20 @@ export class ClaudeAcpAgent {
                   // result re-emit the answer.
                   activateTurn(queued);
                 }
+                break;
+              }
+              // The replayed echo of the latest accepted steering message: the
+              // interrupted response is over and the steered generation starts.
+              // The original turn stays active and its accumulated usage must
+              // survive, so this resets only the response scratch, not the
+              // turn's (issue #934). Do NOT activateTurn() — that would reset
+              // usage and clear the turn's active role. An echo of an older,
+              // superseded steering UUID does not match the latest retained
+              // UUID and falls through to the unrelated-replay branch.
+              const retained = session.activeTurn?.retainedSteering;
+              if (retained?.phase === "awaiting_echo" && message.uuid === retained.promptUuid) {
+                retained.phase = "active";
+                resetResponseScratch();
                 break;
               }
               if ("isReplay" in message && message.isReplay) {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -8791,6 +8791,21 @@ describe("deferred settlement for live background subagents (issues #864/#866)",
     };
   }
 
+  /** The CLI result for a command the SDK pre-empted to process an injected
+   *  steering message: stop_reason null with zero usage (issue #934). */
+  const interruptedResult = () =>
+    resultMessage({
+      stop_reason: null,
+      is_error: false,
+      result: "1. ",
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    });
+
   const stateChanged = (state: "running" | "idle" | "requires_action") => ({
     type: "system",
     subtype: "session_state_changed",
@@ -9776,6 +9791,463 @@ describe("deferred settlement for live background subagents (issues #864/#866)",
     ).rejects.toMatchObject({ code: -32603 });
     await agent.sessions["test-session"]?.consumer;
   });
+
+  it("keeps a deferred subagent turn held across steering, re-holding at the steered result until the subagent drains (issue #934)", async () => {
+    const { agent, events } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // still held
+        const steered = await iter.next(); // the injected steering message
+        // The interrupt boundary must NOT settle the held prompt with the
+        // pre-steering outcome.
+        yield interruptedResult();
+        yield userEcho(steered.value);
+        yield assistantText("STEERED-REAL-OK");
+        yield resultMessage(); // steered terminal result; subagent STILL live -> held again
+        yield idle(); // still held
+        yield taskNotification("agent-1"); // subagent done
+        yield assistantText("promised summary");
+        yield resultMessage({ origin: { kind: "task-notification" } }); // followup result -> settles held turn
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // The turn must be held open (deferredSettle) before steering, so steer()
+    // injects into the LIVE held turn rather than falling back to a new turn.
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    const response = await turn.then((r) => {
+      events.push("resolved");
+      return r;
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Original command 10/5 + interrupted 0/0 + steered 10/5. The followup's
+    // tokens are reported separately, not folded into the prompt response.
+    expect(response.usage?.totalTokens).toBe(30);
+    // The steered output AND the followup summary streamed inside the still-open
+    // turn, before the prompt resolved.
+    const steeredIndex = events.indexOf("chunk:STEERED-REAL-OK");
+    expect(steeredIndex).toBeGreaterThanOrEqual(0);
+    expect(steeredIndex).toBeLessThan(events.indexOf("resolved"));
+    const summaryIndex = events.indexOf("chunk:promised summary");
+    expect(summaryIndex).toBeGreaterThanOrEqual(0);
+    expect(summaryIndex).toBeLessThan(events.indexOf("resolved"));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("settles a deferred subagent turn at the steered result once the subagent has drained (issue #934)", async () => {
+    const { agent, events } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // still held
+        yield taskNotification("agent-1"); // subagent done, turn still held
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult();
+        yield userEcho(steered.value);
+        yield assistantText("STEERED-REAL-OK");
+        yield resultMessage(); // steered terminal result; subagent already drained -> settles here
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Hold the turn open (deferredSettle) BEFORE steering, then let the
+    // subagent drain; steering still injects into the live held turn.
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    const response = await turn.then((r) => {
+      events.push("resolved");
+      return r;
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Original command 10/5 + interrupted 0/0 + steered 10/5.
+    expect(response.usage?.totalTokens).toBe(30);
+    const steeredIndex = events.indexOf("chunk:STEERED-REAL-OK");
+    expect(steeredIndex).toBeGreaterThanOrEqual(0);
+    expect(steeredIndex).toBeLessThan(events.indexOf("resolved"));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("fails a held prompt when the injected echo never arrives and the subagent is still live (issue #934)", async () => {
+    const { agent } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        await iter.next(); // the injected steering message
+        // The interrupt boundary must NOT settle the held prompt with the
+        // pre-steering outcome.
+        yield interruptedResult();
+        // No injected echo: an unowed idle while the retained marker still
+        // awaits its echo must fail the held prompt with the standard
+        // no-result error instead of leaving it pending forever behind the
+        // still-live subagent (settleDeferredIfDrained is a no-op there).
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Pre-armed guard: the no-result rejection can land while the waitFor polls
+    // below, before the assertion below attaches its own handler.
+    turn.catch(() => {});
+    // The turn must be held open (deferredSettle) before steering, so steer()
+    // injects into the LIVE held turn rather than falling back to a new turn.
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    await waitFor(() => !agent.sessions["test-session"]?.activeTurn);
+    await expect(turn).rejects.toThrow(/ended without a result/);
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("fails a held prompt with no_result on the missing echo once the subagent has drained (issue #934)", async () => {
+    const { agent } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        yield taskNotification("agent-1"); // subagent done; turn still held
+        await iter.next(); // the injected steering message
+        yield interruptedResult(); // superseded boundary, must NOT settle
+        // No injected echo and no subagent left: the ordinary held-turn idle
+        // fallback would settle the prompt with the PRE-steering deferred
+        // outcome (wrong usage, no steered content). The retained missing-echo
+        // state must instead fail it with the standard no-result error.
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Pre-armed guard: the no-result rejection can land while the waitFor polls
+    // below, before the assertion below attaches its own handler.
+    turn.catch(() => {});
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    await waitFor(() => !agent.sessions["test-session"]?.activeTurn);
+    await expect(turn).rejects.toThrow(/ended without a result/);
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("clears the retained steering marker when a steered refusal re-holds the turn behind a live subagent (issue #934)", async () => {
+    const { agent } = chunkCapturingAgent();
+    let releaseStream!: () => void;
+    // Keep the query stream open after the refusal so the turn stays held and
+    // the test can observe the retained marker — without it, the consumer's
+    // stream-end handler settles the held turn and the state is gone.
+    const streamGate = new Promise<void>((resolve) => (releaseStream = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle();
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult();
+        yield userEcho(steered.value); // retained phase -> active
+        // A refusal lands after the echo; the refusal lane re-defers the turn
+        // behind the still-live subagent.
+        yield resultMessage({ stop_reason: "refusal" });
+        await streamGate;
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    // The retained marker must be claimed and cleared even though the turn
+    // re-holds behind the live subagent: a stale phase:active marker would
+    // make ensureActiveTurn skip the next echo-less result's hand-off.
+    await waitFor(
+      () => agent.sessions["test-session"]?.activeTurn?.deferredSettle?.stopReason === "refusal",
+    );
+    expect(agent.sessions["test-session"]?.activeTurn?.retainedSteering).toBeUndefined();
+    releaseStream();
+    await agent.sessions["test-session"]?.consumer;
+    // The stream-end settle resolves the still-held prompt with the refusal
+    // outcome the re-hold recorded.
+    await expect(turn).resolves.toMatchObject({ stopReason: "refusal" });
+  });
+
+  it("keeps a held prompt pending when an autonomous followup lands before the injected echo (issue #934)", async () => {
+    // A drained subagent's autonomous followup result arrives between the
+    // interrupted boundary and the injected echo (marker still awaiting_echo).
+    // It must NOT settle the held prompt with the PRE-steering deferred
+    // outcome — neither at the result nor at the followup's trailing idle —
+    // or the steered output would stream outside the already-ended prompt.
+    const { agent, events } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult(); // superseded boundary, marker stays awaiting_echo
+        yield taskNotification("agent-1"); // subagent done; turn still held
+        yield resultMessage({ origin: { kind: "task-notification" } }); // autonomous followup
+        yield idle(); // the autonomous followup's trailing idle
+        yield userEcho(steered.value); // injected echo replays -> phase active
+        yield assistantText("STEERED-AFTER-AUTONOMOUS");
+        yield resultMessage(); // steered terminal result -> settles
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    const response = await turn.then((r) => {
+      events.push("resolved");
+      return r;
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Original command 10/5 + interrupted 0/0 + steered 10/5 — NOT the
+    // pre-steering deferred outcome (15), which would prove an early settle.
+    expect(response.usage?.totalTokens).toBe(30);
+    // The steered output streamed inside the still-open prompt.
+    const steeredIndex = events.indexOf("chunk:STEERED-AFTER-AUTONOMOUS");
+    expect(steeredIndex).toBeGreaterThanOrEqual(0);
+    expect(steeredIndex).toBeLessThan(events.indexOf("resolved"));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("keeps a held prompt pending when an autonomous followup lands after the injected echo (issue #934)", async () => {
+    // Same as above but the autonomous followup arrives AFTER the echo
+    // replayed (marker phase active), while the steered generation is still
+    // running. It must neither claim the retained marker nor settle the held
+    // prompt; only the steered terminal result may.
+    const { agent, events } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult(); // superseded boundary, marker stays awaiting_echo
+        yield taskNotification("agent-1"); // subagent done; turn still held
+        yield userEcho(steered.value); // injected echo replays -> phase active
+        yield resultMessage({ origin: { kind: "task-notification" } }); // autonomous followup
+        yield idle(); // the autonomous followup's trailing idle
+        yield assistantText("STEERED-AFTER-AUTONOMOUS");
+        yield resultMessage(); // steered terminal result -> settles
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    const response = await turn.then((r) => {
+      events.push("resolved");
+      return r;
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Original command 10/5 + interrupted 0/0 + steered 10/5 — NOT the
+    // pre-steering deferred outcome (15), which would prove an early settle.
+    expect(response.usage?.totalTokens).toBe(30);
+    // The steered output streamed inside the still-open prompt.
+    const steeredIndex = events.indexOf("chunk:STEERED-AFTER-AUTONOMOUS");
+    expect(steeredIndex).toBeGreaterThanOrEqual(0);
+    expect(steeredIndex).toBeLessThan(events.indexOf("resolved"));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("fails a held prompt when the steered generation never emits its final result while a subagent is still live (issue #934)", async () => {
+    // The injected echo replayed (retained phase -> active) but no steered
+    // terminal result ever arrives. An unowed idle with a retained marker
+    // still set means the SDK turned over without the response the prompt is
+    // owed — the held no-result branch must fail it (issue #934) rather than
+    // leave it pending forever behind the still-live subagent.
+    const { agent } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult(); // superseded boundary, marker stays awaiting_echo
+        yield userEcho(steered.value); // retained phase -> active
+        // No steered terminal result. Unowed idle: the retained response is
+        // missing, so the held prompt must fail rather than hang.
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Pre-armed guard: the no-result rejection can land while the waitFor polls
+    // below, before the assertion below attaches its own handler.
+    turn.catch(() => {});
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    await waitFor(() => !agent.sessions["test-session"]?.activeTurn);
+    await expect(turn).rejects.toThrow(/ended without a result/);
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("fails a held prompt when the steered generation never emits its final result once the subagent has drained (issue #934)", async () => {
+    // Same as above with the subagent drained first: the ordinary held idle
+    // fallback must not settle the prompt with the PRE-steering deferred
+    // outcome either — the missing retained response fails it.
+    const { agent } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // original terminal result -> held (subagent live)
+        yield idle(); // absorbs the trailer debt
+        yield taskNotification("agent-1"); // subagent done; turn still held
+        const steered = await iter.next(); // the injected steering message
+        yield interruptedResult(); // superseded boundary, marker stays awaiting_echo
+        yield userEcho(steered.value); // retained phase -> active
+        // No steered terminal result. Unowed idle with the retained marker
+        // still set: fail the prompt with the standard no-result error.
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Pre-armed guard: the no-result rejection can land while the waitFor polls
+    // below, before the assertion below attaches its own handler.
+    turn.catch(() => {});
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    await waitFor(() => !agent.sessions["test-session"]?.activeTurn);
+    await expect(turn).rejects.toThrow(/ended without a result/);
+    await agent.sessions["test-session"]?.consumer;
+  });
 });
 
 describe("turn steering (_session/steering)", () => {
@@ -9808,6 +10280,37 @@ describe("turn steering (_session/steering)", () => {
       permission_denials: [],
       uuid: randomUUID(),
       session_id: "test-session",
+    };
+  }
+
+  // The result the CLI emits for the interrupted command when the SDK
+  // pre-empts it to handle the injected steering message: `stop_reason: null`
+  // with zero usage (the interrupt consumed no tokens). Regression fixtures for
+  // issue #934 — the original session/prompt must NOT settle on this result.
+  function createInterruptedSuccessResult() {
+    return {
+      ...createResultMessage(),
+      stop_reason: null,
+      is_error: false,
+      result: "1. ",
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    };
+  }
+
+  // A second real manifestation of the same interrupted result: the CLI rejects
+  // the interrupted command with an `[ede_diagnostic]` payload. Production code
+  // must treat it like any other pre-echo result and never parse its text.
+  function createInterruptedDiagnosticResult() {
+    return {
+      ...createResultMessage(),
+      stop_reason: null,
+      is_error: true,
+      result: "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
     };
   }
 
@@ -9991,10 +10494,11 @@ describe("turn steering (_session/steering)", () => {
         const u1 = await iter.next();
         yield userEcho(u1.value); // turn becomes active
         // The steered message is pushed next; capture it, replay its echo
-        // (which matches no queued turn and must be dropped), then finish.
+        // (which promotes the retained steering phase and must NOT settle a
+        // turn), then finish.
         const steered = await iter.next();
         captured.push(steered.value);
-        yield userEcho(steered.value); // unrelated replay — must NOT settle a turn
+        yield userEcho(steered.value); // retained-steering echo — must NOT settle a turn
         yield createResultMessage();
         yield { type: "system", subtype: "session_state_changed", state: "idle" };
       }
@@ -10039,6 +10543,9 @@ describe("turn steering (_session/steering)", () => {
         yield userEcho(u1.value);
         const steered = await iter.next();
         captured.push(steered.value);
+        // The injected echo must precede the result: without it, the result
+        // would be read as the interrupted command's and the prompt failed.
+        yield userEcho(steered.value);
         yield createResultMessage();
         yield { type: "system", subtype: "session_state_changed", state: "idle" };
       }
@@ -10063,6 +10570,480 @@ describe("turn steering (_session/steering)", () => {
 
     expect(res.outcome).toBe("injected");
     expect(captured[0]?.priority).toBe("now");
+  });
+
+  it("keeps the original prompt pending through the steered result (issue #934, interrupted success)", async () => {
+    const updates: string[] = [];
+    const client = {
+      sessionUpdate: async (notification: any) => {
+        if (notification.update?.sessionUpdate === "agent_message_chunk") {
+          updates.push(notification.update.content?.text);
+        }
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+
+    // Two deferred gates: the generator signals after the interrupted result is
+    // consumed, then waits until the test has asserted the original prompt is
+    // still pending before releasing the injected echo.
+    let releaseAfterInterrupted!: () => void;
+    let releaseInjectedEcho!: () => void;
+    const afterInterrupted = new Promise<void>((resolve) => (releaseAfterInterrupted = resolve));
+    const injectedEchoGate = new Promise<void>((resolve) => (releaseInjectedEcho = resolve));
+
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // original user echo activates the original turn
+        const steered = await iter.next(); // the pushed steering message
+        captured.push(steered.value);
+        yield createInterruptedSuccessResult(); // pre-echo interrupted result
+        releaseAfterInterrupted();
+        await injectedEchoGate;
+        yield userEcho(steered.value); // injected user echo
+        yield createAssistantText("STEERED-REAL-OK");
+        yield createResultMessage(); // steered terminal result
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const originalPrompt = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    // Observe settlement immediately so the RED run cannot leave an unhandled
+    // rejection on the original prompt when the interrupted result settles it.
+    let turnSettledAfterInterruptedResult = false;
+    originalPrompt.then(
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+    );
+
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "Stop and reply with exactly: STEERED-REAL-OK" }],
+    });
+
+    expect(steerResponse).toEqual({ outcome: "injected" });
+    expect(captured).toHaveLength(1);
+    const injected = captured[0];
+    expect(injected.priority).toBe("now");
+
+    // The interrupted result must not settle the prompt; only the injected
+    // echo + steered terminal result may.
+    await afterInterrupted;
+    expect(turnSettledAfterInterruptedResult).toBe(false);
+    releaseInjectedEcho();
+
+    const response = await originalPrompt;
+    expect(response).toEqual(
+      expect.objectContaining({
+        stopReason: "end_turn",
+        usage: expect.objectContaining({ inputTokens: 10, outputTokens: 5 }),
+      }),
+    );
+    expect(updates.join("")).toContain("STEERED-REAL-OK");
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("does not settle or reject the prompt on the interrupted diagnostic result (issue #934)", async () => {
+    const updates: string[] = [];
+    const client = {
+      sessionUpdate: async (notification: any) => {
+        if (notification.update?.sessionUpdate === "agent_message_chunk") {
+          updates.push(notification.update.content?.text);
+        }
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+
+    let releaseAfterInterrupted!: () => void;
+    let releaseInjectedEcho!: () => void;
+    const afterInterrupted = new Promise<void>((resolve) => (releaseAfterInterrupted = resolve));
+    const injectedEchoGate = new Promise<void>((resolve) => (releaseInjectedEcho = resolve));
+
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        const steered = await iter.next();
+        captured.push(steered.value);
+        yield createInterruptedDiagnosticResult(); // is_error=true, stop_reason=null
+        releaseAfterInterrupted();
+        await injectedEchoGate;
+        yield userEcho(steered.value);
+        yield createAssistantText("STEERED-REAL-OK");
+        yield createResultMessage();
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const originalPrompt = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    let turnSettledAfterInterruptedResult = false;
+    originalPrompt.then(
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+    );
+
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "Stop and reply with exactly: STEERED-REAL-OK" }],
+    });
+
+    expect(steerResponse).toEqual({ outcome: "injected" });
+    expect(captured[0].priority).toBe("now");
+
+    // Neither reject nor resolve on the diagnostic result; the final success
+    // result is the one that settles the prompt.
+    await afterInterrupted;
+    expect(turnSettledAfterInterruptedResult).toBe(false);
+    releaseInjectedEcho();
+
+    await expect(originalPrompt).resolves.toEqual(
+      expect.objectContaining({ stopReason: "end_turn" }),
+    );
+    expect(updates.join("")).toContain("STEERED-REAL-OK");
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("steers a submitted-but-not-yet-echoed turn and keeps the queued prompt as the owner (issue #934)", async () => {
+    const agent = createMockAgent();
+    let releaseAfterInterrupted!: () => void;
+    let releaseInjectedEcho!: () => void;
+    const afterInterrupted = new Promise<void>((resolve) => (releaseAfterInterrupted = resolve));
+    const injectedEchoGate = new Promise<void>((resolve) => (releaseInjectedEcho = resolve));
+
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // original echo activates the queued turn
+        const steered = await iter.next();
+        captured.push(steered.value);
+        yield createInterruptedSuccessResult();
+        releaseAfterInterrupted();
+        await injectedEchoGate;
+        yield userEcho(steered.value);
+        yield createResultMessage();
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    // prompt() then steer() before the generator emits the original echo: a
+    // submitted-but-not-yet-echoed turn is still steerable, and the queued
+    // Turn becomes the owner of the steered terminal result.
+    const originalPrompt = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    let turnSettledAfterInterruptedResult = false;
+    originalPrompt.then(
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+      () => {
+        turnSettledAfterInterruptedResult = true;
+      },
+    );
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "late steer" }],
+    });
+
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    // The generator reads the pushed steering message asynchronously; wait for
+    // it so `captured` is populated before the assertions.
+    await waitFor(() => captured.length === 1);
+    expect(captured[0].priority).toBe("now");
+
+    await afterInterrupted;
+    expect(turnSettledAfterInterruptedResult).toBe(false);
+    releaseInjectedEcho();
+
+    await expect(originalPrompt).resolves.toEqual(
+      expect.objectContaining({ stopReason: "end_turn" }),
+    );
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("fails the prompt when the injected echo never arrives (issue #934)", async () => {
+    const agent = createMockAgent();
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        const steered = await iter.next();
+        captured.push(steered.value);
+        yield createInterruptedSuccessResult();
+        // No injected echo: an unowed idle is the SDK's turn-over signal, so the
+        // still-unsettled prompt fails with the standard no-result error.
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "late steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    await expect(turn).rejects.toThrow(/ended without a result/);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].priority).toBe("now");
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("resolves the prompt cancelled when cancel lands before the injected echo (issue #934)", async () => {
+    const agent = createMockAgent();
+    let releaseAfterInterrupted!: () => void;
+    let releaseIdle!: () => void;
+    const afterInterrupted = new Promise<void>((resolve) => (releaseAfterInterrupted = resolve));
+    const idleGate = new Promise<void>((resolve) => (releaseIdle = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        await iter.next(); // the injected message is consumed but never echoed
+        yield createInterruptedSuccessResult();
+        releaseAfterInterrupted();
+        await idleGate;
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "late steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    // Cancel while retained Steering is still awaiting its echo; the trailing
+    // idle then settles the still-active prompt "cancelled" exactly once.
+    await afterInterrupted;
+    await agent.cancel({ sessionId: "test-session" });
+    releaseIdle();
+
+    await expect(turn).resolves.toEqual(expect.objectContaining({ stopReason: "cancelled" }));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("preserves cancelled-turn behavior when cancel lands after the injected echo (issue #934)", async () => {
+    const agent = createMockAgent();
+    let releaseAfterEcho!: () => void;
+    let releaseFinal!: () => void;
+    const afterEcho = new Promise<void>((resolve) => (releaseAfterEcho = resolve));
+    const finalGate = new Promise<void>((resolve) => (releaseFinal = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        const steered = await iter.next();
+        yield createInterruptedSuccessResult();
+        yield userEcho(steered.value); // injected echo -> retained phase becomes active
+        releaseAfterEcho();
+        await finalGate;
+        yield createResultMessage();
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "late steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+
+    // The retained response is active; the steered result that follows a cancel
+    // is dropped at the cancelled guard and the idle settles the turn.
+    await afterEcho;
+    await agent.cancel({ sessionId: "test-session" });
+    releaseFinal();
+
+    await expect(turn).resolves.toEqual(expect.objectContaining({ stopReason: "cancelled" }));
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("counts interrupted and steered usage exactly once in the final response (issue #934)", async () => {
+    const agent = createMockAgent();
+    const interruptedUsage = {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_read_input_tokens: 2,
+      cache_creation_input_tokens: 1,
+    };
+    const steeredUsage = {
+      input_tokens: 20,
+      output_tokens: 10,
+      cache_read_input_tokens: 3,
+      cache_creation_input_tokens: 4,
+    };
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        const steered = await iter.next();
+        captured.push(steered.value);
+        yield { ...createInterruptedSuccessResult(), usage: interruptedUsage };
+        yield userEcho(steered.value);
+        yield createAssistantText("STEERED-REAL-OK");
+        yield { ...createResultMessage(), usage: steeredUsage };
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "late steer" }],
+    });
+    expect(steerResponse).toEqual({ outcome: "injected" });
+    expect(captured).toHaveLength(1);
+
+    // Both results are real spend on the one turn: the final PromptResponse
+    // carries their component-wise sum, counted exactly once.
+    const response = await turn;
+    expect(response).toEqual(
+      expect.objectContaining({
+        stopReason: "end_turn",
+        usage: {
+          inputTokens: 30,
+          outputTokens: 15,
+          cachedReadTokens: 5,
+          cachedWriteTokens: 5,
+          totalTokens: 55,
+        },
+      }),
+    );
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("uses the latest accepted steering UUID as the terminal boundary (issue #934)", async () => {
+    const updates: string[] = [];
+    const client = {
+      sessionUpdate: async (notification: any) => {
+        if (notification.update?.sessionUpdate === "agent_message_chunk") {
+          updates.push(notification.update.content?.text);
+        }
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    const captured: any[] = [];
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        const steerA = await iter.next();
+        captured.push(steerA.value);
+        const steerB = await iter.next();
+        captured.push(steerB.value);
+        // A's generation is interrupted; its echo follows. Under a first-wins
+        // regression the echo of steer A would promote the retained response,
+        // so the SECOND interrupted result (B pre-empting A's continuation)
+        // would then run terminal handling and settle the prompt early. With
+        // the fix, steer B is still awaiting its echo, so this result is a
+        // superseded boundary and the prompt stays pending.
+        yield createInterruptedSuccessResult();
+        yield userEcho(steerA.value); // superseded UUID -> unrelated replay
+        yield createInterruptedSuccessResult();
+        yield userEcho(steerB.value); // latest UUID -> activates retained response
+        yield createAssistantText("STEERED-B");
+        yield createResultMessage();
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    const steerAResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer A" }],
+    });
+    const steerBResponse = await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "steer B" }],
+    });
+    expect(steerAResponse).toEqual({ outcome: "injected" });
+    expect(steerBResponse).toEqual({ outcome: "injected" });
+
+    await waitFor(() => captured.length === 2);
+    expect(captured[0].priority).toBe("now");
+    expect(captured[1].priority).toBe("now");
+
+    // Only the latest accepted UUID controls the terminal boundary: the second
+    // interrupted result still cannot settle the prompt while steer B awaits
+    // its echo, and the echo of the superseded steer A cannot activate it. A
+    // first-wins regression settles the prompt at the second interrupted result
+    // (zero usage), so the original turn resolves before STEERED-B ever streams.
+    const response = await turn;
+    expect(response).toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    expect(updates.join("")).toContain("STEERED-B");
+    await agent.sessions["test-session"]?.consumer;
   });
 });
 


### PR DESCRIPTION
Fixes #934

## Problem

Active steering (`_session/steering` with outcome `injected`) previously let the interrupted command's terminal result settle (or reject) the original ACP v1 `session/prompt` before the injected response even started. The steered output then streamed with no owning turn, so its own terminal result leaked a false trailing-idle debt and the client observed the original prompt resolving early (even with zero usage) or rejecting.

## Scope

This change is limited to ACP v1. The existing `_session/steering` wire contract remains unchanged:

- The request still supports the optional `_meta.steering.idleBehavior: "promptRequired"` field.
- The response outcomes remain `injected`, `startedNewTurn`, and `promptRequired`.
- No `activeBehavior` field or new capability is introduced.

## Why `injected` keeps the original prompt pending

An `injected` outcome means the steering message joined the current prompt turn, not a new one. The SDK cancels the running generation to process the `priority: "now"` message, emits an interrupted boundary result, then replays the injected user echo and runs the steered generation. The original `session/prompt` is the request that owns all of that: it stays pending through the interrupted result and the injected echo, and only the steered terminal result settles it.

## The exact SDK delivery path (unchanged)

- `userMessage.uuid = randomUUID()` — the injected `SDKUserMessage` keeps its freshly generated UUID;
- `userMessage.priority = "now"` (existing `STEER_PRIORITY`);
- `session.input.push(userMessage)` — the same input stream and conversation context as every other message in the turn.

No change to UUID generation, priority, the input stream, or context.

## Both premature-settlement variants fixed

1. **Early resolve** — the interrupted result (`stop_reason: null`) previously settled the prompt before the steered response. It is now classified as a superseded boundary result: its usage is still accumulated into the owning turn, but it never settles the prompt, never counts idle debt, and exits before any terminal handling.
2. **Diagnostic reject** — the same superseded classification also prevents the interrupted result's `[ede_diagnostic]` reject payload from failing the prompt.
3. **Held turn** — a turn already held open behind a live subagent (`Turn.deferredSettle`) previously got handoff-settled by `ensureActiveTurn` on the injected echo's next user-turn result, resolving the original prompt before the steered terminal result. `ensureActiveTurn` now keeps a retained-steering held turn held while the injection is in flight, and the steered terminal result clears the marker before `settleOrDefer`, so a subsequent still-live subagent followup treats it as an ordinary held turn again.

## Additional retained-turn lifecycle handling

4. **Held turn awaiting its echo goes unowed-idle** (High) — if the injected echo never replays, an unowed idle (`phase: "awaiting_echo"` with `owedTrailingIdles === 0`) on a held turn previously left the prompt pending forever behind a still-live subagent, or — once the subagent drained — settled it with the PRE-steering deferred outcome (wrong usage, no steered content). The idle handler now fails it with the standard `no_result` error before the ordinary held-turn branch, covering both live and drained cases (same contract as the #825 idle-fail).
5. **Steered refusal leaves a stale active marker** (Medium) — the `retainedSteering` marker was only cleared at the bottom of the result handler's normal path, so a steered refusal (which re-holds the turn behind a still-live subagent) left a stale `phase: "active"` marker that made `ensureActiveTurn` skip the next echo-less result's hand-off. The result handler now claims the active marker right after the superseded-result check and before all terminal early-return lanes; a result still awaiting its echo keeps the marker so an autonomous subagent followup landing before the echo stays part of the injected boundary.
6. **Autonomous followup settles a held prompt before steering completes** (High) — a drained subagent's autonomous followup result reached `settleDeferredIfDrained()` while the retained marker was still set, and the active marker was cleared even by an autonomous result. Either path resolved the held prompt with the PRE-steering deferred outcome (wrong usage, no steered content) before the injected echo / steered terminal result, so the steered output streamed outside the ended prompt. Three gates now hold while any `retainedSteering` state exists: the `phase: "active"` marker is claimed only by a user-driven result; the autonomous branch skips `settleDeferredIfDrained()`; and the held-turn idle branch skips it too (the autonomous followup's own trailing idle can't settle the prompt). Autonomous usage, `usage_update`, and idle debt are unchanged.
7. **Post-echo missing steered result leaves the prompt pending forever** (High) — the held no-result idle branch only matched `phase: "awaiting_echo"`. Once the injected echo replayed (`phase: "active"`), a missing steered terminal result with an unowed idle fell into the ordinary held branch, which skips `settleDeferredIfDrained()` while a retained marker exists and never fails the prompt — permanent `pending`. The no-result condition is now any `retainedSteering` state with `owedTrailingIdles === 0`: an unowed idle while the marker is set means the SDK turned over without the retained echo or the steered terminal result it owes, so it fails with the standard `no_result` error. An idle WITH debt still belongs to a counted result (an autonomous followup's trailer) and is absorbed by the ordinary held branch — the autonomous-result regression tests exercise exactly that.

## Verified result / echo / final-result / idle order

```
session_state_changed: running
user echo (original prompt)
result (stop_reason null)  -> superseded boundary, prompt still pending
user echo (injected UUID)  -> retained steering phase becomes active
steered assistant output   -> e.g. STEERED-REAL-OK
result (end_turn)          -> settles the original prompt with summed usage
session_state_changed: idle -> single trailing idle, absorbed by owed debt
```

For a held turn (deferred subagent), the same order holds with the prompt staying held through the steered result; if the subagent is still live at that point the turn re-defers and only settles when the subagent drains, at which point the summed usage of interrupted + steered commands is attributed to the original prompt.

## Unchanged idle behavior

The idle `startedNewTurn` and `promptRequired` behaviors are untouched. This fix changes only the active `injected` path, which now retains prompt ownership by default.

## Automated verification

- RED: the new #934 tests fail on the base commit (premature resolve, diagnostic reject, pre-activation, held-turn settle, missing echo, stale marker, autonomous followup before/after echo, post-echo missing result) and pass after the fix.
- Focused: `npx vitest run src/tests/acp-agent.test.ts -t "turn steering|session/cancel wedge recovery|session_state_changed|deferred settlement for live background subagents|autonomous followup lands|never emits its final result"` -> 51 passed; the whole file -> 324 passed, 6 failed (pre-existing path-separator), 9 skipped.
- `npm run build`, `npm run lint`, `git diff --check`, and `prettier --check` on the committed content of the changed files -> pass.
- `npm run test:run` -> 695 passed, 6 failed; the remaining failures are the pre-existing Windows path-separator assertions in `acp-agent.test.ts` and do not touch the Steering implementation.
- `npm run format:check` -> fails only on files that are already failing on `origin/main` (repo-wide prettier drift on this Windows host); the changed files are clean on their committed content.

## Real-model verification

The latest run on the final commit used the issue's prompts and showed the full order above: `injected` outcome, interrupted result, prompt still pending, injected echo, `STEERED-REAL-OK` output, terminal result, one final idle, and the original `session/prompt` resolving `end_turn` with the steered command's usage attributed to it (`input=93`, `output=41`, `cache_read=27904`, `total=28038`) — versus the pre-fix zero-usage early resolve. Two earlier runs showed the same ordering and ownership behavior.
