### PR TITLE
chore: preserve registry update after manual publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,7 @@ jobs:
 
   trigger-registry-update:
     needs: publish-npm
+    if: ${{ always() && needs.publish-npm.result == 'success' }}
     runs-on: ubuntu-latest
     environment: release
     permissions: {}


### PR DESCRIPTION
A skipped `release-please` job propagates to downstream jobs during a manual release, even when npm publishing succeeds through an `always()` condition.

Explicitly evaluate the npm job result so successful manual publications continue to update the agent registry.

Validation: Prettier workflow check.