### PR TITLE
feat: add ai generated session title

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -62,7 +62,6 @@ import {
   EffortLevel,
   FastModeDisabledReason,
   FastModeState,
-  getSessionInfo,
   getSessionMessages,
   listSessions,
   McpServerConfig,
@@ -97,6 +96,7 @@ import {
   parseGoalRequest,
   toGoalSnapshot,
 } from "./goal-extension.js";
+import { sanitizeTitle, SessionTitles } from "./session-titles.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -175,20 +175,7 @@ export const CLAUDE_CONFIG_DIR =
 
 const execFileAsync = promisify(execFile);
 
-const MAX_TITLE_LENGTH = 256;
 const MAX_INLINE_FAILURE_TITLE_LENGTH = 256;
-
-function sanitizeTitle(text: string): string {
-  // Replace newlines and collapse whitespace
-  const sanitized = text
-    .replace(/[\r\n]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (sanitized.length <= MAX_TITLE_LENGTH) {
-    return sanitized;
-  }
-  return sanitized.slice(0, MAX_TITLE_LENGTH - 1) + "…";
-}
 
 /**
  * Logger interface for customizing logging output
@@ -438,7 +425,7 @@ type Turn = {
   completion?: Promise<void>;
 };
 
-type Session = {
+export type Session = {
   query: Query;
   input: Pushable<SDKUserMessage>;
   cancelled: boolean;
@@ -536,6 +523,8 @@ type Session = {
   /** Original ACP parameters used to recreate this query with a new provider. */
   creationParams?: NewSessionRequest;
   settingsManager: SettingsManager;
+  /** This session's title state and the turn-end logic that maintains it. */
+  titles: SessionTitles;
   accumulatedUsage: AccumulatedUsage;
   modes: SessionModeState;
   models: SessionModelState;
@@ -607,12 +596,6 @@ type Session = {
   /** Accumulated task list for the session, keyed by task ID. Task IDs are
    *  per-session, so this state must not be shared across sessions. */
   taskState: TaskState;
-  /** Last session title we pushed to the client via `session_info_update`.
-   *  The SDK auto-generates a title in a background task and persists it to the
-   *  session file; we poll it on each turn-end (`session_state_changed: idle`)
-   *  and only notify the client when it actually changes. Undefined until the
-   *  first title is observed. */
-  lastTitle?: string;
   /** Caches `tool_use` blocks by id so the matching `tool_result` can recover
    *  the tool name/input when mapping it to a `tool_call_update`. Per-session
    *  (tool_use ids are only unique within a session) and pruned at
@@ -1768,40 +1751,6 @@ export class ClaudeAcpAgent {
     };
   }
 
-  /** Read the SDK-maintained title for a session and, if it changed since the
-   *  last time we looked, notify the client with a `session_info_update`. The
-   *  SDK has no push event for the title it auto-generates in the background, so
-   *  we pull it at turn-end. A missing session file or read error is non-fatal:
-   *  the title is best-effort and another turn will retry. */
-  private async maybeUpdateSessionTitle(sessionId: string, session: Session): Promise<void> {
-    let info;
-    try {
-      info = await getSessionInfo(sessionId, { dir: session.cwd });
-    } catch (error) {
-      this.logger.error(`Session ${sessionId}: failed to read session info: ${error}`);
-      return;
-    }
-    // `customTitle` is a user-set `/rename`; `summary` is the auto-generated
-    // title (or first prompt). Prefer the explicit title when present.
-    const rawTitle = info?.customTitle ?? info?.summary;
-    if (!rawTitle) {
-      return;
-    }
-    const title = sanitizeTitle(rawTitle);
-    if (title === session.lastTitle) {
-      return;
-    }
-    session.lastTitle = title;
-    await this.client.sessionUpdate({
-      sessionId,
-      update: {
-        sessionUpdate: "session_info_update",
-        title,
-        updatedAt: new Date(info!.lastModified).toISOString(),
-      },
-    });
-  }
-
   async authenticate(_params: AuthenticateRequest): Promise<void> {
     if (_params.methodId === "gateway" || _params.methodId === "gateway-bedrock") {
       this.gatewayAuthRequest = _params as GatewayAuthRequest;
@@ -1995,6 +1944,8 @@ export class ClaudeAcpAgent {
       session.fileChangeReportRequestIds.add(fileChangeReportRequestId);
       fileChangeAudit = createFileChangeAuditTurnState(fileChangeReportRequestId);
     }
+
+    session.titles.onPrompt(params.prompt);
 
     // Each prompt is a Turn whose deferred the persistent consumer settles once
     // the turn's outcome is known. `prompt()` owns no loop: it enqueues the
@@ -2303,6 +2254,7 @@ export class ClaudeAcpAgent {
           { parentToolUseId?: string | null } | undefined;
         if (!claudeMeta?.parentToolUseId) {
           session.emittedAssistantText = true;
+          session.titles.onAssistantText(update.content);
         }
       }
       await this.client.sessionUpdate(notification);
@@ -3250,11 +3202,9 @@ export class ClaudeAcpAgent {
                       TURN_NO_RESULT_MESSAGE,
                     );
                   }
-                  // The SDK generates the session title in a background task and
-                  // persists it to the session file; `idle` is the turn-over
-                  // signal, so it's the point at which a new title may have
-                  // landed. Push it to the client if it changed.
-                  await this.maybeUpdateSessionTitle(params.sessionId, session);
+                  // Turn-over is when a title may have landed or become
+                  // generatable; see SessionTitles.onTurnEnd.
+                  await session.titles.onTurnEnd(session);
                 }
                 break;
               }
@@ -4602,6 +4552,10 @@ export class ClaudeAcpAgent {
             // before any follow-up prompt can republish stale tasks.
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
+            // A reset mounts a fresh transcript (`new_conversation_id`), so our
+            // cached title no longer describes the session: drop it and
+            // re-evaluate at the next turn-end.
+            session.titles.reset();
             break;
           }
           case "tool_use_summary":
@@ -6732,6 +6686,7 @@ export class ClaudeAcpAgent {
       sessionFingerprint: computeSessionFingerprint(params),
       creationParams: params,
       settingsManager,
+      titles: new SessionTitles(this, sessionId),
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,

--- a/src/session-titles.ts
+++ b/src/session-titles.ts
@@ -1,0 +1,256 @@
+/**
+ * AI-generated session titles.
+ *
+ * Claude Code's own auto-title generation never runs under the Agent SDK — the
+ * latch that arms it is pre-set in the headless path — so `SDKSessionInfo.summary`
+ * degrades to the raw first prompt. This module asks the CLI for a real title
+ * instead, via the `generate_session_title` control request, and publishes it
+ * over ACP as a `session_info_update`.
+ *
+ * {@link SessionTitles} holds the per-session state and is owned by `Session`.
+ * `acp-agent.ts` drives it from four places: {@link SessionTitles.onPrompt} and
+ * {@link SessionTitles.onAssistantText} to collect text,
+ * {@link SessionTitles.onTurnEnd} at `session_state_changed: idle`, and
+ * {@link SessionTitles.reset} on `conversation_reset`.
+ */
+
+import type { ContentBlock, PromptRequest } from "@agentclientprotocol/sdk";
+import { getSessionInfo, type Query, type SDKSessionInfo } from "@anthropic-ai/claude-agent-sdk";
+import type { ClaudeAcpAgent, Session } from "./acp-agent.js";
+
+const MAX_TITLE_LENGTH = 256;
+
+/** How much session text the title is generated from. The CLI caps its own
+ *  title input at the same 1000 trailing characters. */
+const MAX_TITLE_CONTEXT_LENGTH = 1000;
+
+/** Below this the generator returns null without calling the model, so there is
+ *  nothing to gain by asking yet. */
+const MIN_TITLE_CONTEXT_LENGTH = 10;
+
+/** `generateSessionTitle` is present on the SDK's runtime `Query` class but is
+ *  not declared in `sdk.d.ts` (0.3.220), so it is reached through this optional
+ *  shape rather than the published interface. */
+type TitleCapableQuery = Query & {
+  generateSessionTitle?: (
+    description: string,
+    options?: { persist?: boolean },
+  ) => Promise<string | null>;
+};
+
+/** A title already stored for the session, published when generation is
+ *  unavailable or yields nothing. */
+type TitleFallback = { title: string; lastModified: number };
+
+export function sanitizeTitle(text: string): string {
+  // Replace newlines and collapse whitespace
+  const sanitized = text
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (sanitized.length <= MAX_TITLE_LENGTH) {
+    return sanitized;
+  }
+  return sanitized.slice(0, MAX_TITLE_LENGTH - 1) + "…";
+}
+
+/** Rolling text a title is generated from: `previous` plus `text`, keeping only
+ *  the trailing {@link MAX_TITLE_CONTEXT_LENGTH} characters. */
+export function appendTitleContext(previous: string | undefined, text: string): string {
+  const next = (previous ?? "") + text;
+  return next.length > MAX_TITLE_CONTEXT_LENGTH ? next.slice(-MAX_TITLE_CONTEXT_LENGTH) : next;
+}
+
+/** Whether a prompt is worth titling a session after. The CLI's own auto-title
+ *  path skips slash commands, `!bash` lines and tagged system text; match it, or
+ *  sessions end up named "/compact". */
+function isTitleWorthyPrompt(text: string): boolean {
+  const trimmed = text.trim();
+  return trimmed.length > 0 && !/^[/!<]/.test(trimmed);
+}
+
+/** Whether this SDK still offers on-demand title generation. */
+function supportsTitleGeneration(query: Query): boolean {
+  return typeof (query as TitleCapableQuery).generateSessionTitle === "function";
+}
+
+/** One session's title: the text a generated title is derived from, whether a
+ *  title has been settled on, and the last one published. Created with the
+ *  session and reachable as `session.titles`. */
+export class SessionTitles {
+  /** Last title pushed to the client via `session_info_update`, so an unchanged
+   *  title is never re-notified. Undefined until the first push. */
+  private lastTitle?: string;
+
+  /** Rolling tail of this session's own user + assistant text, capped at
+   *  {@link MAX_TITLE_CONTEXT_LENGTH}. Dropped once a title exists. */
+  private context?: string;
+
+  /** Set once this session has a title or has asked for one. A title is
+   *  generated at most once per session: the SDK reports a generated title in
+   *  the same field as a user `/rename`, so re-titling could silently overwrite
+   *  one. Released by {@link reset}, and when generation yields nothing. */
+  private settled = false;
+
+  constructor(
+    private readonly agent: ClaudeAcpAgent,
+    private readonly sessionId: string,
+  ) {}
+
+  /** Collect a prompt's own text for the title, skipping openers not worth
+   *  titling after. No-op once the title is settled. */
+  onPrompt(prompt: PromptRequest["prompt"]): void {
+    if (this.settled) {
+      return;
+    }
+    const promptText = prompt
+      .flatMap((chunk) => (chunk.type === "text" ? [chunk.text] : []))
+      .join("\n");
+
+    if (isTitleWorthyPrompt(promptText)) {
+      this.context = appendTitleContext(this.context, `\n${promptText}\n`);
+    }
+  }
+
+  /** Collect the assistant's own answer for the title. Chunks are appended
+   *  verbatim so streamed text reassembles. No-op once the title is settled. */
+  onAssistantText(content: ContentBlock): void {
+    if (this.settled || content.type !== "text") {
+      return;
+    }
+    this.context = appendTitleContext(this.context, content.text);
+  }
+
+  /** Drop the title state so the next turn re-evaluates. Used on
+   *  `conversation_reset`, which mounts a fresh transcript. */
+  reset(): void {
+    this.settled = false;
+    this.context = undefined;
+    this.lastTitle = undefined;
+  }
+
+  /** Turn-end title handling. `idle` is the SDK's turn-over signal, so it is
+   *  when a title may have landed or become generatable.
+   *
+   *  `info.customTitle` is non-empty only once the session file holds a real
+   *  title — a user `/rename` or one generated earlier; the SDK folds both into
+   *  that one field. Adopt it and latch, so neither is ever titled over.
+   *
+   *  With no title yet, ask the SDK to generate one in the background: it is a
+   *  ~2s small-model call and turn-end must not wait on it. Only when that is
+   *  not possible do we fall back to `summary`, which for an SDK-driven session
+   *  is just the raw first prompt. */
+  async onTurnEnd(session: Session): Promise<void> {
+    const info = await this.readSessionInfo(session);
+
+    if (info?.customTitle) {
+      this.settled = true;
+      this.context = undefined;
+      await this.publish(info.customTitle, info.lastModified);
+      return;
+    }
+
+    const fallback = info?.summary
+      ? { title: info.summary, lastModified: info.lastModified }
+      : undefined;
+
+    if (this.canRequest(session)) {
+      this.settled = true;
+
+      void this.requestGenerateTitle(session, fallback).catch((error) => {
+        this.agent.logger.error(`Session ${this.sessionId}: session title update failed: ${error}`);
+      });
+
+      return;
+    }
+    // Only while this session has no title of its own: `summary` degrades to the
+    // raw first prompt, which must never overwrite a generated title if the
+    // persisted one is slow to show up in `info`.
+    if (fallback && !this.settled) {
+      await this.publish(fallback.title, fallback.lastModified);
+    }
+  }
+
+  /** Read the SDK's stored info for this session. A missing session file or read
+   *  error is non-fatal: the title is best-effort and another turn will retry. */
+  private async readSessionInfo(session: Session): Promise<SDKSessionInfo | undefined> {
+    try {
+      return await getSessionInfo(this.sessionId, { dir: session.cwd });
+    } catch (error) {
+      this.agent.logger.error(`Session ${this.sessionId}: failed to read session info: ${error}`);
+      return undefined;
+    }
+  }
+
+  /** Notify the client of a title, unless it is the one we last sent. */
+  private async publish(rawTitle: string, lastModified: number): Promise<void> {
+    const title = sanitizeTitle(rawTitle);
+    if (title === this.lastTitle) {
+      return;
+    }
+    this.lastTitle = title;
+    await this.agent.client.sessionUpdate({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "session_info_update",
+        title,
+        updatedAt: new Date(lastModified).toISOString(),
+      },
+    });
+  }
+
+  /** Whether to ask the SDK for a generated title now: once per session, on a
+   *  live query, with enough collected text for the generator to work with. */
+  private canRequest(session: Session): boolean {
+    if (this.settled || session.queryClosed || session.cancelled) {
+      return false;
+    }
+    if (!supportsTitleGeneration(session.query)) {
+      return false;
+    }
+    return (this.context?.trim().length ?? 0) >= MIN_TITLE_CONTEXT_LENGTH;
+  }
+
+  /** Generate a title from the session's own text and publish it. `persist`
+   *  writes it to the session file, which is what carries it into
+   *  `session/list` and `session/load`. A null or failed generation releases the
+   *  latch so a later turn retries, and publishes `fallback` (the stored
+   *  summary) so a backend that can't generate titles is no worse off than
+   *  before. */
+  private async requestGenerateTitle(
+    session: Session,
+    fallback: TitleFallback | undefined,
+  ): Promise<void> {
+    const description = this.context?.trim() ?? "";
+    let title: string | null = null;
+
+    try {
+      title =
+        (await (session.query as TitleCapableQuery).generateSessionTitle?.(description, {
+          persist: true,
+        })) ?? null;
+    } catch (error) {
+      this.agent.logger.error(
+        `Session ${this.sessionId}: failed to generate a session title: ${error}`,
+      );
+    }
+
+    // A session torn down or replaced while the title was in flight must not
+    // adopt it.
+    if (this.agent.sessions[this.sessionId] !== session) {
+      return;
+    }
+
+    if (!title) {
+      this.settled = false;
+
+      if (fallback) {
+        await this.publish(fallback.title, fallback.lastModified);
+      }
+      return;
+    }
+
+    this.context = undefined;
+    await this.publish(title, Date.now());
+  }
+}

--- a/src/session-titles.ts
+++ b/src/session-titles.ts
@@ -99,7 +99,7 @@ export class SessionTitles {
       .flatMap((chunk) => (chunk.type === "text" ? [chunk.text] : []))
       .join("\n");
 
-      this.context = appendTitleContext(this.context, `\n${promptText}\n`);
+    this.context = appendTitleContext(this.context, `\n${promptText}\n`);
   }
 
   /** Collect the assistant's own answer for the title. Chunks are appended

--- a/src/session-titles.ts
+++ b/src/session-titles.ts
@@ -61,14 +61,6 @@ export function appendTitleContext(previous: string | undefined, text: string): 
   return next.length > MAX_TITLE_CONTEXT_LENGTH ? next.slice(-MAX_TITLE_CONTEXT_LENGTH) : next;
 }
 
-/** Whether a prompt is worth titling a session after. The CLI's own auto-title
- *  path skips slash commands, `!bash` lines and tagged system text; match it, or
- *  sessions end up named "/compact". */
-function isTitleWorthyPrompt(text: string): boolean {
-  const trimmed = text.trim();
-  return trimmed.length > 0 && !/^[/!<]/.test(trimmed);
-}
-
 /** Whether this SDK still offers on-demand title generation. */
 function supportsTitleGeneration(query: Query): boolean {
   return typeof (query as TitleCapableQuery).generateSessionTitle === "function";
@@ -107,9 +99,7 @@ export class SessionTitles {
       .flatMap((chunk) => (chunk.type === "text" ? [chunk.text] : []))
       .join("\n");
 
-    if (isTitleWorthyPrompt(promptText)) {
       this.context = appendTitleContext(this.context, `\n${promptText}\n`);
-    }
   }
 
   /** Collect the assistant's own answer for the title. Chunks are appended

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -45,6 +45,7 @@ import {
   type SteerRequest,
   type StreamedToolInputCache,
 } from "../acp-agent.js";
+import { SessionTitles } from "../session-titles.js";
 import { Pushable } from "../utils.js";
 import {
   deleteSession,
@@ -55,6 +56,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "crypto";
 import { readFile } from "node:fs/promises";
+import { mockSessionState, userEcho, wrapQuery } from "./session-doubles.js";
 import {
   GOAL_CONTROL_METHOD,
   goalUpdateFromPrompt,
@@ -81,19 +83,6 @@ import type {
   BetaWebFetchToolResultBlockParam,
   BetaCodeExecutionToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
-
-/** Build the replayed `user` message the SDK echoes back for a pushed prompt,
- *  used by mock generators to promote a turn to active. */
-function userEcho(u: any) {
-  return {
-    type: "user",
-    message: u.message,
-    parent_tool_use_id: null,
-    uuid: u.uuid,
-    session_id: "test-session",
-    isReplay: true,
-  };
-}
 
 /** A `system`/init frame advertising the msg_lifecycle_v1 capability, so the
  *  consumer latches `session.msgLifecycleV1` and cancel() routes orphan
@@ -128,57 +117,6 @@ const cancelledTurnUsage = {
   cachedWriteTokens: 0,
   totalTokens: 0,
 };
-
-/** Wrap a mock async generator with the `Query` methods the agent calls outside
- *  of iteration — `close()` (teardown/closeQueryStream), `interrupt()` (cancel),
- *  and `setModel()` — so a bare generator doesn't trip "x is not a function". */
-function wrapQuery(generator: AsyncGenerator<any>) {
-  return Object.assign(generator, {
-    interrupt: vi.fn(async () => {}),
-    close: vi.fn(),
-    setModel: vi.fn(async () => {}),
-  }) as any;
-}
-
-/** The common `Session` mock fields, with per-test overrides spread on top.
- *  Centralizes the boilerplate (usage accumulator, caches, controllers) so a new
- *  Session field is added in one place rather than every inline literal. */
-function mockSessionState(overrides: Record<string, any> = {}) {
-  return {
-    cancelled: false,
-    cwd: "/test",
-    sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-    modes: { currentModeId: "default", availableModes: [] },
-    models: { currentModelId: "default", availableModels: [] },
-    modelInfos: [],
-    settingsManager: { dispose: vi.fn() },
-    accumulatedUsage: {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    },
-    configOptions: [],
-    agents: [],
-    currentAgent: "default",
-    abortController: new AbortController(),
-    emitRawSDKMessages: false,
-    forwardSubagentText: false,
-    contextWindowSize: 200000,
-    contextWindowAuthoritative: false,
-    providerCacheKey: "default",
-    taskState: new Map(),
-    toolUseCache: {},
-    emittedToolCalls: new Set(),
-    liveBackgroundTasks: new Map(),
-    emittedAssistantText: false,
-    owedTrailingIdles: 0,
-    messageIdToUuid: new Map(),
-    sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
-    fileChangeReportRequestIds: new Set(),
-    ...overrides,
-  } as any;
-}
 
 /** Install a mock session whose query is a caller-supplied async generator
  *  driven by the session's streaming input. Returns the input Pushable so the
@@ -4210,98 +4148,6 @@ describe("stop reason propagation", () => {
     expect(chunkTexts).toContain("between-turn background note");
   });
 
-  it("pushes a session_info_update when the SDK generates a title at turn-end", async () => {
-    const sessionUpdates: any[] = [];
-    const mockClient = {
-      sessionUpdate: async (u: any) => {
-        sessionUpdates.push(u);
-      },
-    } as unknown as AcpClient;
-    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
-
-    vi.mocked(getSessionInfo).mockResolvedValue({
-      sessionId: "test-session",
-      summary: "Fix the flaky title test",
-      lastModified: 1_700_000_000_000,
-    } as any);
-
-    const input = new Pushable<any>();
-    async function* messageGenerator() {
-      const iter = input[Symbol.asyncIterator]();
-      const { value: userMessage } = await iter.next();
-      yield userEcho(userMessage);
-      yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
-      yield { type: "system", subtype: "session_state_changed", state: "idle" };
-    }
-
-    agent.sessions["test-session"] = mockSessionState({
-      query: wrapQuery(messageGenerator()),
-      input,
-    });
-
-    await agent.prompt({
-      sessionId: "test-session",
-      prompt: [{ type: "text", text: "test" }],
-    });
-    await agent.sessions["test-session"]?.consumer;
-
-    const titleUpdate = sessionUpdates.find(
-      (u) => u.update?.sessionUpdate === "session_info_update",
-    );
-    expect(titleUpdate?.update).toEqual({
-      sessionUpdate: "session_info_update",
-      title: "Fix the flaky title test",
-      updatedAt: new Date(1_700_000_000_000).toISOString(),
-    });
-    expect(getSessionInfo).toHaveBeenCalledWith("test-session", { dir: "/test" });
-  });
-
-  it("does not re-push session_info_update when the title is unchanged", async () => {
-    const sessionUpdates: any[] = [];
-    const mockClient = {
-      sessionUpdate: async (u: any) => {
-        sessionUpdates.push(u);
-      },
-    } as unknown as AcpClient;
-    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
-
-    vi.mocked(getSessionInfo).mockResolvedValue({
-      sessionId: "test-session",
-      summary: "Stable title",
-      lastModified: 1_700_000_000_000,
-    } as any);
-
-    const input = new Pushable<any>();
-    async function* messageGenerator() {
-      const iter = input[Symbol.asyncIterator]();
-      // Two turns, each ending in idle, but the title never changes.
-      for (let i = 0; i < 2; i++) {
-        const { value: userMessage } = await iter.next();
-        yield userEcho(userMessage);
-        yield createResultMessage({
-          subtype: "success",
-          stop_reason: "end_turn",
-          is_error: false,
-        });
-        yield { type: "system", subtype: "session_state_changed", state: "idle" };
-      }
-    }
-
-    agent.sessions["test-session"] = mockSessionState({
-      query: wrapQuery(messageGenerator()),
-      input,
-    });
-
-    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "one" }] });
-    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "two" }] });
-    await agent.sessions["test-session"]?.consumer;
-
-    const titleUpdates = sessionUpdates.filter(
-      (u) => u.update?.sessionUpdate === "session_info_update",
-    );
-    expect(titleUpdates).toHaveLength(1);
-  });
-
   it("should throw internal error for success with is_error true and no max_tokens", async () => {
     const agent = createMockAgent();
     injectSession(agent, [
@@ -6030,6 +5876,7 @@ describe("session/close", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      titles: new SessionTitles(agent, sessionId),
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: {
@@ -6131,6 +5978,7 @@ describe("session/delete", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      titles: new SessionTitles(agent, sessionId),
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -6240,6 +6088,7 @@ describe("getOrCreateSession param change detection", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      titles: new SessionTitles(agent, sessionId),
       cwd,
       sessionFingerprint: JSON.stringify({
         cwd,
@@ -9103,6 +8952,7 @@ describe("post-error recovery", () => {
       query: gen as any,
       input,
       cancelled: false,
+      titles: new SessionTitles(agent, "test-session"),
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -12883,6 +12733,7 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       query: gen as any,
       input,
       cancelled: false,
+      titles: new SessionTitles(agent, "test-session"),
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -14321,6 +14172,7 @@ describe("agent selection config option", () => {
         query: gen as any,
         input: new Pushable(),
         cancelled: false,
+        titles: new SessionTitles(agent, sessionId),
         cwd: "/test",
         sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
         modes: { currentModeId: "default", availableModes: [] },

--- a/src/tests/session-doubles.ts
+++ b/src/tests/session-doubles.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared session-level test doubles for the agent suites.
+ *
+ * Distinct from `helpers.ts`, which is deliberately vitest-free so `vi.mock`
+ * factories can `await import` it; these need `vi.fn` spies, so they live apart.
+ */
+
+import { vi } from "vitest";
+import { randomUUID } from "crypto";
+import { SessionTitles } from "../session-titles.js";
+
+/** Stand-in agent for a `SessionTitles` whose test doesn't care about titles:
+ *  swallows the publish and the log, and never matches the identity check. */
+function inertTitleAgent() {
+  return {
+    client: { sessionUpdate: async () => {} },
+    logger: { error: () => {} },
+    sessions: {},
+  } as any;
+}
+
+/** Build the replayed `user` message the SDK echoes back for a pushed prompt,
+ *  used by mock generators to promote a turn to active. */
+export function userEcho(u: any) {
+  return {
+    type: "user",
+    message: u.message,
+    parent_tool_use_id: null,
+    uuid: u.uuid,
+    session_id: "test-session",
+    isReplay: true,
+  };
+}
+
+/** Wrap a mock async generator with the `Query` methods the agent calls outside
+ *  of iteration — `close()` (teardown/closeQueryStream), `interrupt()` (cancel),
+ *  and `setModel()` — so a bare generator doesn't trip "x is not a function". */
+export function wrapQuery(generator: AsyncGenerator<any>) {
+  return Object.assign(generator, {
+    interrupt: vi.fn(async () => {}),
+    close: vi.fn(),
+    setModel: vi.fn(async () => {}),
+  }) as any;
+}
+
+/** The common `Session` mock fields, with per-test overrides spread on top.
+ *  Centralizes the boilerplate (usage accumulator, caches, controllers) so a new
+ *  Session field is added in one place rather than every inline literal.
+ *
+ *  Pass `agent` when the test exercises titles — `SessionTitles` publishes and
+ *  logs through it, and compares `agent.sessions[sessionId]` to spot a session
+ *  replaced mid-generation. */
+export function mockSessionState(
+  overrides: Record<string, any> = {},
+  agent?: any,
+  sessionId = "test-session",
+) {
+  return {
+    cancelled: false,
+    cwd: "/test",
+    sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+    titles: new SessionTitles(agent ?? inertTitleAgent(), sessionId),
+    modes: { currentModeId: "default", availableModes: [] },
+    models: { currentModelId: "default", availableModels: [] },
+    modelInfos: [],
+    settingsManager: { dispose: vi.fn() },
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    configOptions: [],
+    agents: [],
+    currentAgent: "default",
+    abortController: new AbortController(),
+    emitRawSDKMessages: false,
+    forwardSubagentText: false,
+    contextWindowSize: 200000,
+    contextWindowAuthoritative: false,
+    providerCacheKey: "default",
+    taskState: new Map(),
+    toolUseCache: {},
+    emittedToolCalls: new Set(),
+    liveBackgroundTasks: new Map(),
+    emittedAssistantText: false,
+    owedTrailingIdles: 0,
+    messageIdToUuid: new Map(),
+    sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+    fileChangeReportRequestIds: new Set(),
+    ...overrides,
+  } as any;
+}
+
+/** One successful turn: echo the pushed prompt, emit a result, go idle. Shared
+ *  by suites that only need a session to reach turn-end. */
+export function successfulResultMessage(overrides: Record<string, any> = {}) {
+  return {
+    type: "result" as const,
+    subtype: "success",
+    stop_reason: "end_turn",
+    is_error: false,
+    result: "",
+    errors: [],
+    duration_ms: 0,
+    duration_api_ms: 0,
+    num_turns: 1,
+    total_cost_usd: 0,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: randomUUID(),
+    session_id: "test-session",
+    ...overrides,
+  };
+}

--- a/src/tests/session-titles.test.ts
+++ b/src/tests/session-titles.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { ClaudeAcpAgent, type AcpClient } from "../acp-agent.js";
+import { appendTitleContext } from "../session-titles.js";
+import { Pushable } from "../utils.js";
+import { getSessionInfo } from "@anthropic-ai/claude-agent-sdk";
+import {
+  mockSessionState,
+  successfulResultMessage,
+  userEcho,
+  wrapQuery,
+} from "./session-doubles.js";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
+  return { ...actual, getSessionInfo: vi.fn() };
+});
+
+describe("SDK title generation contract", () => {
+  // Smoke test for the one undeclared SDK method this feature rests on:
+  // `generateSessionTitle` is on the runtime `Query` class but absent from
+  // `sdk.d.ts`, so nothing else would catch its removal. Method names survive
+  // bundling (only module-scope identifiers get mangled), so an SDK upgrade that
+  // renames or drops it fails here instead of silently degrading titles back to
+  // raw prompts. Runs unconditionally — it reads the shipped bundle and never
+  // spawns the CLI.
+  it("SDK still ships generateSessionTitle and its control subtype", async () => {
+    const sdkEntry = createRequire(import.meta.url).resolve("@anthropic-ai/claude-agent-sdk");
+    const bundle = await readFile(sdkEntry, "utf8");
+    expect({
+      method: bundle.includes("async generateSessionTitle("),
+      subtype: bundle.includes('subtype:"generate_session_title"'),
+    }).toEqual({ method: true, subtype: true });
+  });
+
+  it("keeps only the trailing title context", () => {
+    expect(appendTitleContext("abc", "def")).toBe("abcdef");
+    expect(appendTitleContext(undefined, "abc")).toBe("abc");
+    const overflowed = appendTitleContext("x".repeat(1000), "tail");
+    expect(overflowed).toHaveLength(1000);
+    expect(overflowed.endsWith("tail")).toBe(true);
+  });
+});
+
+describe("session titles at turn-end", () => {
+  beforeEach(() => {
+    vi.mocked(getSessionInfo).mockReset();
+  });
+
+  /** Collect every `session_info_update` an agent pushes. */
+  function titleRecorder() {
+    const updates: any[] = [];
+    const client = {
+      sessionUpdate: async (u: any) => {
+        if (u.update?.sessionUpdate === "session_info_update") updates.push(u.update);
+      },
+    } as unknown as AcpClient;
+    return { client, titles: () => updates.map((u) => u.title) };
+  }
+
+  /** `wrapQuery` plus the undeclared `generateSessionTitle` the real `Query`
+   *  exposes, so turn-end takes the generate branch. */
+  function wrapTitleQuery(generator: AsyncGenerator<any>, title: string | null) {
+    const generateSessionTitle = vi.fn(async (_d: string, _o?: { persist?: boolean }) => title);
+    return {
+      query: Object.assign(wrapQuery(generator), { generateSessionTitle }),
+      generateSessionTitle,
+    };
+  }
+
+  /** One turn: echo the pushed prompt, succeed, go idle. */
+  async function* oneTurn(input: Pushable<any>, turns = 1) {
+    const iter = input[Symbol.asyncIterator]();
+    for (let i = 0; i < turns; i++) {
+      const { value: userMessage } = await iter.next();
+      yield userEcho(userMessage);
+      yield successfulResultMessage();
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+    }
+  }
+
+  function newAgent(client: AcpClient) {
+    return new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+  }
+
+  const LONG_PROMPT = "Explain what the add function in hello.py does, in one sentence";
+
+  it("pushes a session_info_update when the SDK generates a title at turn-end", async () => {
+    const sessionUpdates: any[] = [];
+    const agent = newAgent({
+      sessionUpdate: async (u: any) => {
+        sessionUpdates.push(u);
+      },
+    } as unknown as AcpClient);
+
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: "Fix the flaky title test",
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    agent.sessions["test-session"] = mockSessionState(
+      {
+        query: wrapQuery(oneTurn(input)),
+        input,
+      },
+      agent,
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+    await agent.sessions["test-session"]?.consumer;
+
+    const titleUpdate = sessionUpdates.find(
+      (u) => u.update?.sessionUpdate === "session_info_update",
+    );
+    expect(titleUpdate?.update).toEqual({
+      sessionUpdate: "session_info_update",
+      title: "Fix the flaky title test",
+      updatedAt: new Date(1_700_000_000_000).toISOString(),
+    });
+    expect(getSessionInfo).toHaveBeenCalledWith("test-session", { dir: "/test" });
+  });
+
+  it("does not re-push session_info_update when the title is unchanged", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: "Stable title",
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    agent.sessions["test-session"] = mockSessionState(
+      {
+        query: wrapQuery(oneTurn(input, 2)),
+        input,
+      },
+      agent,
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "one" }] });
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "two" }] });
+    await agent.sessions["test-session"]?.consumer;
+
+    expect(titles()).toEqual(["Stable title"]);
+  });
+
+  it("generates a title at turn-end instead of publishing the raw prompt", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    // What an SDK-driven session really looks like: nothing has written a title,
+    // so `summary` is just the opening prompt.
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: LONG_PROMPT,
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(
+      oneTurn(input),
+      "Explain add() in hello.py",
+    );
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: LONG_PROMPT }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+    // Generation is fired off the turn-end path, so it lands after `idle`.
+    await vi.waitFor(() => {
+      expect(generateSessionTitle).toHaveBeenCalledTimes(1);
+    });
+
+    expect(generateSessionTitle).toHaveBeenCalledWith(LONG_PROMPT, { persist: true });
+    // The raw prompt was never published — only the generated title.
+    expect(titles()).toEqual(["Explain add() in hello.py"]);
+  });
+
+  it("adopts a stored title and never generates over it", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    // The SDK folds a `/rename` and an earlier generated title into the same
+    // field, so a non-empty `customTitle` means hands off.
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: "Renamed by the user",
+      customTitle: "Renamed by the user",
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(oneTurn(input), "Generated instead");
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: LONG_PROMPT }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+
+    expect(generateSessionTitle).not.toHaveBeenCalled();
+    expect(titles()).toEqual(["Renamed by the user"]);
+  });
+
+  it("generates once per session, and a later turn can't fall back to the prompt", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    // `getSessionInfo` never reports the persisted title here, so the
+    // once-per-session latch is the only thing holding the second turn back.
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: LONG_PROMPT,
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(
+      oneTurn(input, 2),
+      "Explain add() in hello.py",
+    );
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: LONG_PROMPT }],
+    });
+    await vi.waitFor(() => {
+      expect(generateSessionTitle).toHaveBeenCalledTimes(1);
+    });
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "And what is the capital of France?" }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+
+    expect(generateSessionTitle).toHaveBeenCalledTimes(1);
+    expect(titles()).toEqual(["Explain add() in hello.py"]);
+  });
+
+  it("releases the latch when generation yields no title", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: LONG_PROMPT,
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(oneTurn(input, 2), null);
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: LONG_PROMPT }],
+    });
+    await vi.waitFor(() => {
+      expect(generateSessionTitle).toHaveBeenCalledTimes(1);
+    });
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "And what is the capital of France?" }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+    await vi.waitFor(() => {
+      expect(generateSessionTitle).toHaveBeenCalledTimes(2);
+    });
+
+    // Nothing generated, so the client still gets the summary fallback.
+    expect(titles()).toEqual([LONG_PROMPT]);
+  });
+
+  it("skips slash-command and bash openers when building the title context", async () => {
+    const { client } = titleRecorder();
+    const agent = newAgent(client);
+
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: "/compact",
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(oneTurn(input), "Compact the session");
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact keep the design discussion" }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+
+    expect(generateSessionTitle).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/session-titles.test.ts
+++ b/src/tests/session-titles.test.ts
@@ -280,7 +280,7 @@ describe("session titles at turn-end", () => {
     expect(titles()).toEqual([LONG_PROMPT]);
   });
 
-  it("skips slash-command and bash openers when building the title context", async () => {
+  it("skips argument-less slash commands and bash openers when building the title context", async () => {
     const { client } = titleRecorder();
     const agent = newAgent(client);
 
@@ -296,10 +296,43 @@ describe("session titles at turn-end", () => {
 
     await agent.prompt({
       sessionId: "test-session",
-      prompt: [{ type: "text", text: "/compact keep the design discussion" }],
+      prompt: [{ type: "text", text: "/compact" }],
     });
     await agent.sessions["test-session"]?.consumer;
 
     expect(generateSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it("includes slash-command arguments in the title context", async () => {
+    const { client, titles } = titleRecorder();
+    const agent = newAgent(client);
+
+    vi.mocked(getSessionInfo).mockResolvedValue({
+      sessionId: "test-session",
+      summary: "/investigate-alert kafka lag on prod-3",
+      lastModified: 1_700_000_000_000,
+    } as any);
+
+    const input = new Pushable<any>();
+    const { query, generateSessionTitle } = wrapTitleQuery(
+      oneTurn(input),
+      "Investigate Kafka lag alert on prod-3",
+    );
+    agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/investigate-alert kafka lag on prod-3" }],
+    });
+    await agent.sessions["test-session"]?.consumer;
+
+    await vi.waitFor(() => {
+      expect(generateSessionTitle).toHaveBeenCalledTimes(1);
+    });
+    expect(generateSessionTitle).toHaveBeenCalledWith(
+      expect.stringContaining("/investigate-alert kafka lag on prod-3"),
+      { persist: true },
+    );
+    expect(titles()).toEqual(["Investigate Kafka lag alert on prod-3"]);
   });
 });


### PR DESCRIPTION
Claude Code's automatic title generation never runs under the Agent SDK, so `SDKSessionInfo.summary` degrades to the raw first prompt — meaning we were publishing up to 256 characters of the user's opening message as the session title.

This PR asks the SDK for a real title instead. On the first completed turn we send the `generate_session_title` control request with the trailing 1000 characters of the session's own user + assistant text, fired in the background off the `idle` handler so turn-end never waits on the ~2 s small-model call, and publish the result through the existing `session_info_update`. 

A title is generated once per session, and any title already in the session file — a user `/rename` or one we generated earlier, which the SDK folds into the same field — is adopted rather than overwritten.`persist: true` writes it to the transcript, so `session/list` and `session/load` show the same name.

The SDK method is undeclared in `sdk.d.ts`, so it's called behind a `typeof` check and a `try/catch` that degrades to the previous behaviour.