### PR TITLE
fix: preserve task plans across prompts

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -122,11 +122,14 @@ import {
 import { SettingsManager } from "./settings.js";
 import {
   applyTaskCreate,
+  applyTaskList,
   applyTaskUpdate,
   ClaudePlanEntry,
   createPostToolUseHook,
   createTaskHook,
   parseTaskCreateOutput,
+  parseTaskListOutput,
+  parseTaskUpdateOutput,
   planEntries,
   registerHookCallback,
   TaskState,
@@ -1893,6 +1896,10 @@ export class ClaudeAcpAgent {
       throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
 
+    if (Array.from(session.taskState.values()).some((task) => task.status !== "completed")) {
+      await this.publishTaskPlan(params.sessionId, session.taskState);
+    }
+
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -1951,6 +1958,16 @@ export class ClaudeAcpAgent {
       update: {
         sessionUpdate: "session_info_update",
         _meta: { goal },
+      },
+    });
+  }
+
+  private async publishTaskPlan(sessionId: string, taskState: TaskState): Promise<void> {
+    await this.client.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "plan",
+        entries: taskStateToPlanEntries(taskState),
       },
     });
   }
@@ -4184,13 +4201,18 @@ export class ClaudeAcpAgent {
             }
             break;
           }
-          // `conversation_reset` (from `/clear`, plan-mode exit, fresh-session
-          // flows) is safe to drop: turn lifecycle here is driven by
-          // results/idle, and the client owns its own transcript view.
+          case "conversation_reset": {
+            // The SDK has switched to a fresh conversation, whose Task* IDs
+            // and task store are independent of the previous transcript.
+            // Clear both the in-memory snapshot and the client's visible plan
+            // before any follow-up prompt can republish stale tasks.
+            session.taskState.clear();
+            await this.publishTaskPlan(params.sessionId, session.taskState);
+            break;
+          }
           case "tool_use_summary":
           case "auth_status":
           case "prompt_suggestion":
-          case "conversation_reset":
             break;
           default:
             unreachable(message, this.logger);
@@ -5832,15 +5854,7 @@ export class ClaudeAcpAgent {
             hooks: [
               createTaskHook({
                 taskState,
-                onChange: async () => {
-                  await this.client.sessionUpdate({
-                    sessionId,
-                    update: {
-                      sessionUpdate: "plan",
-                      entries: taskStateToPlanEntries(taskState),
-                    },
-                  });
-                },
+                onChange: () => this.publishTaskPlan(sessionId, taskState),
               }),
             ],
           },
@@ -5851,15 +5865,7 @@ export class ClaudeAcpAgent {
             hooks: [
               createTaskHook({
                 taskState,
-                onChange: async () => {
-                  await this.client.sessionUpdate({
-                    sessionId,
-                    update: {
-                      sessionUpdate: "plan",
-                      entries: taskStateToPlanEntries(taskState),
-                    },
-                  });
-                },
+                onChange: () => this.publishTaskPlan(sessionId, taskState),
               }),
             ],
           },
@@ -7702,23 +7708,44 @@ export function toAcpNotifications(
 
         if (isTaskTool(toolUse.name)) {
           // Headless/SDK sessions emit Task* tools instead of TodoWrite.
-          // TaskCreate / TaskUpdate mutate the accumulated task list; TaskList
-          // and TaskGet are read-only so we just suppress their tool_call /
-          // tool_result events. The plan update is emitted as a snapshot of
-          // the accumulated state, mirroring the legacy TodoWrite behavior.
+          // TaskCreate / TaskUpdate mutate the accumulated task list. TaskList
+          // reconciles it from the SDK's authoritative snapshot, which repairs
+          // resumed or compacted sessions whose creating calls are no longer in
+          // replay history. TaskGet is read-only and remains suppressed. Plan
+          // updates always carry the full accumulated snapshot, mirroring the
+          // legacy TodoWrite behavior.
           const isError = "is_error" in chunk && chunk.is_error;
+          let shouldEmitTaskPlan = false;
           if (!isError) {
             if (toolUse.name === "TaskCreate") {
               applyTaskCreate(
                 taskState,
                 toolUse.input as Parameters<typeof applyTaskCreate>[1],
-                parseTaskCreateOutput(chunk.content),
+                parseTaskCreateOutput(toolUseResult) ?? parseTaskCreateOutput(chunk.content),
               );
+              shouldEmitTaskPlan = true;
             } else if (toolUse.name === "TaskUpdate") {
-              applyTaskUpdate(taskState, toolUse.input as Parameters<typeof applyTaskUpdate>[1]);
+              const input = toolUse.input as Parameters<typeof applyTaskUpdate>[1];
+              const output =
+                parseTaskUpdateOutput(toolUseResult, input?.taskId) ??
+                parseTaskUpdateOutput(chunk.content, input?.taskId);
+              // Older CLI transcripts have no structured output, so retain the
+              // input-based fallback. When an output is available, only apply a
+              // confirmed update for the same task.
+              if (!output || (output.success && output.taskId === input?.taskId)) {
+                applyTaskUpdate(taskState, input);
+                shouldEmitTaskPlan = true;
+              }
+            } else if (toolUse.name === "TaskList") {
+              const output =
+                parseTaskListOutput(toolUseResult) ?? parseTaskListOutput(chunk.content);
+              if (output) {
+                applyTaskList(taskState, output);
+                shouldEmitTaskPlan = true;
+              }
             }
           }
-          if (!isError && (toolUse.name === "TaskCreate" || toolUse.name === "TaskUpdate")) {
+          if (shouldEmitTaskPlan) {
             update = {
               sessionUpdate: "plan",
               entries: taskStateToPlanEntries(taskState),

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -195,6 +195,150 @@ function injectGeneratorSession(
   return input;
 }
 
+describe("task plan lifecycle", () => {
+  function setup(
+    taskState: Map<string, any>,
+    makeGenerator: (input: Pushable<any>) => AsyncGenerator<any> = successfulPrompt,
+  ) {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: SessionNotification) => {
+          updates.push(notification);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    injectGeneratorSession(agent, makeGenerator, { taskState });
+    return { agent, updates };
+  }
+
+  function successfulResult() {
+    return {
+      type: "result",
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+      result: "",
+      errors: [],
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+  }
+
+  async function* successfulPrompt(input: Pushable<any>) {
+    const iter = input[Symbol.asyncIterator]();
+    const { value: userMessage } = await iter.next();
+    yield userEcho(userMessage);
+    yield successfulResult();
+  }
+
+  it("republishes the session task snapshot when a follow-up prompt starts", async () => {
+    const { agent, updates } = setup(
+      new Map([
+        [
+          "task-1",
+          {
+            subject: "Run tests",
+            status: "in_progress",
+            activeForm: "Running tests",
+          },
+        ],
+        ["task-2", { subject: "Write release notes", status: "pending" }],
+      ]),
+    );
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "Continue" }],
+    });
+
+    expect(updates.filter((notification) => notification.update.sessionUpdate === "plan")).toEqual([
+      {
+        sessionId: "test-session",
+        update: {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Running tests", status: "in_progress", priority: "medium" },
+            { content: "Write release notes", status: "pending", priority: "medium" },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("does not republish a completed plan on an unrelated follow-up", async () => {
+    const { agent, updates } = setup(
+      new Map([["task-1", { subject: "Run tests", status: "completed" }]]),
+    );
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "Start something else" }],
+    });
+
+    expect(updates.filter((notification) => notification.update.sessionUpdate === "plan")).toEqual(
+      [],
+    );
+  });
+
+  it("clears the task plan on a conversation reset", async () => {
+    const taskState = new Map([["task-1", { subject: "Run tests", status: "in_progress" }]]);
+    const { agent, updates } = setup(taskState, async function* (input) {
+      const iter = input[Symbol.asyncIterator]();
+      const first = await iter.next();
+      yield userEcho(first.value);
+      yield {
+        type: "conversation_reset",
+        new_conversation_id: randomUUID(),
+        uuid: randomUUID(),
+        session_id: "test-session",
+      };
+      yield successfulResult();
+
+      const second = await iter.next();
+      yield userEcho(second.value);
+      yield successfulResult();
+    });
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/clear" }],
+    });
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "Start fresh" }],
+    });
+
+    expect(taskState.size).toBe(0);
+    expect(updates.filter((notification) => notification.update.sessionUpdate === "plan")).toEqual([
+      {
+        sessionId: "test-session",
+        update: {
+          sessionUpdate: "plan",
+          entries: [{ content: "Run tests", status: "in_progress", priority: "medium" }],
+        },
+      },
+      {
+        sessionId: "test-session",
+        update: { sessionUpdate: "plan", entries: [] },
+      },
+    ]);
+  });
+});
+
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration", () => {
   let child: ReturnType<typeof spawn>;
 
@@ -1006,7 +1150,7 @@ describe("tool conversions", () => {
           sessionUpdate: "plan",
           entries: [
             {
-              content: "Analyze existing test coverage and identify gaps",
+              content: "Analyzing existing test coverage",
               priority: "medium",
               status: "in_progress",
             },

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -18,8 +18,10 @@ import {
   toolInfoFromToolUse,
   planEntries,
   applyTaskCreate,
+  applyTaskList,
   applyTaskUpdate,
   parseTaskCreateOutput,
+  parseTaskListOutput,
   taskStateToPlanEntries,
   TaskState,
 } from "../tools.js";
@@ -1817,6 +1819,14 @@ describe("planEntries - undefined input regression", () => {
       { content: "Task 2", status: "completed", priority: "medium" },
     ]);
   });
+
+  it("uses activeForm while a todo is in progress", () => {
+    expect(
+      planEntries({
+        todos: [{ content: "Run tests", status: "in_progress", activeForm: "Running tests" }],
+      }),
+    ).toEqual([{ content: "Running tests", status: "in_progress", priority: "medium" }]);
+  });
 });
 
 describe("toAcpNotifications - TodoWrite with undefined input regression", () => {
@@ -1884,6 +1894,20 @@ describe("parseTaskCreateOutput", () => {
     expect(parsed).toEqual({ task: { id: "2", subject: "Y" } });
   });
 
+  it("continues past unrelated JSON blocks", () => {
+    const parsed = parseTaskCreateOutput([
+      { type: "text", text: JSON.stringify({ metadata: "unrelated" }) },
+      { type: "text", text: JSON.stringify({ task: { id: "2", subject: "Y" } }) },
+    ]);
+    expect(parsed).toEqual({ task: { id: "2", subject: "Y" } });
+  });
+
+  it("parses the human-readable TaskCreate format used in session history", () => {
+    expect(parseTaskCreateOutput("Task #42 created successfully: Run tests")).toEqual({
+      task: { id: "42", subject: "Run tests" },
+    });
+  });
+
   it("returns undefined for non-JSON content", () => {
     expect(parseTaskCreateOutput("not json")).toBeUndefined();
     expect(parseTaskCreateOutput([{ type: "text", text: "not json" }])).toBeUndefined();
@@ -1918,11 +1942,15 @@ describe("applyTaskCreate / applyTaskUpdate", () => {
 
   it("updates fields by task ID and keeps insertion order in plan entries", () => {
     const state: TaskState = new Map();
-    applyTaskCreate(state, { subject: "A", description: "" }, { task: { id: "1", subject: "A" } });
+    applyTaskCreate(
+      state,
+      { subject: "A", description: "", activeForm: "Working on A" },
+      { task: { id: "1", subject: "A" } },
+    );
     applyTaskCreate(state, { subject: "B", description: "" }, { task: { id: "2", subject: "B" } });
     applyTaskUpdate(state, { taskId: "1", status: "in_progress" });
     expect(taskStateToPlanEntries(state)).toEqual([
-      { content: "A", status: "in_progress", priority: "medium" },
+      { content: "Working on A", status: "in_progress", priority: "medium" },
       { content: "B", status: "pending", priority: "medium" },
     ]);
   });
@@ -1951,6 +1979,84 @@ describe("applyTaskCreate / applyTaskUpdate", () => {
     // Without a subject we'd render an empty-content plan entry, so the
     // update is dropped instead of synthesizing a blank placeholder.
     expect(state.has("5")).toBe(false);
+  });
+
+  it("rebuilds task state from TaskList while preserving richer local fields", () => {
+    const state: TaskState = new Map([
+      [
+        "1",
+        {
+          subject: "Old subject",
+          status: "pending",
+          activeForm: "Running the task",
+          description: "Details",
+        },
+      ],
+      ["deleted", { subject: "Stale", status: "pending" }],
+    ]);
+    const output = parseTaskListOutput(
+      JSON.stringify({
+        tasks: [
+          { id: "1", subject: "Current subject", status: "in_progress", blockedBy: [] },
+          { id: "2", subject: "New task", status: "pending", blockedBy: [] },
+        ],
+      }),
+    );
+
+    expect(output).toBeDefined();
+    applyTaskList(state, output!);
+
+    expect([...state.entries()]).toEqual([
+      [
+        "1",
+        {
+          subject: "Current subject",
+          status: "in_progress",
+          activeForm: "Running the task",
+          description: "Details",
+        },
+      ],
+      [
+        "2",
+        {
+          subject: "New task",
+          status: "pending",
+          activeForm: undefined,
+          description: undefined,
+        },
+      ],
+    ]);
+  });
+
+  it("finds a TaskList snapshot after an unrelated JSON block", () => {
+    expect(
+      parseTaskListOutput([
+        { type: "text", text: JSON.stringify({ metadata: "unrelated" }) },
+        {
+          type: "text",
+          text: JSON.stringify({
+            tasks: [{ id: "1", subject: "Recovered", status: "pending", blockedBy: [] }],
+          }),
+        },
+      ]),
+    ).toEqual({
+      tasks: [{ id: "1", subject: "Recovered", status: "pending", blockedBy: [] }],
+    });
+  });
+
+  it("parses the human-readable TaskList format used in session history", () => {
+    expect(
+      parseTaskListOutput(
+        "#1 [in_progress] Run tests\n#2 [pending] Write release notes [blocked by #1]",
+      ),
+    ).toEqual({
+      tasks: [
+        { id: "1", subject: "Run tests", status: "in_progress", blockedBy: [] },
+        { id: "2", subject: "Write release notes", status: "pending", blockedBy: ["1"] },
+      ],
+    });
+
+    expect(parseTaskListOutput("No tasks found")).toEqual({ tasks: [] });
   });
 });
 
@@ -2112,10 +2218,9 @@ describe("toAcpNotifications - Task* tools", () => {
     });
   });
 
-  it("suppresses TaskList and TaskGet tool_result without touching task state", () => {
+  it("uses the structured TaskList result as an authoritative plan snapshot", () => {
     const toolUseCache: ToolUseCache = {
       "list-1": { type: "tool_use", id: "list-1", name: "TaskList", input: {} },
-      "get-1": { type: "tool_use", id: "get-1", name: "TaskGet", input: { taskId: "1" } },
     };
     const taskState: TaskState = new Map([
       ["1", { subject: "Existing", status: "in_progress" as const }],
@@ -2123,8 +2228,93 @@ describe("toAcpNotifications - Task* tools", () => {
 
     const notifications = toAcpNotifications(
       [
-        { type: "tool_result", tool_use_id: "list-1", content: "...", is_error: false },
-        { type: "tool_result", tool_use_id: "get-1", content: "...", is_error: false },
+        {
+          type: "tool_result",
+          tool_use_id: "list-1",
+          content: "#2 [pending] Recovered",
+          is_error: false,
+        },
+      ] as any,
+      "user",
+      "test-session",
+      toolUseCache,
+      mockClient,
+      mockLogger,
+      {
+        taskState,
+        toolUseResult: {
+          tasks: [{ id: "2", subject: "Recovered", status: "pending", blockedBy: [] }],
+        },
+      },
+    );
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].update).toMatchObject({
+      sessionUpdate: "plan",
+      entries: [{ content: "Recovered", status: "pending", priority: "medium" }],
+    });
+    expect([...taskState.keys()]).toEqual(["2"]);
+  });
+
+  it("does not apply a logically failed TaskUpdate", () => {
+    const toolUseCache: ToolUseCache = {
+      "update-1": {
+        type: "tool_use",
+        id: "update-1",
+        name: "TaskUpdate",
+        input: { taskId: "1", status: "completed" },
+      },
+    };
+    const taskState: TaskState = new Map([["1", { subject: "Existing", status: "pending" }]]);
+
+    const notifications = toAcpNotifications(
+      [
+        {
+          type: "tool_result",
+          tool_use_id: "update-1",
+          content: "Task #1 not found",
+          is_error: false,
+        },
+      ] as any,
+      "user",
+      "test-session",
+      toolUseCache,
+      mockClient,
+      mockLogger,
+      {
+        taskState,
+        toolUseResult: {
+          success: false,
+          taskId: "1",
+          updatedFields: [],
+          error: "Task not found",
+        },
+      },
+    );
+
+    expect(notifications).toHaveLength(0);
+    expect(taskState.get("1")).toEqual({ subject: "Existing", status: "pending" });
+  });
+
+  it("does not apply a replayed TaskUpdate failure without structured output", () => {
+    const toolUseCache: ToolUseCache = {
+      "update-1": {
+        type: "tool_use",
+        id: "update-1",
+        name: "TaskUpdate",
+        input: { taskId: "1", status: "completed" },
+      },
+    };
+    const taskState: TaskState = new Map([["1", { subject: "Existing", status: "pending" }]]);
+
+    const notifications = toAcpNotifications(
+      [
+        {
+          type: "tool_result",
+          tool_use_id: "update-1",
+          content: "Task #1 not found",
+          is_error: false,
+        },
       ] as any,
       "user",
       "test-session",
@@ -2135,7 +2325,7 @@ describe("toAcpNotifications - Task* tools", () => {
     );
 
     expect(notifications).toHaveLength(0);
-    expect(taskState.get("1")).toEqual({ subject: "Existing", status: "in_progress" });
+    expect(taskState.get("1")).toEqual({ subject: "Existing", status: "pending" });
   });
 
   it("does not apply TaskCreate/TaskUpdate when the tool_result reports an error", () => {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -21,7 +21,9 @@ import {
   ReportFindingsInput,
   TaskCreateInput,
   TaskCreateOutput,
+  TaskListOutput,
   TaskUpdateInput,
+  TaskUpdateOutput,
   TodoWriteInput,
   WebFetchInput,
   WebSearchInput,
@@ -1030,7 +1032,7 @@ export type ClaudePlanEntry = {
 
 export function planEntries(input: { todos: ClaudePlanEntry[] } | undefined): PlanEntry[] {
   return (input?.todos ?? []).map((todo) => ({
-    content: todo.content,
+    content: todo.status === "in_progress" && todo.activeForm ? todo.activeForm : todo.content,
     status: todo.status,
     priority: "medium",
   }));
@@ -1052,30 +1054,28 @@ export type TaskEntry = {
 export type TaskState = Map<string, TaskEntry>;
 
 /**
- * Best-effort parse of a TaskCreate tool_result content into the structured
- * TaskCreateOutput. The SDK delivers tool outputs either as a string or as
- * an array of TextBlockParam-like blocks containing JSON text; try both.
+ * Best-effort parse of a structured Task* tool_result. The SDK delivers tool
+ * outputs either as a string or as an array of TextBlockParam-like blocks
+ * containing JSON text; try both.
  */
-export function parseTaskCreateOutput(content: unknown): TaskCreateOutput | undefined {
-  const tryParse = (text: string): TaskCreateOutput | undefined => {
+function parseJsonToolOutput<T>(
+  content: unknown,
+  isExpectedOutput: (value: unknown) => value is T,
+): T | undefined {
+  const tryParse = (text: string): T | undefined => {
     try {
-      const parsed = JSON.parse(text);
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        parsed.task &&
-        typeof parsed.task.id === "string"
-      ) {
-        return parsed as TaskCreateOutput;
-      }
+      const parsed: unknown = JSON.parse(text);
+      return isExpectedOutput(parsed) ? parsed : undefined;
     } catch {
-      // ignore
+      return undefined;
     }
-    return undefined;
   };
 
   if (typeof content === "string") {
     return tryParse(content);
+  }
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    return isExpectedOutput(content) ? content : undefined;
   }
   if (Array.isArray(content)) {
     for (const block of content) {
@@ -1086,6 +1086,119 @@ export function parseTaskCreateOutput(content: unknown): TaskCreateOutput | unde
           if (parsed) return parsed;
         }
       }
+    }
+  }
+  return undefined;
+}
+
+function toolOutputTexts(content: unknown): string[] {
+  if (typeof content === "string") return [content];
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block) =>
+    block &&
+    typeof block === "object" &&
+    "type" in block &&
+    block.type === "text" &&
+    "text" in block &&
+    typeof block.text === "string"
+      ? [block.text]
+      : [],
+  );
+}
+
+export function parseTaskCreateOutput(content: unknown): TaskCreateOutput | undefined {
+  const structured = parseJsonToolOutput(content, (parsed): parsed is TaskCreateOutput =>
+    Boolean(
+      parsed &&
+      typeof parsed === "object" &&
+      "task" in parsed &&
+      parsed.task &&
+      typeof parsed.task === "object" &&
+      "id" in parsed.task &&
+      typeof parsed.task.id === "string",
+    ),
+  );
+  if (structured) return structured;
+
+  for (const text of toolOutputTexts(content)) {
+    const match = /^Task #(\S+) created successfully: (.+)$/.exec(text.trim());
+    if (match) return { task: { id: match[1], subject: match[2] } };
+  }
+  return undefined;
+}
+
+export function parseTaskListOutput(content: unknown): TaskListOutput | undefined {
+  const validStatuses = new Set(["pending", "in_progress", "completed"]);
+  const structured = parseJsonToolOutput(content, (parsed): parsed is TaskListOutput =>
+    Boolean(
+      parsed &&
+      typeof parsed === "object" &&
+      "tasks" in parsed &&
+      Array.isArray(parsed.tasks) &&
+      parsed.tasks.every(
+        (task) =>
+          task &&
+          typeof task === "object" &&
+          typeof task.id === "string" &&
+          typeof task.subject === "string" &&
+          typeof task.status === "string" &&
+          validStatuses.has(task.status),
+      ),
+    ),
+  );
+  if (structured) return structured;
+
+  for (const text of toolOutputTexts(content)) {
+    if (text.trim() === "No tasks found") return { tasks: [] };
+
+    const tasks: TaskListOutput["tasks"] = [];
+    const lines = text.trim().split("\n");
+    for (const line of lines) {
+      const match =
+        /^#(\S+) \[(pending|in_progress|completed)\] (.+?)(?: \(([^()]*)\))?(?: \[blocked by ((?:#[^,\]]+(?:, )?)+)\])?$/.exec(
+          line,
+        );
+      if (!match) {
+        tasks.length = 0;
+        break;
+      }
+      tasks.push({
+        id: match[1],
+        subject: match[3],
+        status: match[2] as TaskListOutput["tasks"][number]["status"],
+        ...(match[4] ? { owner: match[4] } : {}),
+        blockedBy: match[5] ? match[5].split(", ").map((id) => id.slice(1)) : [],
+      });
+    }
+    if (tasks.length > 0) return { tasks };
+  }
+  return undefined;
+}
+
+export function parseTaskUpdateOutput(
+  content: unknown,
+  expectedTaskId?: string,
+): TaskUpdateOutput | undefined {
+  const structured = parseJsonToolOutput(content, (parsed): parsed is TaskUpdateOutput =>
+    Boolean(
+      parsed &&
+      typeof parsed === "object" &&
+      "success" in parsed &&
+      typeof parsed.success === "boolean" &&
+      "taskId" in parsed &&
+      typeof parsed.taskId === "string" &&
+      "updatedFields" in parsed &&
+      Array.isArray(parsed.updatedFields) &&
+      parsed.updatedFields.every((field) => typeof field === "string"),
+    ),
+  );
+  if (structured) return structured;
+
+  for (const text of toolOutputTexts(content)) {
+    const notFound = /^Task #(\S+) not found$/.exec(text.trim());
+    const taskId = notFound?.[1] ?? expectedTaskId;
+    if (taskId && (notFound || text.trim() === "Failed to delete task")) {
+      return { success: false, taskId, updatedFields: [], error: text.trim() };
     }
   }
   return undefined;
@@ -1125,9 +1238,23 @@ export function applyTaskUpdate(state: TaskState, input: TaskUpdateInput | undef
   });
 }
 
+export function applyTaskList(state: TaskState, output: TaskListOutput): void {
+  const previous = new Map(state);
+  state.clear();
+  for (const task of output.tasks) {
+    const existing = previous.get(task.id);
+    state.set(task.id, {
+      subject: task.subject,
+      status: task.status,
+      activeForm: existing?.activeForm,
+      description: existing?.description,
+    });
+  }
+}
+
 export function taskStateToPlanEntries(state: TaskState): PlanEntry[] {
   return Array.from(state.values()).map((task) => ({
-    content: task.subject,
+    content: task.status === "in_progress" && task.activeForm ? task.activeForm : task.subject,
     status: task.status,
     priority: "medium",
   }));


### PR DESCRIPTION
## Summary

- republish unfinished Task* plan snapshots when a follow-up prompt starts
- avoid resurfacing fully completed historical plans on unrelated prompts
- clear stale task state when Claude starts a fresh conversation
- reconcile task state from authoritative TaskList results after resume or history compaction
- consume structured Task* outputs during live sessions and parse Claude Code textual output when replaying history
- reject logically failed TaskUpdate results instead of persisting the requested mutation
- keep scanning structured tool output past unrelated JSON blocks
- use Claude activeForm for in-progress TodoWrite and Task* entries

This keeps ACP clients from losing an unfinished task list at prompt boundaries, restores state when incremental history is unavailable, and prevents plans from leaking across conversation resets.

## Tests

- npm run test:run (713 passed, 20 skipped)
- npm run check
- npm run build
- git diff --check