### PR TITLE
fix: keep background subagents alive across a follow-up cancel

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -4803,10 +4803,12 @@ export class ClaudeAcpAgent {
     // trailer debt is absorbed by the idle handler when its idle does come.
     // The turn's own usage snapshot is reported per the cancelled-usage
     // contract (issue #844).
+    let settledHeldTurn = false;
     {
       const active = session.activeTurn;
       if (isHeldOpen(active)) {
         this.finishFileChangeAudit(session, active, "cancelled");
+        settledHeldTurn = true;
         active.settled = true;
         // Mirror settleActive's invariants (it is consumer-scoped and
         // unreachable from here): disarm the backstop — none should be
@@ -4851,6 +4853,47 @@ export class ClaudeAcpAgent {
     // when only one trailer comes absorbs a future idle.
     if (isSteering(session.activeTurn) && session.activeTurn.steeredSettle !== undefined) {
       session.owedTrailingIdles++;
+    }
+
+    // Nothing is left to interrupt: the turn settled just above was only
+    // PARKED for its background subagents — its result had already arrived and
+    // the CLI's trailer had fired — and no other turn is active or queued.
+    // Interrupting here would tear those subagents down to cancel work the
+    // model already finished.
+    //
+    // That is the shape a client produces on every FOLLOW-UP prompt, not just
+    // on an explicit cancel: Zed's `run_turn` cancels unconditionally before
+    // sending, and a held turn keeps `session/prompt` pending, so a session
+    // waiting on background subagents always reads as "still running". Without
+    // this skip the hold — which exists to keep subagent output inside the turn
+    // — makes every follow-up message kill the very subagents it serves, losing
+    // their work and the task notifications that would have reported it.
+    //
+    // Clearing the cancelled latch is part of the skip, not a detail: while it
+    // is set the consumer drops every incoming message and only `activateTurn`
+    // clears it, so leaving it set would swallow the surviving subagents'
+    // output anyway — and forever if no next prompt follows. Nothing is left
+    // latched for: the prompt was already answered "cancelled" above, and the
+    // session is quiescent.
+    //
+    // Subagents surviving a cancel matches how background SHELLS already
+    // behave: they never defer a turn (see `liveBackgroundTasks.isSubagent`),
+    // so no cancel has ever reached them. Both have the same wake-on-
+    // notification contract with the model rather than a turn-scoped one.
+    if (
+      settledHeldTurn &&
+      !session.activeTurn &&
+      orphanedTurns.length === 0 &&
+      (session.turnQueue?.length ?? 0) === 0 &&
+      // The one state in which the hold provably sits on a quiet SDK. Anything
+      // else means a cycle is genuinely running (or blocked on a permission
+      // request) and must still be interrupted. Same read as the trailer-debt
+      // decision above, which keeps the two branches complementary: this path
+      // never records a debt, and never produces the idle a debt would drain.
+      session.lastSessionState === "idle"
+    ) {
+      session.cancelled = false;
+      return;
     }
 
     // Arm a backstop before interrupting: if a turn is actively consuming the

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -11061,6 +11061,114 @@ describe("deferred settlement for live background subagents (issues #864/#866)",
     await agent.sessions["test-session"]?.consumer;
   });
 
+  it("keeps a hold's subagents alive across a cancel on a quiet session", async () => {
+    // A client cancels unconditionally before each prompt (Zed's run_turn
+    // does), and a held turn keeps session/prompt pending — so an ordinary
+    // FOLLOW-UP message reaches cancel() looking exactly like an abort.
+    // Interrupting there would tear down subagents whose results the model is
+    // still waiting on, and the notifications reporting their work would never
+    // arrive: the hold would kill the very subagents it exists to serve.
+    const { agent, events } = chunkCapturingAgent();
+    let releaseAfterCancel!: () => void;
+    const afterCancel = new Promise<void>((resolve) => (releaseAfterCancel = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const { value: userMessage } = await iter.next();
+        yield userEcho(userMessage);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // deferral point
+        yield idle(); // the turn's trailer: the SDK is quiet, the subagent is not
+        await afterCancel;
+        // The subagent survives the cancel and reports afterwards.
+        yield taskNotification("agent-1");
+        yield assistantText("post-cancel summary");
+        yield resultMessage({ origin: { kind: "task-notification" } });
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn?.deferredSettle);
+    await agent.cancel({ sessionId: "test-session" });
+
+    // The prompt is still answered per the ACP cancellation contract.
+    await expect(first).resolves.toEqual({
+      stopReason: "cancelled",
+      usage: expect.objectContaining({ totalTokens: 15 }),
+    });
+
+    const session = agent.sessions["test-session"];
+    // The hold sat on a quiet SDK — the only thing left to interrupt was the
+    // subagent, which is exactly what must survive.
+    expect(session.query.interrupt).not.toHaveBeenCalled();
+    // The latch makes the consumer drop every message it sees, so leaving it
+    // set would lose the surviving subagent's output just as surely.
+    expect(session.cancelled).toBe(false);
+
+    releaseAfterCancel();
+    await session.consumer;
+    // The whole point: work done after the cancel still reaches the client.
+    expect(events).toContain("chunk:post-cancel summary");
+    expect(session.liveBackgroundTasks.has("agent-1")).toBe(false);
+  });
+
+  it("still interrupts a cancel during a hold whose session is running", async () => {
+    // The skip is scoped to a provably quiet SDK. Once a subagent's
+    // notification wakes the model, the turn is still held but a cycle is
+    // genuinely in flight — a cancel must reach it, or an explicit abort
+    // during a followup would do nothing.
+    const agent = createMockAgent();
+    let releaseAfterCancel!: () => void;
+    const afterCancel = new Promise<void>((resolve) => (releaseAfterCancel = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const { value: userMessage } = await iter.next();
+        yield userEcho(userMessage);
+        yield running();
+        yield subagentStarted("agent-1");
+        yield resultMessage(); // deferral point
+        yield idle();
+        yield taskNotification("agent-1"); // the model wakes for the summary
+        yield running();
+        await afterCancel;
+        yield idle();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Both conditions in one wait: the turn's OWN result also runs through a
+    // "running" state, so waiting on them separately could latch on that one
+    // and race the trailing idle that follows it.
+    await waitFor(
+      () =>
+        !!agent.sessions["test-session"]?.activeTurn?.deferredSettle &&
+        agent.sessions["test-session"]?.lastSessionState === "running",
+    );
+    await agent.cancel({ sessionId: "test-session" });
+
+    await expect(first).resolves.toEqual({
+      stopReason: "cancelled",
+      usage: expect.objectContaining({ totalTokens: 15 }),
+    });
+    expect(agent.sessions["test-session"].query.interrupt).toHaveBeenCalled();
+
+    releaseAfterCancel();
+    await agent.sessions["test-session"]?.consumer;
+  });
+
   it("does not fail a held turn when a followup errors while another subagent is live", async () => {
     // A followup's is_error must never touch the user-turn lifecycle: the
     // held turn's own result recorded a success.


### PR DESCRIPTION
Implements the minimal fix (a) proposed in #976.

Since #870, a turn whose terminal result arrives while the background subagents it spawned are still live is held open, so its `session/prompt` stays pending. Clients that cancel before each prompt therefore reach `cancel()` on every ordinary follow-up message — Zed's `run_turn` cancels unconditionally whenever a turn appears to be running, and a held turn always does — and `query.interrupt()` tears down the very subagents the hold exists to serve. Their work is lost, and the `task_notification` that would have reported completion never fires.

This skips the interrupt in the one state where there is provably nothing to interrupt: the turn settled just above was only held open, no other turn is active, orphaned or queued, and the session's last consumed state is `idle`. Every other shape still interrupts exactly as before.

Clearing the `cancelled` latch is part of the skip rather than an aside: while it is set the consumer drops every incoming message and only `activateTurn` clears it, so leaving it set would swallow the surviving subagents' output anyway — and permanently if no further prompt follows.

The resulting behaviour matches how background *shells* already work: they never defer a turn, so no cancel has ever reached them.

Tests:

- `keeps a hold's subagents alive across a cancel on a quiet session`
- `still interrupts a cancel during a hold whose session is running`

Verified against Zed across a long orchestration session: background subagents now survive follow-up messages, and their completion notifications arrive. The structural option (b) in #976 — releasing the hold once the session goes idle — is intentionally not part of this PR.
