### PR TITLE
feat: preserve message timestamps during replay

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -4578,6 +4578,9 @@ export class ClaudeAcpAgent {
       supportsSubagentTranscript(this.clientCapabilities);
 
     for (const message of messages) {
+      const persistedTimestamp = (message as unknown as { timestamp?: unknown }).timestamp;
+      const replayTimestamp =
+        typeof persistedTimestamp === "string" ? persistedTimestamp : undefined;
       // Backfill the ACP messageId -> SDK uuid mapping for messages we didn't
       // observe live (resumed/loaded sessions), so rewind/resume can translate
       // a client-supplied id without an extra getSessionMessages read. Not read
@@ -4625,6 +4628,15 @@ export class ClaudeAcpAgent {
           parentToolUseId,
         },
       )) {
+        if (replayTimestamp) {
+          notification.update._meta = {
+            ...notification.update._meta,
+            claudeCode: {
+              ...(notification.update._meta?.claudeCode || {}),
+              timestamp: replayTimestamp,
+            },
+          };
+        }
         await this.client.sessionUpdate(notification);
       }
     }

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1638,6 +1638,48 @@ describe("synthetic login message (issue #863)", () => {
   });
 });
 
+describe("replay timestamps", () => {
+  it("forwards a persisted message timestamp on every replayed update", async () => {
+    const updates: SessionNotification[] = [];
+    const client = {
+      sessionUpdate: async (update: SessionNotification) => updates.push(update),
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "a1",
+        timestamp: "2026-08-05T18:42:13.456Z",
+        session_id: "s1",
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          id: "api-message",
+          model: "claude-sonnet-4-5",
+          role: "assistant",
+          type: "message",
+          stop_reason: "tool_use",
+          content: [
+            { type: "text", text: "Checking" },
+            { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "pwd" } },
+          ],
+        },
+      },
+    ] as unknown as Awaited<ReturnType<typeof getSessionMessages>>);
+
+    await (
+      agent as unknown as { replaySessionHistory(sessionId: string): Promise<void> }
+    ).replaySessionHistory("s1");
+
+    expect(updates.length).toBeGreaterThan(0);
+    for (const { update } of updates) {
+      expect(update._meta?.claudeCode).toMatchObject({
+        timestamp: "2026-08-05T18:42:13.456Z",
+      });
+    }
+  });
+});
+
 describe("subagent transcript replay", () => {
   const replayHistory = [
     {


### PR DESCRIPTION
[Matt's AI] Session history replay currently drops persisted message timestamps, so ACP clients cannot reconstruct when transcript content happened. This forwards the SDK timestamp on every update generated from a stored message.

- Namespaces the timestamp under Claude Code metadata on message and tool-call updates
- Preserves existing metadata and omits the field when older SDK data has no timestamp