### PR TITLE
feat(steering): settle a steered turn at idle, not at the interrupt

### DIFF
--- a/examples/simple-client.ts
+++ b/examples/simple-client.ts
@@ -30,10 +30,10 @@
  *                   already running, so it can change course between tool
  *                   calls. Answers "injected", or "startedNewTurn" if the turn
  *                   beat us to the finish. An injected reply streams as
- *                   `session/update` notifications *within* that turn: its
- *                   `stopReason` waits for the steered work to finish. The
- *                   "startedNewTurn" output belongs to a detached turn no
- *                   `session/prompt` of ours tracks. See ./steering.ts.
+ *                   `session/update` notifications inside that turn, whose
+ *                   `stopReason` waits for it. "startedNewTurn" output belongs
+ *                   to a detached turn no `session/prompt` of ours tracks.
+ *                   See ./steering.ts.
  *   !queue <text>   `session/prompt` sent mid-turn anyway. The agent advertises
  *                   `promptQueueing`, so it takes the backlog instead of us —
  *                   same ordering, different owner.
@@ -566,8 +566,8 @@ async function main() {
     try {
       const result = await agent.request<SteeringResponse>(STEERING_METHOD, params);
       // Either way the steered message's own output arrives as `session/update`
-      // notifications, not in this response. When it was injected, that output
-      // lands inside the turn we steered — whose `stopReason` waits for it.
+      // notifications, not in this response. When injected, it lands inside the
+      // turn we steered, whose `stopReason` waits for it.
       log(
         result.outcome === "injected"
           ? "steer outcome: injected into the running turn"

--- a/examples/simple-client.ts
+++ b/examples/simple-client.ts
@@ -29,9 +29,11 @@
  *   !steer <text>   `_session/steering` — injected into the turn that is
  *                   already running, so it can change course between tool
  *                   calls. Answers "injected", or "startedNewTurn" if the turn
- *                   beat us to the finish. Either way the reply arrives as
- *                   `session/update` notifications that can outlast the
- *                   `stopReason` of the turn you steered. See ./steering.ts.
+ *                   beat us to the finish. An injected reply streams as
+ *                   `session/update` notifications *within* that turn: its
+ *                   `stopReason` waits for the steered work to finish. The
+ *                   "startedNewTurn" output belongs to a detached turn no
+ *                   `session/prompt` of ours tracks. See ./steering.ts.
  *   !queue <text>   `session/prompt` sent mid-turn anyway. The agent advertises
  *                   `promptQueueing`, so it takes the backlog instead of us —
  *                   same ordering, different owner.
@@ -564,8 +566,8 @@ async function main() {
     try {
       const result = await agent.request<SteeringResponse>(STEERING_METHOD, params);
       // Either way the steered message's own output arrives as `session/update`
-      // notifications, not in this response — and it may well keep streaming
-      // after the turn we steered has already answered with its stopReason.
+      // notifications, not in this response. When it was injected, that output
+      // lands inside the turn we steered — whose `stopReason` waits for it.
       log(
         result.outcome === "injected"
           ? "steer outcome: injected into the running turn"

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -361,36 +361,25 @@ type Turn = {
    *  pre-hold behavior (pending wakes are not countable: notifications can
    *  batch into one followup). */
   deferredSettle?: PromptResponse;
-  /** Present once `steer()` has injected a message into this turn; holds the
-   *  uuids of injected messages the SDK has not replayed back yet.
+  /** Uuids of `steer()`-injected messages the SDK has not replayed back yet.
    *
-   *  Steering is delivered at {@link STEER_PRIORITY} (`now`), which makes the
-   *  CLI ABORT the cycle that is running. The aborted cycle is finalized with an
-   *  ordinary human-origin `result` — indistinguishable from a turn's terminal
-   *  one — and the steered message then runs as a SECOND cycle. Settling at that
-   *  first result answers `session/prompt` while the steered work is still
-   *  streaming, leaving the turn's remaining tool calls and its actual answer to
-   *  arrive out-of-turn. So from the injection on, a steered turn's results only
-   *  RECORD their outcome (`steeredSettle`) and the turn settles at the SDK's
-   *  `idle` — its authoritative turn-over signal, and the only one that spans
-   *  both cycles (observed on CLI 2.1.220: one idle after the steered cycle's
-   *  result, none between the cycles).
+   *  A steer is delivered at {@link STEER_PRIORITY} (`now`), so the CLI ABORTS
+   *  the running cycle: it emits its own human-origin `result` —
+   *  indistinguishable from a turn's terminal one — and the steered message runs
+   *  as a SECOND cycle. Settling at that result would answer `session/prompt`
+   *  mid-work, so a steered turn's results only RECORD their outcome
+   *  (`steeredSettle`) and it settles at the SDK's `idle`, the only signal
+   *  spanning both cycles (CLI 2.1.220).
    *
-   *  The set is what distinguishes "the steered work is still ahead" from "it
-   *  has run": the CLI replays an injected message when it picks it up, which is
-   *  AFTER the interrupted cycle's result. A non-empty set at an idle therefore
-   *  means the steered cycle hasn't started — the idle belongs to the cycle the
-   *  steer interrupted, or to a turn that ended before the steer landed — so it
-   *  is swallowed rather than settling the turn. Drained by the replay handler.
+   *  A non-empty set at an idle means the steered cycle hasn't started — the CLI
+   *  replays a message only when it picks it up, always after the interrupted
+   *  cycle's result — so that idle is swallowed. Drained by the replay handler.
    *
-   *  Accepted residual: an injected message the CLI drops without replaying
-   *  leaves the turn parked until `session/cancel` or the next prompt (both
-   *  settle it, as with the subagent hold above). */
+   *  Residual: a message the CLI drops unreplayed parks the turn until
+   *  `session/cancel` or the next prompt (both settle it). */
   steeredEchoes?: Set<string>;
-  /** The outcome recorded by the most recent result of a steered turn (see
-   *  `steeredEchoes`) — what the turn settles with once its steered work has
-   *  run. Later cycles overwrite it, so the last result wins and its usage
-   *  snapshot covers every cycle the turn ran. */
+  /** What a steered turn settles with once its steered work has run: the outcome
+   *  of its latest result, so its usage covers every cycle the turn ran. */
   steeredSettle?: PromptResponse;
   resolve: (response: PromptResponse) => void;
   reject: (error: unknown) => void;
@@ -720,10 +709,8 @@ function isHeldOpen(
   return turn != null && turn.deferredSettle !== undefined && !turn.settled;
 }
 
-/** Whether a steering message has been injected into this turn, which moves its
- *  settlement off the next result and onto the SDK's `idle` (see
- *  Turn.steeredEchoes for why a result no longer ends such a turn). The single
- *  spelling of the steer predicate, shared by the consumer's settle lanes. */
+/** Whether a steer moved this turn's settlement off the next result and onto the
+ *  SDK's `idle` (see Turn.steeredEchoes). Shared by the consumer's settle lanes. */
 function isSteering(turn: Turn | null | undefined): turn is Turn & { steeredEchoes: Set<string> } {
   return turn != null && turn.steeredEchoes !== undefined && !turn.settled;
 }
@@ -1923,11 +1910,9 @@ export class ClaudeAcpAgent {
    *  calls). The steered message's own output streams via `session/update`, not
    *  this response.
    *
-   *  Pre-empting means ABORTING: the interrupted cycle is finalized with a
-   *  `result` of its own and the steered message runs as a second cycle, so the
-   *  steered turn is marked (`Turn.steeredEchoes`) and its settlement moves from
-   *  the next result to the SDK's `idle`. Without that the turn would answer at
-   *  the interrupt and its real answer would stream out-of-turn.
+   *  Pre-empting means ABORTING: the interrupted cycle emits a `result` of its
+   *  own and the steered message runs as a second one, so the turn is marked
+   *  (`Turn.steeredEchoes`) to settle at the SDK's `idle` instead of that result.
    *
    *  When the session is idle, the opt-in path returns `promptRequired` WITHOUT
    *  calling `prompt()`, pushing SDK input, or mutating `turnQueue`: the content
@@ -1979,16 +1964,14 @@ export class ClaudeAcpAgent {
     // Deliver into the running turn rather than queuing behind it as a fresh
     // prompt would.
     userMessage.priority = STEER_PRIORITY;
-    // Hand the turn's settlement to the idle lane before the push, in the same
-    // synchronous section as the in-flight check: the interrupt this push
-    // triggers can have the CLI finalizing the aborted cycle by the time the
-    // consumer next runs, and a result reaching it unmarked would settle the
-    // turn (see Turn.steeredEchoes).
+    // Mark before the push and in the same synchronous section as the in-flight
+    // check: the interrupt can have the CLI finalizing the aborted cycle by the
+    // time the consumer next runs, and an unmarked result would settle the turn
+    // (see Turn.steeredEchoes).
     (turnInFlight.steeredEchoes ??= new Set()).add(steeredUuid);
-    // A turn already held for its background subagents has a recorded outcome
-    // the steer supersedes: carry it into the steer lane so one lane owns the
-    // settlement, and the hold is re-applied when the steered work is done (the
-    // idle handler routes back through the subagent gate).
+    // A turn already held for background subagents has a recorded outcome the
+    // steer supersedes: move it into the steer lane so one lane owns settlement.
+    // The idle handler re-applies the hold through the subagent gate.
     if (turnInFlight.deferredSettle !== undefined) {
       turnInFlight.steeredSettle = turnInFlight.deferredSettle;
       turnInFlight.deferredSettle = undefined;
@@ -2323,11 +2306,10 @@ export class ClaudeAcpAgent {
      *  calling settleActive directly bypasses the hold and re-opens the
      *  out-of-turn permission deadlock (issue #866) through its lane. */
     const settleOrDefer = (outcome: PromptResponse) => {
-      // A steer injected into this turn aborted the cycle whose result this may
-      // be, and the steered message runs as another one — so no result ends a
-      // steered turn. Record the outcome and let the idle lane settle with it
-      // (see Turn.steeredEchoes); later cycles overwrite it, so the turn settles
-      // with its last result and a usage snapshot covering all of them.
+      // No result ends a steered turn: the steer aborted the cycle this result
+      // may belong to, and the steered one is still to come. Record the outcome
+      // for the idle lane (see Turn.steeredEchoes); later cycles overwrite it,
+      // so the last result and its usage win.
       if (isSteering(session.activeTurn)) {
         session.activeTurn.steeredSettle = outcome;
         return;
@@ -2821,36 +2803,26 @@ export class ClaudeAcpAgent {
                     // this lagged idle (no active turn to settle): the idle
                     // still belongs to that settled turn, and skipping the
                     // decrement would leak the debt permanently.
-                    // Deliberately BEFORE the steer lane below: a lagged idle
-                    // owed by an earlier turn carries no identity of its own,
-                    // and reading it as the steered sequence's turn-over signal
-                    // would settle a turn whose steered cycle is still running.
-                    // A steered turn's own results owe nothing (see the result
-                    // handler), so its idle reaches the lane below.
+                    // Deliberately BEFORE the steer lane below: an owed idle
+                    // belongs to an earlier turn, and reading it as the steered
+                    // sequence's turn-over signal would settle a turn whose
+                    // steered cycle is still running. Steered results owe none.
                     session.owedTrailingIdles--;
                   } else if (isSteering(session.activeTurn)) {
-                    // A turn a steer was injected into settles here rather than
-                    // at a result: the steer aborted the running cycle, so the
-                    // idle is the only signal that spans the interrupted cycle
-                    // AND the steered one (see Turn.steeredEchoes).
+                    // A steered turn settles here, not at a result: this idle is
+                    // the only signal spanning the interrupted and steered cycles
+                    // (see Turn.steeredEchoes). An idle before the steered echo,
+                    // or before any result was recorded, means the answer is
+                    // still ahead — swallow it, and never let it reach the #825
+                    // fail below, which would reject a prompt about to answer.
                     //
-                    // An idle that arrives before the steered message is replayed
-                    // — or before any result was recorded — is swallowed instead:
-                    // the steered cycle hasn't started (this idle belongs to the
-                    // cycle the steer interrupted, or to a turn that had already
-                    // finished when the steer landed), so the answer is still
-                    // ahead. Such idles must never reach the #825 fail below,
-                    // which would reject a prompt that is about to answer.
-                    //
-                    // Typed as the plain Turn so the fields can be cleared below;
-                    // isSteering's guard narrows steeredEchoes to non-optional.
+                    // Plain Turn so the fields can be cleared below; isSteering
+                    // narrows steeredEchoes to non-optional.
                     const steered: Turn = session.activeTurn;
                     if (steered.steeredEchoes?.size === 0 && steered.steeredSettle !== undefined) {
-                      // Hand the recorded outcome to the subagent gate rather
-                      // than settling directly: a steered turn can also have
-                      // spawned background subagents, and they own the turn from
-                      // here (the gate settles now when none is live, holds
-                      // otherwise).
+                      // Via the subagent gate, not settleActive: a steered turn
+                      // can also have spawned background subagents, which own it
+                      // from here (settles now if none is live, holds otherwise).
                       steered.deferredSettle = steered.steeredSettle;
                       steered.steeredEchoes = undefined;
                       steered.steeredSettle = undefined;
@@ -3305,12 +3277,10 @@ export class ClaudeAcpAgent {
               // cancel window still gets its own trailer and must be counted,
               // or that idle would later false-fail the next prompt.
               // A second exclusion: a steered turn's own results (see
-              // Turn.steeredEchoes). The cycle a steer aborted gets no trailing
-              // idle at all — the CLI emits one idle for the whole interrupted +
-              // steered sequence — and that single idle is what settles the turn,
-              // so counting either cycle's result would leave a debt that
-              // swallows the idle the settle needs. Autonomous results landing
-              // inside a steered turn keep their own trailers.
+              // Turn.steeredEchoes). One idle covers the whole interrupted +
+              // steered sequence and that idle settles the turn, so counting
+              // either result would leave a debt that swallows it. Autonomous
+              // results inside a steered turn keep their own trailers.
               const owesTrailingIdle = isAutonomousResult || !isSteering(session.activeTurn);
               if (
                 owesTrailingIdle &&
@@ -3772,21 +3742,17 @@ export class ClaudeAcpAgent {
                       isSteering(session.activeTurn) &&
                       session.activeTurn.steeredSettle !== undefined
                     ) {
-                      // Same for a turn whose steer is still open (see
+                      // Same for a turn with an open steer (see
                       // Turn.steeredEchoes): the user moving on outranks the
-                      // steered continuation, but the stop reason its last
-                      // result recorded stands. With no result recorded yet it
-                      // falls through to the end_turn hand-off below, as an
-                      // unsteered turn would (and nothing is owed there: no
-                      // result means no trailer).
+                      // steered continuation, but its last result's stop reason
+                      // stands. With no result yet it falls through to the
+                      // end_turn hand-off below, owing nothing there.
                       //
-                      // That recorded result owes a trailing idle nobody
-                      // counted — the steer lane pays for its idles by settling
-                      // on them, and this hand-off settles instead. Count it
-                      // here or that idle would arrive un-owed against the
-                      // freshly activated turn and false-fail it (issue #825).
-                      // Benign when the trailer never comes (the interrupted
-                      // cycle emits none): the debt absorbs one future idle.
+                      // The steer lane normally pays for that result's trailing
+                      // idle by settling on it; this hand-off settles instead,
+                      // so count it here or it arrives un-owed against the fresh
+                      // turn and false-fails it (issue #825). Harmless if it
+                      // never comes: the debt absorbs one future idle.
                       session.owedTrailingIdles++;
                       settleActive(session.activeTurn.steeredSettle);
                     } else {
@@ -3806,10 +3772,9 @@ export class ClaudeAcpAgent {
               }
               if ("isReplay" in message && message.isReplay) {
                 // A steered message's echo matches no turn (steer() creates
-                // none), but it is the signal that the CLI has picked the
-                // message up and the steered cycle is running — which is what
-                // lets the idle lane tell "the answer is still ahead" from "the
-                // turn is over" (see Turn.steeredEchoes).
+                // none), but it marks the steered cycle as running — how the idle
+                // lane tells "the answer is still ahead" from "the turn is over"
+                // (see Turn.steeredEchoes).
                 if (isSteering(session.activeTurn)) {
                   session.activeTurn.steeredEchoes.delete(message.uuid);
                 }
@@ -4290,14 +4255,12 @@ export class ClaudeAcpAgent {
       }
     }
 
-    // A steered active turn (see Turn.steeredEchoes) is left to the consumer's
-    // cancelled-settle at the interrupt's trailing idle, like any live turn. But
-    // its last result's own trailer was deliberately left uncounted — the steer
-    // lane pays for its idles by settling on them, which this cancel pre-empts —
-    // so two trailers can be in flight where that settle consumes only one.
-    // Count the other, or it arrives un-owed against the next prompt and
-    // false-fails it (issue #825); when only one materializes the debt merely
-    // absorbs one future idle.
+    // A steered active turn (see Turn.steeredEchoes) settles "cancelled" in the
+    // consumer at the interrupt's trailing idle, like any live turn. But the
+    // steer lane pays for its last result's trailer by settling on it, which
+    // this cancel pre-empts, so count that trailer here or it arrives un-owed
+    // against the next prompt and false-fails it (issue #825). Over-counting
+    // when only one trailer comes absorbs a future idle.
     if (isSteering(session.activeTurn) && session.activeTurn.steeredSettle !== undefined) {
       session.owedTrailingIdles++;
     }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -361,6 +361,37 @@ type Turn = {
    *  pre-hold behavior (pending wakes are not countable: notifications can
    *  batch into one followup). */
   deferredSettle?: PromptResponse;
+  /** Present once `steer()` has injected a message into this turn; holds the
+   *  uuids of injected messages the SDK has not replayed back yet.
+   *
+   *  Steering is delivered at {@link STEER_PRIORITY} (`now`), which makes the
+   *  CLI ABORT the cycle that is running. The aborted cycle is finalized with an
+   *  ordinary human-origin `result` — indistinguishable from a turn's terminal
+   *  one — and the steered message then runs as a SECOND cycle. Settling at that
+   *  first result answers `session/prompt` while the steered work is still
+   *  streaming, leaving the turn's remaining tool calls and its actual answer to
+   *  arrive out-of-turn. So from the injection on, a steered turn's results only
+   *  RECORD their outcome (`steeredSettle`) and the turn settles at the SDK's
+   *  `idle` — its authoritative turn-over signal, and the only one that spans
+   *  both cycles (observed on CLI 2.1.220: one idle after the steered cycle's
+   *  result, none between the cycles).
+   *
+   *  The set is what distinguishes "the steered work is still ahead" from "it
+   *  has run": the CLI replays an injected message when it picks it up, which is
+   *  AFTER the interrupted cycle's result. A non-empty set at an idle therefore
+   *  means the steered cycle hasn't started — the idle belongs to the cycle the
+   *  steer interrupted, or to a turn that ended before the steer landed — so it
+   *  is swallowed rather than settling the turn. Drained by the replay handler.
+   *
+   *  Accepted residual: an injected message the CLI drops without replaying
+   *  leaves the turn parked until `session/cancel` or the next prompt (both
+   *  settle it, as with the subagent hold above). */
+  steeredEchoes?: Set<string>;
+  /** The outcome recorded by the most recent result of a steered turn (see
+   *  `steeredEchoes`) — what the turn settles with once its steered work has
+   *  run. Later cycles overwrite it, so the last result wins and its usage
+   *  snapshot covers every cycle the turn ran. */
+  steeredSettle?: PromptResponse;
   resolve: (response: PromptResponse) => void;
   reject: (error: unknown) => void;
 };
@@ -687,6 +718,14 @@ function isHeldOpen(
   turn: Turn | null | undefined,
 ): turn is Turn & { deferredSettle: PromptResponse } {
   return turn != null && turn.deferredSettle !== undefined && !turn.settled;
+}
+
+/** Whether a steering message has been injected into this turn, which moves its
+ *  settlement off the next result and onto the SDK's `idle` (see
+ *  Turn.steeredEchoes for why a result no longer ends such a turn). The single
+ *  spelling of the steer predicate, shared by the consumer's settle lanes. */
+function isSteering(turn: Turn | null | undefined): turn is Turn & { steeredEchoes: Set<string> } {
+  return turn != null && turn.steeredEchoes !== undefined && !turn.settled;
 }
 
 /** Disarm the force-cancel backstop (see Session.forceCancelTimer). Every
@@ -1884,6 +1923,12 @@ export class ClaudeAcpAgent {
    *  calls). The steered message's own output streams via `session/update`, not
    *  this response.
    *
+   *  Pre-empting means ABORTING: the interrupted cycle is finalized with a
+   *  `result` of its own and the steered message runs as a second cycle, so the
+   *  steered turn is marked (`Turn.steeredEchoes`) and its settlement moves from
+   *  the next result to the SDK's `idle`. Without that the turn would answer at
+   *  the interrupt and its real answer would stream out-of-turn.
+   *
    *  When the session is idle, the opt-in path returns `promptRequired` WITHOUT
    *  calling `prompt()`, pushing SDK input, or mutating `turnQueue`: the content
    *  stays Host-owned so the Host can submit it through a standard
@@ -1904,7 +1949,7 @@ export class ClaudeAcpAgent {
     // which is exactly the window in which steering is meaningful. This check
     // and the active-path push below stay in one synchronous section so the
     // turn cannot settle in the gap between deciding to inject and enqueueing.
-    const turnInFlight = (session.turnQueue ?? []).some((turn) => !turn.settled);
+    const turnInFlight = (session.turnQueue ?? []).find((turn) => !turn.settled);
     if (!turnInFlight) {
       const promptRequest: PromptRequest = {
         sessionId,
@@ -1929,10 +1974,25 @@ export class ClaudeAcpAgent {
       prompt: params.prompt,
     };
     const userMessage = promptToClaude(promptRequest);
-    userMessage.uuid = randomUUID();
+    const steeredUuid = randomUUID();
+    userMessage.uuid = steeredUuid;
     // Deliver into the running turn rather than queuing behind it as a fresh
     // prompt would.
     userMessage.priority = STEER_PRIORITY;
+    // Hand the turn's settlement to the idle lane before the push, in the same
+    // synchronous section as the in-flight check: the interrupt this push
+    // triggers can have the CLI finalizing the aborted cycle by the time the
+    // consumer next runs, and a result reaching it unmarked would settle the
+    // turn (see Turn.steeredEchoes).
+    (turnInFlight.steeredEchoes ??= new Set()).add(steeredUuid);
+    // A turn already held for its background subagents has a recorded outcome
+    // the steer supersedes: carry it into the steer lane so one lane owns the
+    // settlement, and the hold is re-applied when the steered work is done (the
+    // idle handler routes back through the subagent gate).
+    if (turnInFlight.deferredSettle !== undefined) {
+      turnInFlight.steeredSettle = turnInFlight.deferredSettle;
+      turnInFlight.deferredSettle = undefined;
+    }
     session.input.push(userMessage);
     return { outcome: "injected" };
   }
@@ -2263,6 +2323,15 @@ export class ClaudeAcpAgent {
      *  calling settleActive directly bypasses the hold and re-opens the
      *  out-of-turn permission deadlock (issue #866) through its lane. */
     const settleOrDefer = (outcome: PromptResponse) => {
+      // A steer injected into this turn aborted the cycle whose result this may
+      // be, and the steered message runs as another one — so no result ends a
+      // steered turn. Record the outcome and let the idle lane settle with it
+      // (see Turn.steeredEchoes); later cycles overwrite it, so the turn settles
+      // with its last result and a usage snapshot covering all of them.
+      if (isSteering(session.activeTurn)) {
+        session.activeTurn.steeredSettle = outcome;
+        return;
+      }
       if (
         session.activeTurn &&
         !session.activeTurn.settled &&
@@ -2752,7 +2821,41 @@ export class ClaudeAcpAgent {
                     // this lagged idle (no active turn to settle): the idle
                     // still belongs to that settled turn, and skipping the
                     // decrement would leak the debt permanently.
+                    // Deliberately BEFORE the steer lane below: a lagged idle
+                    // owed by an earlier turn carries no identity of its own,
+                    // and reading it as the steered sequence's turn-over signal
+                    // would settle a turn whose steered cycle is still running.
+                    // A steered turn's own results owe nothing (see the result
+                    // handler), so its idle reaches the lane below.
                     session.owedTrailingIdles--;
+                  } else if (isSteering(session.activeTurn)) {
+                    // A turn a steer was injected into settles here rather than
+                    // at a result: the steer aborted the running cycle, so the
+                    // idle is the only signal that spans the interrupted cycle
+                    // AND the steered one (see Turn.steeredEchoes).
+                    //
+                    // An idle that arrives before the steered message is replayed
+                    // — or before any result was recorded — is swallowed instead:
+                    // the steered cycle hasn't started (this idle belongs to the
+                    // cycle the steer interrupted, or to a turn that had already
+                    // finished when the steer landed), so the answer is still
+                    // ahead. Such idles must never reach the #825 fail below,
+                    // which would reject a prompt that is about to answer.
+                    //
+                    // Typed as the plain Turn so the fields can be cleared below;
+                    // isSteering's guard narrows steeredEchoes to non-optional.
+                    const steered: Turn = session.activeTurn;
+                    if (steered.steeredEchoes?.size === 0 && steered.steeredSettle !== undefined) {
+                      // Hand the recorded outcome to the subagent gate rather
+                      // than settling directly: a steered turn can also have
+                      // spawned background subagents, and they own the turn from
+                      // here (the gate settles now when none is live, holds
+                      // otherwise).
+                      steered.deferredSettle = steered.steeredSettle;
+                      steered.steeredEchoes = undefined;
+                      steered.steeredSettle = undefined;
+                      settleDeferredIfDrained();
+                    }
                   } else if (
                     !session.cancelled &&
                     session.activeTurn &&
@@ -3201,7 +3304,18 @@ export class ClaudeAcpAgent {
               // turn's OWN result — a followup result arriving inside the
               // cancel window still gets its own trailer and must be counted,
               // or that idle would later false-fail the next prompt.
-              if (isAutonomousResult || !session.cancelled || !session.activeTurn) {
+              // A second exclusion: a steered turn's own results (see
+              // Turn.steeredEchoes). The cycle a steer aborted gets no trailing
+              // idle at all — the CLI emits one idle for the whole interrupted +
+              // steered sequence — and that single idle is what settles the turn,
+              // so counting either cycle's result would leave a debt that
+              // swallows the idle the settle needs. Autonomous results landing
+              // inside a steered turn keep their own trailers.
+              const owesTrailingIdle = isAutonomousResult || !isSteering(session.activeTurn);
+              if (
+                owesTrailingIdle &&
+                (isAutonomousResult || !session.cancelled || !session.activeTurn)
+              ) {
                 session.owedTrailingIdles++;
               }
 
@@ -3654,6 +3768,27 @@ export class ClaudeAcpAgent {
                       // either. Its trailing-idle debt stands and is absorbed
                       // when the drain idle eventually arrives.
                       settleActive(session.activeTurn.deferredSettle);
+                    } else if (
+                      isSteering(session.activeTurn) &&
+                      session.activeTurn.steeredSettle !== undefined
+                    ) {
+                      // Same for a turn whose steer is still open (see
+                      // Turn.steeredEchoes): the user moving on outranks the
+                      // steered continuation, but the stop reason its last
+                      // result recorded stands. With no result recorded yet it
+                      // falls through to the end_turn hand-off below, as an
+                      // unsteered turn would (and nothing is owed there: no
+                      // result means no trailer).
+                      //
+                      // That recorded result owes a trailing idle nobody
+                      // counted — the steer lane pays for its idles by settling
+                      // on them, and this hand-off settles instead. Count it
+                      // here or that idle would arrive un-owed against the
+                      // freshly activated turn and false-fail it (issue #825).
+                      // Benign when the trailer never comes (the interrupted
+                      // cycle emits none): the debt absorbs one future idle.
+                      session.owedTrailingIdles++;
+                      settleActive(session.activeTurn.steeredSettle);
                     } else {
                       settleActive({ stopReason: "end_turn", usage: sessionUsage(session) });
                     }
@@ -3670,6 +3805,14 @@ export class ClaudeAcpAgent {
                 break;
               }
               if ("isReplay" in message && message.isReplay) {
+                // A steered message's echo matches no turn (steer() creates
+                // none), but it is the signal that the CLI has picked the
+                // message up and the steered cycle is running — which is what
+                // lets the idle lane tell "the answer is still ahead" from "the
+                // turn is over" (see Turn.steeredEchoes).
+                if (isSteering(session.activeTurn)) {
+                  session.activeTurn.steeredEchoes.delete(message.uuid);
+                }
                 // Unrelated replay (e.g. the echo of an already-settled turn).
                 break;
               }
@@ -4145,6 +4288,18 @@ export class ClaudeAcpAgent {
         }
         active.resolve({ stopReason: "cancelled", usage: active.deferredSettle.usage });
       }
+    }
+
+    // A steered active turn (see Turn.steeredEchoes) is left to the consumer's
+    // cancelled-settle at the interrupt's trailing idle, like any live turn. But
+    // its last result's own trailer was deliberately left uncounted — the steer
+    // lane pays for its idles by settling on them, which this cancel pre-empts —
+    // so two trailers can be in flight where that settle consumes only one.
+    // Count the other, or it arrives un-owed against the next prompt and
+    // false-fails it (issue #825); when only one materializes the debt merely
+    // absorbs one future idle.
+    if (isSteering(session.activeTurn) && session.activeTurn.steeredSettle !== undefined) {
+      session.owedTrailingIdles++;
     }
 
     // Arm a backstop before interrupting: if a turn is actively consuming the

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -10029,6 +10029,96 @@ describe("turn steering (_session/steering)", () => {
     expect(JSON.stringify(injected.message.content)).toContain("also handle X");
   });
 
+  // A steer does not join the running cycle — it ABORTS it: the CLI interrupts
+  // the in-flight query as soon as a queued message carries priority 'now'. The
+  // interrupted cycle therefore ends with an ordinary human-origin `result`, and
+  // the steered message runs as a SECOND cycle. Treating that first result as
+  // the turn's terminal one answers session/prompt mid-work: the client is told
+  // `end_turn`, then keeps receiving the turn's remaining tool calls and its
+  // actual answer as updates belonging to no turn.
+  it("keeps the turn open across the interrupt its own steer caused", async () => {
+    // One ordered record of what the client saw, so "the response came before
+    // the output it was supposed to cover" is a plain assertion rather than a
+    // timing dance.
+    const timeline: string[] = [];
+    const client = {
+      sessionUpdate: async (notification: any) => {
+        if (notification.update?.sessionUpdate === "agent_message_chunk") {
+          timeline.push(notification.update.content?.text);
+        }
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+
+    /** The result the CLI emits for the cycle the steer aborted. `origin.kind`
+     *  "human" is not one of AUTONOMOUS_RESULT_ORIGINS, so it reaches the
+     *  user-turn lifecycle. Which subtype an abort picks is the CLI's business
+     *  and nothing here depends on it: every non-error subtype maps to
+     *  `end_turn`, the stop reason clients actually observe. */
+    const interruptedCycleResult = () => ({
+      ...createResultMessage(),
+      origin: { kind: "human" },
+    });
+    const idle = () => ({ type: "system", subtype: "session_state_changed", state: "idle" });
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn becomes active
+        yield createAssistantText("working on it");
+        // The steered message is pushed at priority 'now'...
+        const steered = await iter.next();
+        // ...so the CLI aborts the query: the interrupted cycle ends with a
+        // result of its own, followed by that cycle's trailing idle.
+        yield interruptedCycleResult();
+        yield idle();
+        // Only now does the steered message run, as a second cycle. Its echo
+        // matches no queued turn (dropped as an unrelated replay), its output is
+        // the answer the user is waiting for, and its result is the one that
+        // genuinely ends the turn.
+        yield userEcho(steered.value);
+        yield createAssistantText("STEERED-OK");
+        yield createResultMessage();
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent
+      .prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "start" }] })
+      .then((response) => {
+        timeline.push(`prompt:${response.stopReason}`);
+        return response;
+      });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    await expect(
+      agent.steer({ sessionId: "test-session", prompt: [{ type: "text", text: "also handle X" }] }),
+    ).resolves.toEqual({ outcome: "injected" });
+
+    const response = await turn;
+    // Drain the rest of the stream so the timeline is complete either way —
+    // when the turn settles early, the steered output arrives after `response`.
+    await agent.sessions["test-session"]?.consumer;
+
+    // The steered continuation is part of the turn the client is waiting on, so
+    // all of it precedes that turn's response. A `prompt:` entry anywhere but
+    // last is the bug: updates outlived the stopReason.
+    expect(timeline).toEqual(["working on it", "STEERED-OK", "prompt:end_turn"]);
+    // Both cycles ran for this one prompt, so its usage covers both (2 × the
+    // mock result's 10 in / 5 out) rather than stopping at the interrupt.
+    expect(response.usage).toEqual({
+      inputTokens: 20,
+      outputTokens: 10,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+      totalTokens: 30,
+    });
+    // Still exactly one response for one prompt, and nothing left behind.
+    expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
+  });
+
   it("always injects at 'now' priority, ignoring any client-supplied priority", async () => {
     const agent = createMockAgent();
     const captured: any[] = [];

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -9835,11 +9835,10 @@ describe("turn steering (_session/steering)", () => {
   }
 
   /** The `result` the CLI emits for the cycle a priority:'now' steer aborted, as
-   *  observed on CLI 2.1.220: `origin.kind` "human" (not one of
-   *  AUTONOMOUS_RESULT_ORIGINS, so it reaches the user-turn lifecycle) and
-   *  `stop_reason` "tool_use" — the abort landed on a pending tool call. Nothing
-   *  in these tests depends on the subtype or stop reason: every non-error
-   *  combination maps to `end_turn`, the stop reason clients actually observe. */
+   *  observed on CLI 2.1.220: `origin.kind` "human" (not autonomous, so it
+   *  reaches the user-turn lifecycle) and `stop_reason` "tool_use" — the abort
+   *  landed on a pending tool call. No test here depends on either: every
+   *  non-error combination maps to the `end_turn` clients observe. */
   function interruptedCycleResult() {
     return { ...createResultMessage(), stop_reason: "tool_use", origin: { kind: "human" } };
   }
@@ -9849,8 +9848,7 @@ describe("turn steering (_session/steering)", () => {
     return { type: "system", subtype: "session_state_changed", state: "idle" };
   }
 
-  /** Records every `agent_message_chunk` a client observed.
-   **/
+  /** Records every `agent_message_chunk` the client observes. */
   function timelineClient(timeline: string[]) {
     return {
       sessionUpdate: async (notification: any) => {
@@ -10058,11 +10056,11 @@ describe("turn steering (_session/steering)", () => {
 
   // A steer does not join the running cycle — it ABORTS it: the CLI interrupts
   // the in-flight query as soon as a queued message carries priority 'now'. The
-  // interrupted cycle therefore ends with an ordinary human-origin `result`, and
-  // the steered message runs as a SECOND cycle. Treating that first result as
-  // the turn's terminal one answers session/prompt mid-work: the client is told
-  // `end_turn`, then keeps receiving the turn's remaining tool calls and its
-  // actual answer as updates belonging to no turn.
+  // interrupted cycle ends with an ordinary human-origin `result` and the
+  // steered message runs as a SECOND cycle. Treating that first result as
+  // terminal answers session/prompt mid-work: the client is told `end_turn`,
+  // then keeps receiving the turn's remaining tool calls and its actual answer
+  // as updates belonging to no turn.
   it("keeps the turn open across the interrupt its own steer caused", async () => {
     const timeline: string[] = [];
     const agent = new ClaudeAcpAgent(timelineClient(timeline), {
@@ -10079,13 +10077,13 @@ describe("turn steering (_session/steering)", () => {
         // The steered message is pushed at priority 'now'...
         const steered = await iter.next();
         // ...so the CLI aborts the query, ending the interrupted cycle with a
-        // result of its own. No idle follows it: the CLI emits one for the whole
-        // interrupted + steered sequence, at the very end.
+        // result of its own. No idle follows it: one comes at the very end, for
+        // the whole interrupted + steered sequence.
         yield interruptedCycleResult();
         // Only now does the steered message run, as a second cycle. Its echo
         // matches no queued turn (dropped as an unrelated replay), its output is
-        // the answer the user is waiting for, and its result is the last word on
-        // the turn's stop reason.
+        // the answer the user is waiting for, and its result has the last word
+        // on the turn's stop reason.
         yield userEcho(steered.value);
         yield createAssistantText("STEERED-OK");
         yield createResultMessage();
@@ -10107,11 +10105,11 @@ describe("turn steering (_session/steering)", () => {
     ).resolves.toEqual({ outcome: "injected" });
 
     const response = await turn;
-    // Drain the rest of the stream so the timeline is complete either way —
-    // when the turn settles early, the steered output arrives after `response`.
+    // Drain the rest of the stream so the timeline is complete either way — on
+    // an early settle the steered output arrives after `response`.
     await agent.sessions["test-session"]?.consumer;
 
-    // The steered continuation is part of the turn the client is waiting on, so
+    // The steered continuation belongs to the turn the client is waiting on, so
     // all of it precedes that turn's response. A `prompt:` entry anywhere but
     // last is the bug: updates outlived the stopReason.
     expect(timeline).toEqual(["working on it", "STEERED-OK", "prompt:end_turn"]);
@@ -10128,11 +10126,11 @@ describe("turn steering (_session/steering)", () => {
     expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
   });
 
-  // The other steer ordering: the cycle had already finished on its own when the
-  // steer landed, so nothing was aborted and the interrupted cycle's result IS a
-  // natural one — followed by its own idle, before the steered message is picked
-  // up. Settling on that idle would answer the prompt with the steered work still
-  // ahead, so the turn waits for the steered message's echo (Turn.steeredEchoes).
+  // The other steer ordering: the cycle had already finished when the steer
+  // landed, so nothing was aborted and its result is a natural one — followed by
+  // its own idle, before the steered message is picked up. Settling on that idle
+  // would answer the prompt with the steered work still ahead, so the turn waits
+  // for the steered message's echo (Turn.steeredEchoes).
   it("does not settle a steered turn at an idle that precedes the steered echo", async () => {
     const timeline: string[] = [];
     const agent = new ClaudeAcpAgent(timelineClient(timeline), {
@@ -10180,9 +10178,9 @@ describe("turn steering (_session/steering)", () => {
     expect(agent.sessions["test-session"].owedTrailingIdles).toBe(0);
   });
 
-  // A steer must not be able to hold a prompt hostage: the next prompt's echo
-  // hands the steered turn off, and — like the subagent hold — it reports the
-  // stop reason its last result recorded rather than a guessed one.
+  // A steer must not hold a prompt hostage: the next prompt's echo hands the
+  // steered turn off, reporting — like the subagent hold — the stop reason its
+  // last result recorded rather than a guessed one.
   it("hands a steered turn off to the next prompt with its recorded outcome", async () => {
     const timeline: string[] = [];
     const agent = new ClaudeAcpAgent(timelineClient(timeline), {
@@ -10198,8 +10196,8 @@ describe("turn steering (_session/steering)", () => {
         yield createAssistantText("working on it");
         await iter.next(); // the steered message, which this CLI never replays
         yield interruptedCycleResult();
-        // The user moves on instead: the second prompt's echo arrives while the
-        // steered turn is still open.
+        // The user moves on: the second prompt's echo arrives while the steered
+        // turn is still open.
         const second = await iter.next();
         yield userEcho(second.value);
         yield createAssistantText("second turn");
@@ -10246,10 +10244,10 @@ describe("turn steering (_session/steering)", () => {
   });
 
   // Cancelling a steered turn answers "cancelled" through the normal lane, but
-  // its last result's trailing idle was deliberately left uncounted (the steer
-  // lane pays for its idles by settling on them, which the cancel pre-empted).
-  // That idle can lag past the next prompt's echo, where an un-owed idle reads as
-  // "the SDK went idle without a result" and false-fails a healthy prompt (#825).
+  // its last result's trailing idle went uncounted (the steer lane pays for its
+  // idles by settling on them, which the cancel pre-empted). That idle can lag
+  // past the next prompt's echo, where an un-owed idle reads as "the SDK went
+  // idle without a result" and false-fails a healthy prompt (#825).
   it("cancels a steered turn without false-failing the next prompt", async () => {
     const agent = createMockAgent();
     let releaseAfterCancel = () => {};

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -9834,6 +9834,33 @@ describe("turn steering (_session/steering)", () => {
     };
   }
 
+  /** The `result` the CLI emits for the cycle a priority:'now' steer aborted, as
+   *  observed on CLI 2.1.220: `origin.kind` "human" (not one of
+   *  AUTONOMOUS_RESULT_ORIGINS, so it reaches the user-turn lifecycle) and
+   *  `stop_reason` "tool_use" — the abort landed on a pending tool call. Nothing
+   *  in these tests depends on the subtype or stop reason: every non-error
+   *  combination maps to `end_turn`, the stop reason clients actually observe. */
+  function interruptedCycleResult() {
+    return { ...createResultMessage(), stop_reason: "tool_use", origin: { kind: "human" } };
+  }
+
+  /** The SDK's authoritative turn-over signal. */
+  function idleMessage() {
+    return { type: "system", subtype: "session_state_changed", state: "idle" };
+  }
+
+  /** Records every `agent_message_chunk` a client observed.
+   **/
+  function timelineClient(timeline: string[]) {
+    return {
+      sessionUpdate: async (notification: any) => {
+        if (notification.update?.sessionUpdate === "agent_message_chunk") {
+          timeline.push(notification.update.content?.text);
+        }
+      },
+    } as unknown as AcpClient;
+  }
+
   const waitFor = async (cond: () => boolean) => {
     for (let i = 0; i < 200; i++) {
       if (cond()) return;
@@ -10037,29 +10064,11 @@ describe("turn steering (_session/steering)", () => {
   // `end_turn`, then keeps receiving the turn's remaining tool calls and its
   // actual answer as updates belonging to no turn.
   it("keeps the turn open across the interrupt its own steer caused", async () => {
-    // One ordered record of what the client saw, so "the response came before
-    // the output it was supposed to cover" is a plain assertion rather than a
-    // timing dance.
     const timeline: string[] = [];
-    const client = {
-      sessionUpdate: async (notification: any) => {
-        if (notification.update?.sessionUpdate === "agent_message_chunk") {
-          timeline.push(notification.update.content?.text);
-        }
-      },
-    } as unknown as AcpClient;
-    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
-
-    /** The result the CLI emits for the cycle the steer aborted. `origin.kind`
-     *  "human" is not one of AUTONOMOUS_RESULT_ORIGINS, so it reaches the
-     *  user-turn lifecycle. Which subtype an abort picks is the CLI's business
-     *  and nothing here depends on it: every non-error subtype maps to
-     *  `end_turn`, the stop reason clients actually observe. */
-    const interruptedCycleResult = () => ({
-      ...createResultMessage(),
-      origin: { kind: "human" },
+    const agent = new ClaudeAcpAgent(timelineClient(timeline), {
+      log: () => {},
+      error: () => {},
     });
-    const idle = () => ({ type: "system", subtype: "session_state_changed", state: "idle" });
 
     injectGeneratorSession(agent, (input) => {
       async function* messageGenerator() {
@@ -10069,18 +10078,18 @@ describe("turn steering (_session/steering)", () => {
         yield createAssistantText("working on it");
         // The steered message is pushed at priority 'now'...
         const steered = await iter.next();
-        // ...so the CLI aborts the query: the interrupted cycle ends with a
-        // result of its own, followed by that cycle's trailing idle.
+        // ...so the CLI aborts the query, ending the interrupted cycle with a
+        // result of its own. No idle follows it: the CLI emits one for the whole
+        // interrupted + steered sequence, at the very end.
         yield interruptedCycleResult();
-        yield idle();
         // Only now does the steered message run, as a second cycle. Its echo
         // matches no queued turn (dropped as an unrelated replay), its output is
-        // the answer the user is waiting for, and its result is the one that
-        // genuinely ends the turn.
+        // the answer the user is waiting for, and its result is the last word on
+        // the turn's stop reason.
         yield userEcho(steered.value);
         yield createAssistantText("STEERED-OK");
         yield createResultMessage();
-        yield idle();
+        yield idleMessage();
       }
       return messageGenerator();
     });
@@ -10117,6 +10126,177 @@ describe("turn steering (_session/steering)", () => {
     });
     // Still exactly one response for one prompt, and nothing left behind.
     expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
+  });
+
+  // The other steer ordering: the cycle had already finished on its own when the
+  // steer landed, so nothing was aborted and the interrupted cycle's result IS a
+  // natural one — followed by its own idle, before the steered message is picked
+  // up. Settling on that idle would answer the prompt with the steered work still
+  // ahead, so the turn waits for the steered message's echo (Turn.steeredEchoes).
+  it("does not settle a steered turn at an idle that precedes the steered echo", async () => {
+    const timeline: string[] = [];
+    const agent = new ClaudeAcpAgent(timelineClient(timeline), {
+      log: () => {},
+      error: () => {},
+    });
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield createAssistantText("working on it");
+        const steered = await iter.next();
+        // The cycle ends and goes idle before the steered message is dequeued.
+        yield interruptedCycleResult();
+        yield idleMessage();
+        // Then the steered message runs as its own cycle.
+        yield userEcho(steered.value);
+        yield createAssistantText("STEERED-OK");
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent
+      .prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "start" }] })
+      .then((response) => {
+        timeline.push(`prompt:${response.stopReason}`);
+        return response;
+      });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "also handle X" }],
+    });
+
+    await turn;
+    await agent.sessions["test-session"]?.consumer;
+
+    expect(timeline).toEqual(["working on it", "STEERED-OK", "prompt:end_turn"]);
+    // The swallowed idle must not leave a phantom debt that would absorb a later
+    // turn's trailing idle (and blind the issue-#825 detector).
+    expect(agent.sessions["test-session"].owedTrailingIdles).toBe(0);
+  });
+
+  // A steer must not be able to hold a prompt hostage: the next prompt's echo
+  // hands the steered turn off, and — like the subagent hold — it reports the
+  // stop reason its last result recorded rather than a guessed one.
+  it("hands a steered turn off to the next prompt with its recorded outcome", async () => {
+    const timeline: string[] = [];
+    const agent = new ClaudeAcpAgent(timelineClient(timeline), {
+      log: () => {},
+      error: () => {},
+    });
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield createAssistantText("working on it");
+        await iter.next(); // the steered message, which this CLI never replays
+        yield interruptedCycleResult();
+        // The user moves on instead: the second prompt's echo arrives while the
+        // steered turn is still open.
+        const second = await iter.next();
+        yield userEcho(second.value);
+        yield createAssistantText("second turn");
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent
+      .prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "start" }] })
+      .then((response) => {
+        timeline.push(`first:${response.stopReason}`);
+        return response;
+      });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "also handle X" }],
+    });
+
+    const second = agent
+      .prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "next" }] })
+      .then((response) => {
+        timeline.push(`second:${response.stopReason}`);
+        return response;
+      });
+
+    const firstResponse = await first;
+    await second;
+    await agent.sessions["test-session"]?.consumer;
+
+    // The steered turn ends at the hand-off — before the new turn's output — and
+    // carries the interrupted cycle's own usage, not the next turn's.
+    expect(timeline).toEqual(["working on it", "first:end_turn", "second turn", "second:end_turn"]);
+    expect(firstResponse.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+      totalTokens: 15,
+    });
+    expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
+  });
+
+  // Cancelling a steered turn answers "cancelled" through the normal lane, but
+  // its last result's trailing idle was deliberately left uncounted (the steer
+  // lane pays for its idles by settling on them, which the cancel pre-empted).
+  // That idle can lag past the next prompt's echo, where an un-owed idle reads as
+  // "the SDK went idle without a result" and false-fails a healthy prompt (#825).
+  it("cancels a steered turn without false-failing the next prompt", async () => {
+    const agent = createMockAgent();
+    let releaseAfterCancel = () => {};
+    const afterCancel = new Promise<void>((resolve) => (releaseAfterCancel = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield createAssistantText("working on it");
+        await iter.next(); // the steered message
+        yield interruptedCycleResult();
+        await afterCancel;
+        yield idleMessage(); // the interrupt's trailer: settles the turn "cancelled"
+        const second = await iter.next();
+        yield userEcho(second.value); // activates the next turn, clears `cancelled`
+        yield idleMessage(); // the steered result's lagged trailer — must be absorbed
+        yield createAssistantText("second turn");
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    await agent.steer({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "also handle X" }],
+    });
+    // The interrupted cycle's result has been recorded on the turn (not settled).
+    await waitFor(() => agent.sessions["test-session"]?.activeTurn?.steeredSettle !== undefined);
+
+    await agent.cancel({ sessionId: "test-session" });
+    releaseAfterCancel();
+
+    await expect(first).resolves.toEqual(expect.objectContaining({ stopReason: "cancelled" }));
+    // The next prompt runs to completion instead of being rejected by the #825
+    // detector when the steered turn's lagged idle lands.
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "next" }] }),
+    ).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    expect(agent.sessions["test-session"].owedTrailingIdles).toBe(0);
   });
 
   it("always injects at 'now' priority, ignoring any client-supplied priority", async () => {


### PR DESCRIPTION
Steering is delivered at priority `now`, which makes the CLI **abort** the running cycle instead of folding the message into it. The aborted cycle ends with an ordinary human-origin `result`, so we answered `session/prompt` with `end_turn` while the steered work was still going — its remaining tool calls, its answer, and its file edits then streamed with no turn in flight.

A steered turn's results now only record their outcome, and the turn settles at the SDK's `idle` — the only signal spanning both the interrupted and the steered cycle. The injected message's replay tells them apart: an idle arriving before it means the steered cycle hasn't started, so it is swallowed. `session/cancel` and the next prompt still settle the turn early, with the recorded stop reason.

Four steering tests cover the interrupt, an early idle, the next-prompt hand-off, and cancel.
