### PR TITLE
Publish ExitPlanMode Markdown via ACP plan updates

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -513,10 +513,10 @@ type Session = {
    *  tool_use block streams; this set makes the two paths converge regardless of
    *  order. Pruned at `tool_result` time alongside `toolUseCache`. */
   emittedToolCalls: Set<string>;
-  /** Last Markdown published through ACP's experimental `plan_update` lane,
-   *  keyed by plan id. The SDK can surface ExitPlanMode through the stream and
-   *  permission callback in either order; retaining the content makes those
-   *  paths converge without sending the same plan twice. */
+  /** Last Markdown delivered through ACP's experimental `plan_update` lane,
+   *  keyed by plan id. Live ExitPlanMode updates are owned by the permission
+   *  path so the plan and referenced tool call are both delivered before the
+   *  permission request; replay uses the same cache without a concurrent ask. */
   emittedPlanContent?: Map<string, string>;
   /** Registry of live background tasks, keyed by task id: populated at
    *  `task_started`, pruned when the task settles (a `task_notification` or
@@ -3506,6 +3506,7 @@ export class ClaudeAcpAgent {
                 taskState: session.taskState,
                 emittedToolCalls: session.emittedToolCalls,
                 emittedPlanContent: session.emittedPlanContent,
+                emitExitPlanUpdates: false,
                 messageId: currentStreamMessageId,
                 streamedToolInputs,
               },
@@ -3773,6 +3774,7 @@ export class ClaudeAcpAgent {
                 taskState: session.taskState,
                 emittedToolCalls: session.emittedToolCalls,
                 emittedPlanContent: session.emittedPlanContent,
+                emitExitPlanUpdates: false,
                 messageId: messageIdForGrouping(message),
                 toolUseResult: message.type === "user" ? message.tool_use_result : undefined,
                 // On the wire since CLI 2.1.216 but not in SDKUserMessage's
@@ -4507,9 +4509,14 @@ export class ClaudeAcpAgent {
       toolInput,
       this.clientCapabilities,
       (session.emittedPlanContent ??= new Map()),
+      parentToolUseId,
     );
     if (planUpdate) {
       await this.client.sessionUpdate(planUpdate);
+      session.emittedPlanContent.set(
+        claudePlanId(parentToolUseId),
+        (toolInput as { plan: string }).plan,
+      );
     }
     if (session.emittedToolCalls.has(toolCallId)) {
       return;
@@ -7005,6 +7012,10 @@ function toolCallNotification(
 
 const CLAUDE_PLAN_ID = "claude-plan";
 
+function claudePlanId(parentToolUseId?: string | null): string {
+  return parentToolUseId ? `${CLAUDE_PLAN_ID}:${parentToolUseId}` : CLAUDE_PLAN_ID;
+}
+
 function supportsPlanUpdates(clientCapabilities?: ClientCapabilities | null): boolean {
   return clientCapabilities?.plan != null;
 }
@@ -7020,7 +7031,9 @@ function exitPlanUpdate(
   toolInput: unknown,
   clientCapabilities?: ClientCapabilities | null,
   emittedPlanContent?: Map<string, string>,
+  parentToolUseId?: string | null,
 ): SessionNotification | undefined {
+  const planId = claudePlanId(parentToolUseId);
   if (
     toolName !== "ExitPlanMode" ||
     !supportsPlanUpdates(clientCapabilities) ||
@@ -7029,18 +7042,17 @@ function exitPlanUpdate(
     !("plan" in toolInput) ||
     typeof toolInput.plan !== "string" ||
     toolInput.plan.trim().length === 0 ||
-    emittedPlanContent?.get(CLAUDE_PLAN_ID) === toolInput.plan
+    emittedPlanContent?.get(planId) === toolInput.plan
   ) {
     return undefined;
   }
-  emittedPlanContent?.set(CLAUDE_PLAN_ID, toolInput.plan);
   return {
     sessionId,
     update: {
       sessionUpdate: "plan_update",
       plan: {
         type: "markdown",
-        planId: CLAUDE_PLAN_ID,
+        planId,
         content: toolInput.plan,
       },
     },
@@ -7136,6 +7148,10 @@ export function toAcpNotifications(
     // historical single-source behavior).
     emittedToolCalls?: Set<string>;
     emittedPlanContent?: Map<string, string>;
+    // Live ExitPlanMode plan updates are sent from canUseTool immediately
+    // before requestPermission, which gives strict clients deterministic
+    // ordering. Replay has no concurrent permission request and emits here.
+    emitExitPlanUpdates?: boolean;
     // Opaque id identifying the message these chunks belong to (ACP message ids
     // are opaque strings — no particular format is required). Attached to
     // user/agent message and thought chunks so clients can group streamed chunks
@@ -7260,15 +7276,22 @@ export function toAcpNotifications(
           // tool_result time once we have the task ID (for TaskCreate) and
           // confirmation that the change took effect.
         } else {
-          const planUpdate = exitPlanUpdate(
-            sessionId,
-            chunk.name,
-            chunk.input,
-            options?.clientCapabilities,
-            options?.emittedPlanContent,
-          );
-          if (planUpdate) {
-            output.push(planUpdate);
+          if (options?.emitExitPlanUpdates !== false) {
+            const planUpdate = exitPlanUpdate(
+              sessionId,
+              chunk.name,
+              chunk.input,
+              options?.clientCapabilities,
+              options?.emittedPlanContent,
+              options?.parentToolUseId,
+            );
+            if (planUpdate) {
+              output.push(planUpdate);
+              options?.emittedPlanContent?.set(
+                claudePlanId(options?.parentToolUseId),
+                (chunk.input as { plan: string }).plan,
+              );
+            }
           }
           // Only register hooks on first encounter to avoid double-firing
           if (registerHooks && !alreadyCached) {
@@ -7553,6 +7576,7 @@ export function streamEventToAcpNotifications(
     taskState?: TaskState;
     emittedToolCalls?: Set<string>;
     emittedPlanContent?: Map<string, string>;
+    emitExitPlanUpdates?: boolean;
     messageId?: string;
     streamedToolInputs?: StreamedToolInputCache;
   },
@@ -7567,6 +7591,7 @@ export function streamEventToAcpNotifications(
     taskState: options?.taskState,
     emittedToolCalls: options?.emittedToolCalls,
     emittedPlanContent: options?.emittedPlanContent,
+    emitExitPlanUpdates: options?.emitExitPlanUpdates,
     messageId: options?.messageId,
   };
   switch (event.type) {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -513,6 +513,11 @@ type Session = {
    *  tool_use block streams; this set makes the two paths converge regardless of
    *  order. Pruned at `tool_result` time alongside `toolUseCache`. */
   emittedToolCalls: Set<string>;
+  /** Last Markdown published through ACP's experimental `plan_update` lane,
+   *  keyed by plan id. The SDK can surface ExitPlanMode through the stream and
+   *  permission callback in either order; retaining the content makes those
+   *  paths converge without sending the same plan twice. */
+  emittedPlanContent?: Map<string, string>;
   /** Registry of live background tasks, keyed by task id: populated at
    *  `task_started`, pruned when the task settles (a `task_notification` or
    *  a terminal `task_updated` patch), and reconciled against
@@ -3500,6 +3505,7 @@ export class ClaudeAcpAgent {
                 cwd: session.cwd,
                 taskState: session.taskState,
                 emittedToolCalls: session.emittedToolCalls,
+                emittedPlanContent: session.emittedPlanContent,
                 messageId: currentStreamMessageId,
                 streamedToolInputs,
               },
@@ -3766,6 +3772,7 @@ export class ClaudeAcpAgent {
                 cwd: session.cwd,
                 taskState: session.taskState,
                 emittedToolCalls: session.emittedToolCalls,
+                emittedPlanContent: session.emittedPlanContent,
                 messageId: messageIdForGrouping(message),
                 toolUseResult: message.type === "user" ? message.tool_use_result : undefined,
                 // On the wire since CLI 2.1.216 but not in SDKUserMessage's
@@ -4365,6 +4372,7 @@ export class ClaudeAcpAgent {
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
     const toolUseCache: ToolUseCache = {};
+    const emittedPlanContent = new Map<string, string>();
     const messages = await getSessionMessages(sessionId);
     const forwardSubagentText =
       this.sessions[sessionId]?.forwardSubagentText ??
@@ -4414,6 +4422,7 @@ export class ClaudeAcpAgent {
           clientCapabilities: this.clientCapabilities,
           cwd: this.sessions[sessionId]?.cwd,
           taskState: this.sessions[sessionId]?.taskState,
+          emittedPlanContent,
           messageId: replayMessageId,
           parentToolUseId,
         },
@@ -4492,6 +4501,16 @@ export class ClaudeAcpAgent {
     if (!session) {
       return;
     }
+    const planUpdate = exitPlanUpdate(
+      sessionId,
+      toolName,
+      toolInput,
+      this.clientCapabilities,
+      (session.emittedPlanContent ??= new Map()),
+    );
+    if (planUpdate) {
+      await this.client.sessionUpdate(planUpdate);
+    }
     if (session.emittedToolCalls.has(toolCallId)) {
       return;
     }
@@ -4502,6 +4521,7 @@ export class ClaudeAcpAgent {
       toolInput,
       supportsTerminalOutput,
       session.cwd,
+      supportsPlanUpdates(this.clientCapabilities),
     );
     if (parentToolUseId) {
       update._meta = {
@@ -4606,6 +4626,7 @@ export class ClaudeAcpAgent {
                 { name: toolName, input: toolInput, id: toolUseID },
                 supportsTerminalOutput,
                 session?.cwd,
+                supportsPlanUpdates(this.clientCapabilities),
               ),
               // `claudeCode` metas always carry `toolName` (see ToolUpdateMeta),
               // so clients can rely on one shape everywhere.
@@ -5776,6 +5797,7 @@ export class ClaudeAcpAgent {
       taskState,
       toolUseCache: {},
       emittedToolCalls: new Set(),
+      emittedPlanContent: new Map(),
       liveBackgroundTasks: new Map(),
       emittedAssistantText: false,
       owedTrailingIdles: 0,
@@ -6954,6 +6976,7 @@ function toolCallNotification(
   rawInput: unknown,
   supportsTerminalOutput: boolean,
   cwd?: string,
+  usePlanUpdate = false,
   refine = false,
 ): SessionNotification["update"] {
   if (refine) {
@@ -6962,7 +6985,7 @@ function toolCallNotification(
       toolCallId: toolUse.id,
       sessionUpdate: "tool_call_update",
       rawInput,
-      ...toolInfoFromToolUse(toolUse, supportsTerminalOutput, cwd),
+      ...toolInfoFromToolUse(toolUse, supportsTerminalOutput, cwd, usePlanUpdate),
     };
   }
   return {
@@ -6976,7 +6999,51 @@ function toolCallNotification(
     sessionUpdate: "tool_call",
     rawInput,
     status: "pending",
-    ...toolInfoFromToolUse(toolUse, supportsTerminalOutput, cwd),
+    ...toolInfoFromToolUse(toolUse, supportsTerminalOutput, cwd, usePlanUpdate),
+  };
+}
+
+const CLAUDE_PLAN_ID = "claude-plan";
+
+function supportsPlanUpdates(clientCapabilities?: ClientCapabilities | null): boolean {
+  return clientCapabilities?.plan != null;
+}
+
+/** Build a Markdown plan update for ExitPlanMode when the client opts into the
+ * experimental plan capability. A stable per-session plan id lets a revised
+ * plan replace the previous draft instead of accumulating one plan per tool
+ * call. `rawInput.plan` remains on the switch_mode call used by the permission
+ * request; this only moves visual rendering out of that call. */
+function exitPlanUpdate(
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+  clientCapabilities?: ClientCapabilities | null,
+  emittedPlanContent?: Map<string, string>,
+): SessionNotification | undefined {
+  if (
+    toolName !== "ExitPlanMode" ||
+    !supportsPlanUpdates(clientCapabilities) ||
+    toolInput === null ||
+    typeof toolInput !== "object" ||
+    !("plan" in toolInput) ||
+    typeof toolInput.plan !== "string" ||
+    toolInput.plan.trim().length === 0 ||
+    emittedPlanContent?.get(CLAUDE_PLAN_ID) === toolInput.plan
+  ) {
+    return undefined;
+  }
+  emittedPlanContent?.set(CLAUDE_PLAN_ID, toolInput.plan);
+  return {
+    sessionId,
+    update: {
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId: CLAUDE_PLAN_ID,
+        content: toolInput.plan,
+      },
+    },
   };
 }
 
@@ -7068,6 +7135,7 @@ export function toAcpNotifications(
     // tool_call/update decision falls back to `toolUseCache` presence (the
     // historical single-source behavior).
     emittedToolCalls?: Set<string>;
+    emittedPlanContent?: Map<string, string>;
     // Opaque id identifying the message these chunks belong to (ACP message ids
     // are opaque strings — no particular format is required). Attached to
     // user/agent message and thought chunks so clients can group streamed chunks
@@ -7088,6 +7156,7 @@ export function toAcpNotifications(
   const taskState = options?.taskState ?? new Map();
   const registerHooks = options?.registerHooks !== false;
   const supportsTerminalOutput = options?.clientCapabilities?._meta?.["terminal_output"] === true;
+  const usePlanUpdate = supportsPlanUpdates(options?.clientCapabilities);
   if (typeof content === "string") {
     if (content.length === 0) {
       return [];
@@ -7191,6 +7260,16 @@ export function toAcpNotifications(
           // tool_result time once we have the task ID (for TaskCreate) and
           // confirmation that the change took effect.
         } else {
+          const planUpdate = exitPlanUpdate(
+            sessionId,
+            chunk.name,
+            chunk.input,
+            options?.clientCapabilities,
+            options?.emittedPlanContent,
+          );
+          if (planUpdate) {
+            output.push(planUpdate);
+          }
           // Only register hooks on first encounter to avoid double-firing
           if (registerHooks && !alreadyCached) {
             // Capture the tool name in the closure rather than re-reading the
@@ -7258,12 +7337,19 @@ export function toAcpNotifications(
               rawInput,
               supportsTerminalOutput,
               options?.cwd,
+              usePlanUpdate,
               true,
             );
           } else {
             // First surface (streaming content_block_start or replay) — send as
             // tool_call (with terminal_info for Bash).
-            update = toolCallNotification(chunk, rawInput, supportsTerminalOutput, options?.cwd);
+            update = toolCallNotification(
+              chunk,
+              rawInput,
+              supportsTerminalOutput,
+              options?.cwd,
+              usePlanUpdate,
+            );
           }
         }
         break;
@@ -7466,6 +7552,7 @@ export function streamEventToAcpNotifications(
     cwd?: string;
     taskState?: TaskState;
     emittedToolCalls?: Set<string>;
+    emittedPlanContent?: Map<string, string>;
     messageId?: string;
     streamedToolInputs?: StreamedToolInputCache;
   },
@@ -7479,6 +7566,7 @@ export function streamEventToAcpNotifications(
     cwd: options?.cwd,
     taskState: options?.taskState,
     emittedToolCalls: options?.emittedToolCalls,
+    emittedPlanContent: options?.emittedPlanContent,
     messageId: options?.messageId,
   };
   switch (event.type) {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1722,6 +1722,57 @@ describe("subagent transcript replay", () => {
   });
 });
 
+describe("ExitPlanMode replay", () => {
+  it("replays Markdown through plan_update for capable clients without duplicating tool content", async () => {
+    const updates: SessionNotification[] = [];
+    const client = {
+      sessionUpdate: async (update: SessionNotification) => updates.push(update),
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    agent.clientCapabilities = { plan: {} };
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "plan-message",
+        session_id: "s1",
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          id: "api-plan-message",
+          model: "claude-sonnet-4-5",
+          role: "assistant",
+          type: "message",
+          stop_reason: "tool_use",
+          content: [
+            {
+              type: "tool_use",
+              id: "exit-plan-tool",
+              name: "ExitPlanMode",
+              input: { plan: "# Replayed plan" },
+            },
+          ],
+        },
+      },
+    ] as Awaited<ReturnType<typeof getSessionMessages>>);
+
+    await (
+      agent as unknown as { replaySessionHistory(sessionId: string): Promise<void> }
+    ).replaySessionHistory("s1");
+
+    expect(updates.map((u) => u.update.sessionUpdate)).toEqual(["plan_update", "tool_call"]);
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "plan_update",
+      plan: { type: "markdown", planId: "claude-plan", content: "# Replayed plan" },
+    });
+    expect(updates[1].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "exit-plan-tool",
+      kind: "switch_mode",
+      content: [],
+    });
+  });
+});
+
 describe("escape markdown", () => {
   it("should escape markdown characters", () => {
     let text = "Hello *world*!";
@@ -2239,6 +2290,118 @@ describe("tool_call emitted before permission request", () => {
     expect(events).toEqual(["permission"]);
   });
 
+  it("delivers plan_update and tool_call before an ExitPlanMode permission-first request", async () => {
+    const { agent, events, updates, session } = setup();
+    agent.clientCapabilities = { plan: {} };
+
+    await agent.canUseTool("session-1")("ExitPlanMode", { plan: "# Permission-first plan" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "plan-tool-1",
+    } as any);
+
+    expect(events).toEqual(["update:plan_update", "update:tool_call", "permission"]);
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId: "claude-plan",
+        content: "# Permission-first plan",
+      },
+    });
+    expect(updates[1].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "plan-tool-1",
+      kind: "switch_mode",
+      content: [],
+    });
+    expect(session.emittedPlanContent?.get("claude-plan")).toBe("# Permission-first plan");
+
+    const streamed = toAcpNotifications(
+      [
+        {
+          type: "tool_use",
+          id: "plan-tool-1",
+          name: "ExitPlanMode",
+          input: { plan: "# Permission-first plan" },
+        },
+      ],
+      "assistant",
+      "session-1",
+      session.toolUseCache,
+      {} as AcpClient,
+      console,
+      {
+        clientCapabilities: agent.clientCapabilities,
+        emittedToolCalls: session.emittedToolCalls,
+        emittedPlanContent: session.emittedPlanContent,
+        emitExitPlanUpdates: false,
+      },
+    );
+    expect(streamed.map((n) => n.update.sessionUpdate)).toEqual(["tool_call_update"]);
+  });
+
+  it("delivers a streamed tool_call, then plan_update, before the permission request", async () => {
+    const { agent, events, session } = setup();
+    agent.clientCapabilities = { plan: {} };
+
+    const streamed = toAcpNotifications(
+      [
+        {
+          type: "tool_use",
+          id: "plan-tool-2",
+          name: "ExitPlanMode",
+          input: { plan: "# Stream-first plan" },
+        },
+      ],
+      "assistant",
+      "session-1",
+      session.toolUseCache,
+      agent.client,
+      console,
+      {
+        clientCapabilities: agent.clientCapabilities,
+        emittedToolCalls: session.emittedToolCalls,
+        emittedPlanContent: session.emittedPlanContent,
+        emitExitPlanUpdates: false,
+      },
+    );
+    for (const notification of streamed) {
+      await agent.client.sessionUpdate(notification);
+    }
+
+    await agent.canUseTool("session-1")("ExitPlanMode", { plan: "# Stream-first plan" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "plan-tool-2",
+    } as any);
+
+    expect(events).toEqual(["update:tool_call", "update:plan_update", "permission"]);
+  });
+
+  it("keeps the ExitPlanMode Markdown in the permission tool call for legacy clients", async () => {
+    const { agent, events, updates } = setup();
+
+    await agent.canUseTool("session-1")("ExitPlanMode", { plan: "# Legacy plan" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "plan-tool-legacy",
+    } as any);
+
+    expect(events).toEqual(["update:tool_call", "permission"]);
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "plan-tool-legacy",
+      kind: "switch_mode",
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "# Legacy plan" },
+        },
+      ],
+    });
+  });
+
   it("refines the eagerly-emitted tool_call with a tool_call_update when the chunk streams", () => {
     const { session } = setup();
     // Permission flow already emitted the tool_call for this id.
@@ -2572,6 +2735,36 @@ describe("subagent permission attribution (issue #851)", () => {
     // meta has (toolName is required by ToolUpdateMeta).
     expect(requests[0].toolCall._meta).toMatchObject({
       claudeCode: { toolName: "Bash", parentToolUseId: "toolu_parent" },
+    });
+  });
+
+  it("scopes a subagent ExitPlanMode plan to the spawning tool call", async () => {
+    const { agent, updates, session } = setup();
+    agent.clientCapabilities = { plan: {} };
+    session.liveBackgroundTasks.set("agent-42", {
+      parentToolUseId: "toolu_parent",
+      isSubagent: true,
+    });
+
+    await agent.canUseTool("session-1")("ExitPlanMode", { plan: "# Subagent plan" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "toolu_sub_plan",
+      agentID: "agent-42",
+    } as any);
+
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId: "claude-plan:toolu_parent",
+        content: "# Subagent plan",
+      },
+    });
+    expect(updates[1].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_sub_plan",
+      _meta: { claudeCode: { parentToolUseId: "toolu_parent" } },
     });
   });
 

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -1366,8 +1366,8 @@ describe("session config options", () => {
       session.emittedToolCalls.add("toolu_plan_update");
 
       const canUseTool = (agent as any).canUseTool(SESSION_ID);
-      try {
-        await canUseTool(
+      await expect(
+        canUseTool(
           "ExitPlanMode",
           { plan: "# Approved plan" },
           {
@@ -1375,10 +1375,8 @@ describe("session config options", () => {
             suggestions: undefined,
             toolUseID: "toolu_plan_update",
           },
-        );
-      } catch {
-        // The mock returns cancelled after capturing the request.
-      }
+        ),
+      ).rejects.toThrow("Tool use aborted");
 
       expect(sessionUpdates).toEqual([
         {
@@ -1399,6 +1397,63 @@ describe("session config options", () => {
         rawInput: { plan: "# Approved plan" },
         content: [],
       });
+    });
+
+    it("approves ExitPlanMode after publishing the capable-client plan", async () => {
+      (agent as unknown as { clientCapabilities: ClientCapabilities }).clientCapabilities = {
+        plan: {},
+      };
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      session.modes.currentModeId = "plan";
+      permissionResponse = { outcome: { outcome: "selected", optionId: "default" } };
+
+      const result = await (agent as any).canUseTool(SESSION_ID)(
+        "ExitPlanMode",
+        { plan: "# Implement it" },
+        {
+          signal: new AbortController().signal,
+          suggestions: undefined,
+          toolUseID: "toolu_plan_approve",
+        },
+      );
+
+      expect(result.behavior).toBe("allow");
+      expect(session.modes.currentModeId).toBe("default");
+      expect(sessionUpdates.map((n) => n.update.sessionUpdate)).toEqual([
+        "plan_update",
+        "tool_call",
+        "current_mode_update",
+        "config_option_update",
+      ]);
+    });
+
+    it("rejects ExitPlanMode without switching mode after publishing the plan", async () => {
+      (agent as unknown as { clientCapabilities: ClientCapabilities }).clientCapabilities = {
+        plan: {},
+      };
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      session.modes.currentModeId = "plan";
+      permissionResponse = { outcome: { outcome: "selected", optionId: "plan" } };
+
+      const result = await (agent as any).canUseTool(SESSION_ID)(
+        "ExitPlanMode",
+        { plan: "# Keep planning" },
+        {
+          signal: new AbortController().signal,
+          suggestions: undefined,
+          toolUseID: "toolu_plan_reject",
+        },
+      );
+
+      expect(result).toMatchObject({
+        behavior: "deny",
+        message: "User rejected request to exit plan mode.",
+      });
+      expect(session.modes.currentModeId).toBe("plan");
+      expect(sessionUpdates.map((n) => n.update.sessionUpdate)).toEqual([
+        "plan_update",
+        "tool_call",
+      ]);
     });
   });
 });

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { SessionNotification } from "@agentclientprotocol/sdk";
+import { ClientCapabilities, SessionNotification } from "@agentclientprotocol/sdk";
 import type { ModelInfo } from "@anthropic-ai/claude-agent-sdk";
 import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
 import { makeMockQuery } from "./helpers.js";
@@ -1356,6 +1356,49 @@ describe("session config options", () => {
       expect(capturedPermissionRequest).not.toBeNull();
       const optionIds = capturedPermissionRequest.options.map((o: any) => o.optionId);
       expect(optionIds).toContain("auto");
+    });
+
+    it("sends plan_update before permission when the tool call was already streamed", async () => {
+      (agent as unknown as { clientCapabilities: ClientCapabilities }).clientCapabilities = {
+        plan: {},
+      };
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      session.emittedToolCalls.add("toolu_plan_update");
+
+      const canUseTool = (agent as any).canUseTool(SESSION_ID);
+      try {
+        await canUseTool(
+          "ExitPlanMode",
+          { plan: "# Approved plan" },
+          {
+            signal: new AbortController().signal,
+            suggestions: undefined,
+            toolUseID: "toolu_plan_update",
+          },
+        );
+      } catch {
+        // The mock returns cancelled after capturing the request.
+      }
+
+      expect(sessionUpdates).toEqual([
+        {
+          sessionId: SESSION_ID,
+          update: {
+            sessionUpdate: "plan_update",
+            plan: {
+              type: "markdown",
+              planId: "claude-plan",
+              content: "# Approved plan",
+            },
+          },
+        },
+      ]);
+      expect(capturedPermissionRequest.toolCall).toMatchObject({
+        toolCallId: "toolu_plan_update",
+        kind: "switch_mode",
+        rawInput: { plan: "# Approved plan" },
+        content: [],
+      });
     });
   });
 });

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -1753,6 +1753,92 @@ describe("toolInfoFromToolUse - ExitPlanMode", () => {
     expect(repeated.filter((n) => n.update.sessionUpdate === "plan_update")).toHaveLength(0);
   });
 
+  it("defers live plan_update to the permission path while keeping the tool call compact", () => {
+    const emittedPlanContent = new Map<string, string>();
+    const notifications = toAcpNotifications(
+      [
+        {
+          type: "tool_use" as const,
+          name: "ExitPlanMode",
+          id: "toolu_plan_live",
+          input: { plan: "# Live plan" },
+        },
+      ],
+      "assistant",
+      "test-session",
+      {},
+      {} as AcpClient,
+      { log: () => {}, error: () => {} },
+      {
+        clientCapabilities: { plan: {} },
+        emittedPlanContent,
+        emitExitPlanUpdates: false,
+      },
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_plan_live",
+      kind: "switch_mode",
+      content: [],
+    });
+    expect(emittedPlanContent.size).toBe(0);
+  });
+
+  it("does not create plan_update for an empty Markdown plan", () => {
+    const notifications = toAcpNotifications(
+      [
+        {
+          type: "tool_use" as const,
+          name: "ExitPlanMode",
+          id: "toolu_plan_empty",
+          input: { plan: "  \n" },
+        },
+      ],
+      "assistant",
+      "test-session",
+      {},
+      {} as AcpClient,
+      { log: () => {}, error: () => {} },
+      { clientCapabilities: { plan: {} } },
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].update.sessionUpdate).toBe("tool_call");
+  });
+
+  it("scopes replayed subagent plans by their parent tool call", () => {
+    const emittedPlanContent = new Map<string, string>();
+    const render = (parentToolUseId: string, id: string, plan: string) =>
+      toAcpNotifications(
+        [{ type: "tool_use" as const, name: "ExitPlanMode", id, input: { plan } }],
+        "assistant",
+        "test-session",
+        {},
+        {} as AcpClient,
+        { log: () => {}, error: () => {} },
+        {
+          clientCapabilities: { plan: {} },
+          emittedPlanContent,
+          parentToolUseId,
+        },
+      );
+
+    const first = render("agent-parent-1", "toolu_subplan_1", "# First subagent plan");
+    const second = render("agent-parent-2", "toolu_subplan_2", "# Second subagent plan");
+
+    expect(first[0].update).toMatchObject({
+      sessionUpdate: "plan_update",
+      plan: { planId: "claude-plan:agent-parent-1" },
+    });
+    expect(second[0].update).toMatchObject({
+      sessionUpdate: "plan_update",
+      plan: { planId: "claude-plan:agent-parent-2" },
+    });
+    expect(emittedPlanContent.size).toBe(2);
+  });
+
   it("keeps Markdown in the switch_mode tool call when plan_update is unsupported", () => {
     const notifications = toAcpNotifications(
       [

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -1698,6 +1698,90 @@ describe("toolInfoFromToolUse - ExitPlanMode", () => {
     expect(info.kind).toBe("switch_mode");
     expect(info.content).toEqual([]);
   });
+
+  it("publishes Markdown through plan_update for capable clients and keeps the tool call compact", () => {
+    const toolUse = {
+      type: "tool_use" as const,
+      name: "ExitPlanMode",
+      id: "toolu_plan_capable",
+      input: { plan: "# Implement\n\nRun the tests." },
+    };
+    const emittedPlanContent = new Map<string, string>();
+
+    const notifications = toAcpNotifications(
+      [toolUse],
+      "assistant",
+      "test-session",
+      {},
+      {} as AcpClient,
+      { log: () => {}, error: () => {} },
+      {
+        clientCapabilities: { plan: {} },
+        emittedPlanContent,
+      },
+    );
+
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0].update).toEqual({
+      sessionUpdate: "plan_update",
+      plan: {
+        type: "markdown",
+        planId: "claude-plan",
+        content: "# Implement\n\nRun the tests.",
+      },
+    });
+    expect(notifications[1].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_plan_capable",
+      kind: "switch_mode",
+      rawInput: { plan: "# Implement\n\nRun the tests." },
+      content: [],
+    });
+
+    const repeated = toAcpNotifications(
+      [toolUse],
+      "assistant",
+      "test-session",
+      {},
+      {} as AcpClient,
+      { log: () => {}, error: () => {} },
+      {
+        clientCapabilities: { plan: {} },
+        emittedPlanContent,
+      },
+    );
+    expect(repeated.filter((n) => n.update.sessionUpdate === "plan_update")).toHaveLength(0);
+  });
+
+  it("keeps Markdown in the switch_mode tool call when plan_update is unsupported", () => {
+    const notifications = toAcpNotifications(
+      [
+        {
+          type: "tool_use" as const,
+          name: "ExitPlanMode",
+          id: "toolu_plan_fallback",
+          input: { plan: "# Fallback plan" },
+        },
+      ],
+      "assistant",
+      "test-session",
+      {},
+      {} as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      kind: "switch_mode",
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "# Fallback plan" },
+        },
+      ],
+    });
+  });
 });
 
 describe("toolInfoFromToolUse - undefined input regression", () => {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -130,6 +130,7 @@ export function toolInfoFromToolUse(
   toolUse: any,
   supportsTerminalOutput: boolean = false,
   cwd?: string,
+  usePlanUpdate: boolean = false,
 ): ToolInfo {
   const name = toolUse.name;
 
@@ -433,9 +434,15 @@ export function toolInfoFromToolUse(
       return {
         title: "Ready to code?",
         kind: "switch_mode",
-        content: planInput?.plan
-          ? [{ type: "content" as const, content: { type: "text" as const, text: planInput.plan } }]
-          : [],
+        content:
+          !usePlanUpdate && planInput?.plan
+            ? [
+                {
+                  type: "content" as const,
+                  content: { type: "text" as const, text: planInput.plan },
+                },
+              ]
+            : [],
       };
     }
 


### PR DESCRIPTION
## Summary

- publish `ExitPlanMode` Markdown through experimental ACP `plan_update` when the client advertises `clientCapabilities.plan`
- keep `requestPermission` as the confirmation mechanism and retain `rawInput.plan` on the `switch_mode` tool call
- fall back to the existing tool-call content for clients without plan support
- serialize live plan publication through the permission path so `plan_update` and the referenced `tool_call` are delivered before `requestPermission`
- use stable per-scope plan IDs so main-agent and subagent plans cannot overwrite each other
- replay capable-client plans through `plan_update` without duplicating Markdown in tool content

## Testing

- permission-first and stream-first event ordering
- approve, reject, and cancel outcomes
- capable-client Markdown payload and legacy fallback
- empty plan suppression, replay, deduplication, and subagent plan IDs
- `vitest run` (697 passed, 20 skipped)
- `tsc --noEmit`
- ESLint and Prettier on changed files