### PR TITLE
feat: surface context compaction as an ACP tool lifecycle

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -203,6 +203,10 @@ import {
   supportsAgentFileChangeReport,
 } from "./file-change-audit.js";
 import {
+  ContextCompactionMetadata,
+  createContextCompactionMeta,
+} from "./context-compaction-meta.js";
+import {
   applyTaskCreate,
   applyTaskList,
   applyTaskUpdate,
@@ -1164,6 +1168,7 @@ type ProviderConfig = {
 };
 
 export type ToolUpdateMeta = {
+  contextCompaction?: ContextCompactionMetadata;
   claudeCode?: {
     /* The name of the tool that was used in Claude Code. */
     toolName: string;
@@ -3025,11 +3030,19 @@ export class ClaudeAcpAgent {
     // stop_reason "refusal" and structured stop_details. We capture the
     // human-readable explanation so the terminal `result` can surface it.
     let lastRefusalExplanation: string | null = null;
-    // Tracks whether we're inside a compaction. The SDK emits the terminal
-    // `status` (compact_result success/failed) twice for a single failed
-    // compaction, and the two messages are indistinguishable — so we report the
-    // outcome only while a compaction is in progress, then clear this.
-    let compactionInProgress = false;
+    type CompactionState = {
+      toolCallId: string;
+      terminalStatus?: "completed" | "failed";
+      heartbeatSent: boolean;
+    };
+    // The SDK can duplicate terminal compact_result messages and can omit the
+    // opening status on replay. Keep one lifecycle per session stream until
+    // idle (or a new compacting status) so both shapes remain idempotent.
+    let activeCompaction: CompactionState | undefined;
+    // A compaction tool call is visible output even though it is not assistant
+    // text. Preserve that fact across echo-less /compact promotion so the
+    // result-only fallback does not expose the generated summary as prose.
+    let compactionOutputDelivered = false;
     // Anthropic API message id of the assistant message currently being
     // streamed, captured from `message_start` so the streamed chunks that follow
     // (whose delta events don't carry it) can all be tagged with the same,
@@ -3158,6 +3171,114 @@ export class ClaudeAcpAgent {
       ]);
     };
 
+    const compactionToolMeta = (
+      metadata: Omit<ContextCompactionMetadata, "version"> = {},
+    ): ToolUpdateMeta => ({
+      ...createContextCompactionMeta(metadata),
+      claudeCode: { toolName: "compact" },
+    });
+
+    const startCompaction = async (sessionId: string, toolCallId: string) => {
+      if (activeCompaction && !activeCompaction.terminalStatus) return activeCompaction;
+      activeCompaction = { toolCallId, heartbeatSent: false };
+      compactionOutputDelivered = true;
+      await sendUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId,
+          title: "Compact conversation",
+          kind: "think",
+          status: "in_progress",
+          _meta: compactionToolMeta(),
+        },
+      });
+      return activeCompaction;
+    };
+
+    const compactionHeartbeat = async (sessionId: string, fallbackId: string) => {
+      const state = activeCompaction ?? (await startCompaction(sessionId, fallbackId));
+      if (state.terminalStatus || state.heartbeatSent) return;
+      state.heartbeatSent = true;
+      await sendUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: state.toolCallId,
+          status: "in_progress",
+          _meta: compactionToolMeta(),
+        },
+      });
+    };
+
+    const finishCompaction = async (
+      sessionId: string,
+      fallbackId: string,
+      status: "completed" | "failed",
+      metadata: Omit<ContextCompactionMetadata, "version"> = {},
+      enrichTerminal = false,
+    ) => {
+      const rawOutput = Object.keys(metadata).length > 0 ? metadata : undefined;
+      if (!activeCompaction) {
+        activeCompaction = { toolCallId: fallbackId, heartbeatSent: false, terminalStatus: status };
+        compactionOutputDelivered = true;
+        await sendUpdate({
+          sessionId,
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId: fallbackId,
+            title: "Compact conversation",
+            kind: "think",
+            status,
+            ...(status === "failed" && metadata.error
+              ? {
+                  content: [
+                    {
+                      type: "content" as const,
+                      content: {
+                        type: "text" as const,
+                        text: `Compaction failed: ${metadata.error}`,
+                      },
+                    },
+                  ],
+                }
+              : {}),
+            ...(rawOutput ? { rawOutput } : {}),
+            _meta: compactionToolMeta(metadata),
+          },
+        });
+        return;
+      }
+
+      const state = activeCompaction;
+      if (state.terminalStatus && !enrichTerminal) return;
+      const firstTerminal = state.terminalStatus === undefined;
+      if (firstTerminal) state.terminalStatus = status;
+      await sendUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: state.toolCallId,
+          ...(firstTerminal ? { status } : {}),
+          ...(status === "failed" && metadata.error
+            ? {
+                content: [
+                  {
+                    type: "content" as const,
+                    content: {
+                      type: "text" as const,
+                      text: `Compaction failed: ${metadata.error}`,
+                    },
+                  },
+                ],
+              }
+            : {}),
+          ...(rawOutput ? { rawOutput } : {}),
+          _meta: compactionToolMeta(metadata),
+        },
+      });
+    };
+
     let pendingWorkerShutdown = false;
     const isCurrentConsumer = () => this.sessions[params.sessionId] === session;
     const sessionFailures = new SessionFailureController({
@@ -3229,7 +3350,6 @@ export class ClaudeAcpAgent {
       lastAssistantWasUsageLimit = false;
       lastAssistantFailureTitle = undefined;
       lastRefusalExplanation = null;
-      compactionInProgress = false;
       // Do NOT reset currentStreamMessageId or streamedBlocks here. Turn
       // activation can fire mid-message (the replayed user echo with
       // --replay-user-messages lands between a message's blocks); clearing the
@@ -3975,40 +4095,13 @@ export class ClaudeAcpAgent {
                 }
                 break;
               case "status": {
-                // These banners count as delivered text (via sendUpdate), so
-                // an echo-less turn that only ever emits them (e.g. `/compact`,
-                // promoted at its own result) doesn't have its result text
-                // re-emitted by the issue-#453 fallback.
                 if (message.status === "compacting") {
-                  compactionInProgress = true;
-                  await sendUpdate({
-                    sessionId: message.session_id,
-                    update: {
-                      sessionUpdate: "agent_message_chunk",
-                      content: { type: "text", text: "Compacting..." },
-                    },
-                  });
-                } else if (message.compact_result === "success" && compactionInProgress) {
-                  // The SDK signals manual `/compact` completion with a status
-                  // message carrying `compact_result`, not the `compact_boundary`
-                  // message (which only fires when there's content to compact).
-                  compactionInProgress = false;
-                  await sendUpdate({
-                    sessionId: message.session_id,
-                    update: {
-                      sessionUpdate: "agent_message_chunk",
-                      content: { type: "text", text: "\n\nCompacting completed." },
-                    },
-                  });
-                } else if (message.compact_result === "failed" && compactionInProgress) {
-                  compactionInProgress = false;
-                  const reason = message.compact_error ? `: ${message.compact_error}` : ".";
-                  await sendUpdate({
-                    sessionId: message.session_id,
-                    update: {
-                      sessionUpdate: "agent_message_chunk",
-                      content: { type: "text", text: `\n\nCompacting failed${reason}` },
-                    },
+                  await startCompaction(message.session_id, message.uuid);
+                } else if (message.compact_result === "success") {
+                  await finishCompaction(message.session_id, message.uuid, "completed");
+                } else if (message.compact_result === "failed") {
+                  await finishCompaction(message.session_id, message.uuid, "failed", {
+                    ...(message.compact_error ? { error: message.compact_error } : {}),
                   });
                 }
                 break;
@@ -4032,9 +4125,25 @@ export class ClaudeAcpAgent {
                 // compaction frees occupancy, it doesn't change the model's
                 // window.
                 //
-                // The "Compacting completed." text is emitted from the `status`
-                // handler (keyed on `compact_result`), not here, so the failure
-                // path gets a message too.
+                const compactMetadata = message.compact_metadata;
+                await finishCompaction(
+                  message.session_id,
+                  message.uuid,
+                  "completed",
+                  compactMetadata
+                    ? {
+                        trigger: compactMetadata.trigger === "auto" ? "automatic" : "manual",
+                        preTokens: compactMetadata.pre_tokens,
+                        ...(compactMetadata.post_tokens !== undefined
+                          ? { postTokens: compactMetadata.post_tokens }
+                          : {}),
+                        ...(compactMetadata.duration_ms !== undefined
+                          ? { durationMs: compactMetadata.duration_ms }
+                          : {}),
+                      }
+                    : {},
+                  true,
+                );
                 const usedTokens = await fetchContextUsedTokens(session.query, this.logger);
                 lastAssistantUsage = null;
                 lastAssistantTotalUsage = usedTokens ?? 0;
@@ -4062,6 +4171,8 @@ export class ClaudeAcpAgent {
               case "session_state_changed": {
                 session.lastSessionState = message.state;
                 if (message.state === "idle") {
+                  activeCompaction = undefined;
+                  compactionOutputDelivered = false;
                   // A non-cancelled turn normally settled at its terminal
                   // `result` already (issue #773), and that result recorded an
                   // owed trailing idle — absorbed here via the decrement. We
@@ -4693,6 +4804,7 @@ export class ClaudeAcpAgent {
               // through the early break below, which the gated `finally`
               // leaves alone).
               const deliveredAssistantText = session.emittedAssistantText;
+              const deliveredCompactionOutput = compactionOutputDelivered;
 
               // Every user-turn result terminates a turn (settle, reject, or
               // orphan skip) and the SDK follows it with a trailing
@@ -5055,7 +5167,9 @@ export class ClaudeAcpAgent {
                   // prose can be injected into the feed.)
                   if (
                     session.activeTurn?.isLocalOnlyCommand ||
-                    (!deliveredAssistantText && (message.usage.output_tokens ?? 0) === 0)
+                    (!deliveredAssistantText &&
+                      !deliveredCompactionOutput &&
+                      (message.usage.output_tokens ?? 0) === 0)
                   ) {
                     for (const notification of toAcpNotifications(
                       message.result,
@@ -5166,11 +5280,20 @@ export class ClaudeAcpAgent {
             } finally {
               if (!isAutonomousResult) {
                 session.emittedAssistantText = false;
+                compactionOutputDelivered = false;
               }
             }
             break;
           }
           case "stream_event": {
+            const isCompactionProgress =
+              (message.event.type === "content_block_start" &&
+                message.event.content_block.type === "compaction") ||
+              (message.event.type === "content_block_delta" &&
+                message.event.delta.type === "compaction_delta");
+            if (isCompactionProgress) {
+              await compactionHeartbeat(message.session_id, message.uuid);
+            }
             // `message_start` carries the Anthropic API message id; capture it
             // so the streamed chunks that follow (whose delta events don't carry
             // it) can all be tagged with the same, replay-stable id.

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -4042,7 +4042,6 @@ export class ClaudeAcpAgent {
               case "session_state_changed": {
                 session.lastSessionState = message.state;
                 if (message.state === "idle") {
-                  compaction.reset();
                   // A non-cancelled turn normally settled at its terminal
                   // `result` already (issue #773), and that result recorded an
                   // owed trailing idle — absorbed here via the decrement. We
@@ -4073,6 +4072,7 @@ export class ClaudeAcpAgent {
                   // the interrupted turn's tokens entirely (issue #844). Zero
                   // when the cancel pre-empted the result (wedge/force-cancel).
                   if (session.cancelled && session.activeTurn && !session.activeTurn.settled) {
+                    compaction.reset();
                     settleActive(turnOutcome(session, "cancelled"));
                     // An interrupt can pre-empt the turn's result entirely
                     // (nothing ran the result-case `finally`), so close the
@@ -4133,6 +4133,7 @@ export class ClaudeAcpAgent {
                     session.activeTurn &&
                     !session.activeTurn.settled
                   ) {
+                    compaction.reset();
                     // Deliberately only the ACTIVE turn: a queued turn that
                     // was never echoed is NOT failed here, because an idle
                     // can legitimately precede the SDK picking up freshly
@@ -5150,7 +5151,11 @@ export class ClaudeAcpAgent {
             } finally {
               if (!isAutonomousResult) {
                 session.emittedAssistantText = false;
-                compaction.clearDeliveredOutput();
+                // A result closes this compaction lifecycle. Reset here rather
+                // than at idle: an owed idle from this turn can arrive after
+                // the next turn has already started and must not erase that
+                // turn's compaction state.
+                compaction.reset();
               }
             }
             break;

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3078,6 +3078,7 @@ export class ClaudeAcpAgent {
       async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
     ));
 
+    const compaction = new ContextCompactionLifecycle((notification) => sendUpdate(notification));
     const sendUpdate = async (notification: AcpSessionNotification) => {
       const { update } = notification;
       const claudeMeta = update._meta?.claudeCode as
@@ -3114,6 +3115,13 @@ export class ClaudeAcpAgent {
         return;
       }
       if (update.sessionUpdate === "agent_message_chunk") {
+        if (
+          !claudeMeta?.parentToolUseId &&
+          update.content.type === "text" &&
+          compaction.consumeDuplicateErrorOutput(update.content.text)
+        ) {
+          return;
+        }
         if (!claudeMeta?.parentToolUseId) {
           session.emittedAssistantText = true;
           session.titles.onAssistantText(update.content);
@@ -3158,8 +3166,6 @@ export class ClaudeAcpAgent {
           ),
       ]);
     };
-
-    const compaction = new ContextCompactionLifecycle(sendUpdate);
 
     let pendingWorkerShutdown = false;
     const isCurrentConsumer = () => this.sessions[params.sessionId] === session;
@@ -4030,6 +4036,9 @@ export class ClaudeAcpAgent {
                 break;
               }
               case "local_command_output": {
+                if (compaction.consumeDuplicateErrorOutput(message.content)) {
+                  break;
+                }
                 await sendUpdate({
                   sessionId: message.session_id,
                   update: {
@@ -5405,6 +5414,21 @@ export class ClaudeAcpAgent {
             }
 
             if (session.cancelled) {
+              break;
+            }
+
+            // Synthetic assistant frames carry the CLI's local-command output.
+            // On resume the SDK can replay a stale frame from an earlier compact
+            // attempt after a later compaction completed. Scope suppression to
+            // the compaction lifecycle and the synthetic frame itself rather
+            // than to the owning turn: one model turn may compact more than once,
+            // and its real assistant response must still be delivered.
+            if (
+              message.type === "assistant" &&
+              message.parent_tool_use_id === null &&
+              message.message.model === "<synthetic>" &&
+              compaction.hasDeliveredOutput
+            ) {
               break;
             }
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -161,6 +161,7 @@ import { buildClaudePermissionOptions } from "./permissions/options.js";
 import { buildClaudePermissionPresentation } from "./permissions/presentation.js";
 import { decodeClaudePermissionResponse } from "./permissions/response.js";
 import { SettingsManager } from "./settings.js";
+import { ContextCompactionMetadata } from "./context-compaction-meta.js";
 import {
   activeUsageLimitMessage,
   airSessionFailureCapabilityMeta,
@@ -203,9 +204,9 @@ import {
   supportsAgentFileChangeReport,
 } from "./file-change-audit.js";
 import {
-  ContextCompactionMetadata,
-  createContextCompactionMeta,
-} from "./context-compaction-meta.js";
+  ContextCompactionLifecycle,
+  contextCompactionMetadataFromBoundary,
+} from "./context-compaction.js";
 import {
   applyTaskCreate,
   applyTaskList,
@@ -3030,19 +3031,6 @@ export class ClaudeAcpAgent {
     // stop_reason "refusal" and structured stop_details. We capture the
     // human-readable explanation so the terminal `result` can surface it.
     let lastRefusalExplanation: string | null = null;
-    type CompactionState = {
-      toolCallId: string;
-      terminalStatus?: "completed" | "failed";
-      heartbeatSent: boolean;
-    };
-    // The SDK can duplicate terminal compact_result messages and can omit the
-    // opening status on replay. Keep one lifecycle per session stream until
-    // idle (or a new compacting status) so both shapes remain idempotent.
-    let activeCompaction: CompactionState | undefined;
-    // A compaction tool call is visible output even though it is not assistant
-    // text. Preserve that fact across echo-less /compact promotion so the
-    // result-only fallback does not expose the generated summary as prose.
-    let compactionOutputDelivered = false;
     // Anthropic API message id of the assistant message currently being
     // streamed, captured from `message_start` so the streamed chunks that follow
     // (whose delta events don't carry it) can all be tagged with the same,
@@ -3171,113 +3159,7 @@ export class ClaudeAcpAgent {
       ]);
     };
 
-    const compactionToolMeta = (
-      metadata: Omit<ContextCompactionMetadata, "version"> = {},
-    ): ToolUpdateMeta => ({
-      ...createContextCompactionMeta(metadata),
-      claudeCode: { toolName: "compact" },
-    });
-
-    const startCompaction = async (sessionId: string, toolCallId: string) => {
-      if (activeCompaction && !activeCompaction.terminalStatus) return activeCompaction;
-      activeCompaction = { toolCallId, heartbeatSent: false };
-      compactionOutputDelivered = true;
-      await sendUpdate({
-        sessionId,
-        update: {
-          sessionUpdate: "tool_call",
-          toolCallId,
-          title: "Compact conversation",
-          kind: "think",
-          status: "in_progress",
-          _meta: compactionToolMeta(),
-        },
-      });
-      return activeCompaction;
-    };
-
-    const compactionHeartbeat = async (sessionId: string, fallbackId: string) => {
-      const state = activeCompaction ?? (await startCompaction(sessionId, fallbackId));
-      if (state.terminalStatus || state.heartbeatSent) return;
-      state.heartbeatSent = true;
-      await sendUpdate({
-        sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: state.toolCallId,
-          status: "in_progress",
-          _meta: compactionToolMeta(),
-        },
-      });
-    };
-
-    const finishCompaction = async (
-      sessionId: string,
-      fallbackId: string,
-      status: "completed" | "failed",
-      metadata: Omit<ContextCompactionMetadata, "version"> = {},
-      enrichTerminal = false,
-    ) => {
-      const rawOutput = Object.keys(metadata).length > 0 ? metadata : undefined;
-      if (!activeCompaction) {
-        activeCompaction = { toolCallId: fallbackId, heartbeatSent: false, terminalStatus: status };
-        compactionOutputDelivered = true;
-        await sendUpdate({
-          sessionId,
-          update: {
-            sessionUpdate: "tool_call",
-            toolCallId: fallbackId,
-            title: "Compact conversation",
-            kind: "think",
-            status,
-            ...(status === "failed" && metadata.error
-              ? {
-                  content: [
-                    {
-                      type: "content" as const,
-                      content: {
-                        type: "text" as const,
-                        text: `Compaction failed: ${metadata.error}`,
-                      },
-                    },
-                  ],
-                }
-              : {}),
-            ...(rawOutput ? { rawOutput } : {}),
-            _meta: compactionToolMeta(metadata),
-          },
-        });
-        return;
-      }
-
-      const state = activeCompaction;
-      if (state.terminalStatus && !enrichTerminal) return;
-      const firstTerminal = state.terminalStatus === undefined;
-      if (firstTerminal) state.terminalStatus = status;
-      await sendUpdate({
-        sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: state.toolCallId,
-          ...(firstTerminal ? { status } : {}),
-          ...(status === "failed" && metadata.error
-            ? {
-                content: [
-                  {
-                    type: "content" as const,
-                    content: {
-                      type: "text" as const,
-                      text: `Compaction failed: ${metadata.error}`,
-                    },
-                  },
-                ],
-              }
-            : {}),
-          ...(rawOutput ? { rawOutput } : {}),
-          _meta: compactionToolMeta(metadata),
-        },
-      });
-    };
+    const compaction = new ContextCompactionLifecycle(sendUpdate);
 
     let pendingWorkerShutdown = false;
     const isCurrentConsumer = () => this.sessions[params.sessionId] === session;
@@ -4096,11 +3978,11 @@ export class ClaudeAcpAgent {
                 break;
               case "status": {
                 if (message.status === "compacting") {
-                  await startCompaction(message.session_id, message.uuid);
+                  await compaction.start(message.session_id, message.uuid);
                 } else if (message.compact_result === "success") {
-                  await finishCompaction(message.session_id, message.uuid, "completed");
+                  await compaction.finish(message.session_id, message.uuid, "completed");
                 } else if (message.compact_result === "failed") {
-                  await finishCompaction(message.session_id, message.uuid, "failed", {
+                  await compaction.finish(message.session_id, message.uuid, "failed", {
                     ...(message.compact_error ? { error: message.compact_error } : {}),
                   });
                 }
@@ -4126,22 +4008,11 @@ export class ClaudeAcpAgent {
                 // window.
                 //
                 const compactMetadata = message.compact_metadata;
-                await finishCompaction(
+                await compaction.finish(
                   message.session_id,
                   message.uuid,
                   "completed",
-                  compactMetadata
-                    ? {
-                        trigger: compactMetadata.trigger === "auto" ? "automatic" : "manual",
-                        preTokens: compactMetadata.pre_tokens,
-                        ...(compactMetadata.post_tokens !== undefined
-                          ? { postTokens: compactMetadata.post_tokens }
-                          : {}),
-                        ...(compactMetadata.duration_ms !== undefined
-                          ? { durationMs: compactMetadata.duration_ms }
-                          : {}),
-                      }
-                    : {},
+                  compactMetadata ? contextCompactionMetadataFromBoundary(compactMetadata) : {},
                   true,
                 );
                 const usedTokens = await fetchContextUsedTokens(session.query, this.logger);
@@ -4171,8 +4042,7 @@ export class ClaudeAcpAgent {
               case "session_state_changed": {
                 session.lastSessionState = message.state;
                 if (message.state === "idle") {
-                  activeCompaction = undefined;
-                  compactionOutputDelivered = false;
+                  compaction.reset();
                   // A non-cancelled turn normally settled at its terminal
                   // `result` already (issue #773), and that result recorded an
                   // owed trailing idle — absorbed here via the decrement. We
@@ -4804,7 +4674,7 @@ export class ClaudeAcpAgent {
               // through the early break below, which the gated `finally`
               // leaves alone).
               const deliveredAssistantText = session.emittedAssistantText;
-              const deliveredCompactionOutput = compactionOutputDelivered;
+              const deliveredCompactionOutput = compaction.hasDeliveredOutput;
 
               // Every user-turn result terminates a turn (settle, reject, or
               // orphan skip) and the SDK follows it with a trailing
@@ -5280,7 +5150,7 @@ export class ClaudeAcpAgent {
             } finally {
               if (!isAutonomousResult) {
                 session.emittedAssistantText = false;
-                compactionOutputDelivered = false;
+                compaction.clearDeliveredOutput();
               }
             }
             break;
@@ -5292,7 +5162,7 @@ export class ClaudeAcpAgent {
               (message.event.type === "content_block_delta" &&
                 message.event.delta.type === "compaction_delta");
             if (isCompactionProgress) {
-              await compactionHeartbeat(message.session_id, message.uuid);
+              await compaction.heartbeat(message.session_id, message.uuid);
             }
             // `message_start` carries the Anthropic API message id; capture it
             // so the streamed chunks that follow (whose delta events don't carry

--- a/src/context-compaction-meta.ts
+++ b/src/context-compaction-meta.ts
@@ -1,0 +1,29 @@
+export const CONTEXT_COMPACTION_META_KEY = "contextCompaction";
+export const CONTEXT_COMPACTION_META_VERSION = 1;
+
+export type ContextCompactionTrigger = "manual" | "automatic";
+
+export interface ContextCompactionMetadata {
+  version: typeof CONTEXT_COMPACTION_META_VERSION;
+  trigger?: ContextCompactionTrigger;
+  preTokens?: number;
+  postTokens?: number;
+  durationMs?: number;
+  error?: string;
+}
+
+/**
+ * Provider-neutral metadata for a synthetic ACP context-compaction tool call.
+ * The standard toolCallId and status fields own lifecycle identity and phase;
+ * this extension carries only compaction-specific facts.
+ */
+export function createContextCompactionMeta(
+  metadata: Omit<ContextCompactionMetadata, "version"> = {},
+): Record<typeof CONTEXT_COMPACTION_META_KEY, ContextCompactionMetadata> {
+  return {
+    [CONTEXT_COMPACTION_META_KEY]: {
+      version: CONTEXT_COMPACTION_META_VERSION,
+      ...metadata,
+    },
+  };
+}

--- a/src/context-compaction.ts
+++ b/src/context-compaction.ts
@@ -1,0 +1,169 @@
+import { SessionNotification } from "@agentclientprotocol/sdk";
+import {
+  ContextCompactionMetadata,
+  createContextCompactionMeta,
+} from "./context-compaction-meta.js";
+
+type CompactionStatus = "completed" | "failed";
+
+type CompactionState = {
+  toolCallId: string;
+  terminalStatus?: CompactionStatus;
+  heartbeatSent: boolean;
+};
+
+type SendUpdate = (notification: SessionNotification) => Promise<void>;
+
+/**
+ * Translates Claude's compaction signals into one idempotent ACP tool lifecycle.
+ *
+ * The SDK can duplicate terminal compact_result messages and can omit the
+ * opening status on replay. State therefore lives for the whole session stream
+ * until idle (or a new compacting status).
+ */
+export class ContextCompactionLifecycle {
+  private activeCompaction: CompactionState | undefined;
+  private outputDelivered = false;
+
+  constructor(private readonly sendUpdate: SendUpdate) {}
+
+  get hasDeliveredOutput(): boolean {
+    return this.outputDelivered;
+  }
+
+  clearDeliveredOutput(): void {
+    this.outputDelivered = false;
+  }
+
+  reset(): void {
+    this.activeCompaction = undefined;
+    this.outputDelivered = false;
+  }
+
+  async start(sessionId: string, toolCallId: string): Promise<CompactionState> {
+    if (this.activeCompaction && !this.activeCompaction.terminalStatus) {
+      return this.activeCompaction;
+    }
+
+    this.activeCompaction = { toolCallId, heartbeatSent: false };
+    this.outputDelivered = true;
+    await this.sendUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title: "Compact conversation",
+        kind: "think",
+        status: "in_progress",
+        _meta: compactionToolMeta(),
+      },
+    });
+    return this.activeCompaction;
+  }
+
+  async heartbeat(sessionId: string, fallbackId: string): Promise<void> {
+    const state = this.activeCompaction ?? (await this.start(sessionId, fallbackId));
+    if (state.terminalStatus || state.heartbeatSent) return;
+
+    state.heartbeatSent = true;
+    await this.sendUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: state.toolCallId,
+        status: "in_progress",
+        _meta: compactionToolMeta(),
+      },
+    });
+  }
+
+  async finish(
+    sessionId: string,
+    fallbackId: string,
+    status: CompactionStatus,
+    metadata: Omit<ContextCompactionMetadata, "version"> = {},
+    enrichTerminal = false,
+  ): Promise<void> {
+    const rawOutput = Object.keys(metadata).length > 0 ? metadata : undefined;
+    if (!this.activeCompaction) {
+      this.activeCompaction = {
+        toolCallId: fallbackId,
+        heartbeatSent: false,
+        terminalStatus: status,
+      };
+      this.outputDelivered = true;
+      await this.sendUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: fallbackId,
+          title: "Compact conversation",
+          kind: "think",
+          status,
+          ...(status === "failed" && metadata.error
+            ? { content: [compactionErrorContent(metadata.error)] }
+            : {}),
+          ...(rawOutput ? { rawOutput } : {}),
+          _meta: compactionToolMeta(metadata),
+        },
+      });
+      return;
+    }
+
+    const state = this.activeCompaction;
+    if (state.terminalStatus && !enrichTerminal) return;
+
+    const firstTerminal = state.terminalStatus === undefined;
+    if (firstTerminal) state.terminalStatus = status;
+    await this.sendUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: state.toolCallId,
+        ...(firstTerminal ? { status } : {}),
+        ...(status === "failed" && metadata.error
+          ? { content: [compactionErrorContent(metadata.error)] }
+          : {}),
+        ...(rawOutput ? { rawOutput } : {}),
+        _meta: compactionToolMeta(metadata),
+      },
+    });
+  }
+}
+
+export function contextCompactionMetadataFromBoundary(compactMetadata: {
+  trigger: "manual" | "auto";
+  pre_tokens: number;
+  post_tokens?: number;
+  duration_ms?: number;
+}): Omit<ContextCompactionMetadata, "version"> {
+  return {
+    trigger: compactMetadata.trigger === "auto" ? "automatic" : "manual",
+    preTokens: compactMetadata.pre_tokens,
+    ...(compactMetadata.post_tokens !== undefined
+      ? { postTokens: compactMetadata.post_tokens }
+      : {}),
+    ...(compactMetadata.duration_ms !== undefined
+      ? { durationMs: compactMetadata.duration_ms }
+      : {}),
+  };
+}
+
+function compactionToolMeta(
+  metadata: Omit<ContextCompactionMetadata, "version"> = {},
+): Record<string, unknown> {
+  return {
+    ...createContextCompactionMeta(metadata),
+    claudeCode: { toolName: "compact" },
+  };
+}
+
+function compactionErrorContent(error: string) {
+  return {
+    type: "content" as const,
+    content: {
+      type: "text" as const,
+      text: `Compaction failed: ${error}`,
+    },
+  };
+}

--- a/src/context-compaction.ts
+++ b/src/context-compaction.ts
@@ -18,8 +18,9 @@ type SendUpdate = (notification: SessionNotification) => Promise<void>;
  * Translates Claude's compaction signals into one idempotent ACP tool lifecycle.
  *
  * The SDK can duplicate terminal compact_result messages and can omit the
- * opening status on replay. State therefore lives for the whole session stream
- * until idle (or a new compacting status).
+ * opening status on replay. State therefore lives until the owning turn's
+ * result (or abort), while a new compacting status after a terminal outcome
+ * starts a fresh lifecycle.
  */
 export class ContextCompactionLifecycle {
   private activeCompaction: CompactionState | undefined;
@@ -29,10 +30,6 @@ export class ContextCompactionLifecycle {
 
   get hasDeliveredOutput(): boolean {
     return this.outputDelivered;
-  }
-
-  clearDeliveredOutput(): void {
-    this.outputDelivered = false;
   }
 
   reset(): void {

--- a/src/context-compaction.ts
+++ b/src/context-compaction.ts
@@ -25,6 +25,7 @@ type SendUpdate = (notification: SessionNotification) => Promise<void>;
 export class ContextCompactionLifecycle {
   private activeCompaction: CompactionState | undefined;
   private outputDelivered = false;
+  private duplicateErrorOutput: string | undefined;
 
   constructor(private readonly sendUpdate: SendUpdate) {}
 
@@ -35,6 +36,23 @@ export class ContextCompactionLifecycle {
   reset(): void {
     this.activeCompaction = undefined;
     this.outputDelivered = false;
+    this.duplicateErrorOutput = undefined;
+  }
+
+  /**
+   * Claude also emits a failed manual compaction's error as local-command
+   * stdout. Consume that one duplicate after the tool lifecycle carried it,
+   * without hiding unrelated command output.
+   */
+  consumeDuplicateErrorOutput(content: string): boolean {
+    if (
+      this.duplicateErrorOutput === undefined ||
+      content.trim() !== this.duplicateErrorOutput.trim()
+    ) {
+      return false;
+    }
+    this.duplicateErrorOutput = undefined;
+    return true;
   }
 
   async start(sessionId: string, toolCallId: string): Promise<CompactionState> {
@@ -89,6 +107,9 @@ export class ContextCompactionLifecycle {
         terminalStatus: status,
       };
       this.outputDelivered = true;
+      if (status === "failed" && metadata.error) {
+        this.duplicateErrorOutput = metadata.error;
+      }
       await this.sendUpdate({
         sessionId,
         update: {
@@ -112,6 +133,9 @@ export class ContextCompactionLifecycle {
 
     const firstTerminal = state.terminalStatus === undefined;
     if (firstTerminal) state.terminalStatus = status;
+    if (status === "failed" && metadata.error) {
+      this.duplicateErrorOutput = metadata.error;
+    }
     await this.sendUpdate({
       sessionId,
       update: {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -10488,7 +10488,21 @@ describe("assembled assistant text fallback", () => {
         uuid: "compact-failed-2",
         session_id: "test-session",
       },
-      result(),
+      {
+        type: "system",
+        subtype: "local_command_output",
+        content: "summary rejected",
+        uuid: "compact-local-output",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "local_command_output",
+        content: "additional diagnostic",
+        uuid: "compact-distinct-local-output",
+        session_id: "test-session",
+      },
+      replayedResult("summary rejected"),
       idle,
     ]);
 
@@ -10511,6 +10525,126 @@ describe("assembled assistant text fallback", () => {
         claudeCode: { toolName: "compact" },
       },
     });
+    expect(messageChunkTexts(updates)).toEqual(["additional diagnostic"]);
+  });
+
+  it("does not repeat a failed compaction error delivered as an assistant message", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "failed",
+        compact_error: "Not enough messages to compact.",
+        uuid: "compact-failed",
+        session_id: "test-session",
+      },
+      assistantMessage("compact-error", [
+        { type: "text", text: "Not enough messages to compact." },
+      ]),
+      replayedResult("Not enough messages to compact."),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "/compact" }] });
+
+    expect(messageChunkTexts(updates)).toEqual([]);
+    expect(updates.map((notification) => notification.update)).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: "tool_call_update",
+        status: "failed",
+        rawOutput: { error: "Not enough messages to compact." },
+      }),
+    );
+  });
+
+  it("does not replay stale local-command output after a successful compaction", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    const staleCommandOutput = assistantMessage("stale-command-output", [
+      { type: "text", text: "Not enough messages to compact." },
+    ]);
+    staleCommandOutput.message.model = "<synthetic>";
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "success",
+        uuid: "compact-completed",
+        session_id: "test-session",
+      },
+      staleCommandOutput,
+      replayedResult("Not enough messages to compact."),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "/compact" }] });
+
+    expect(messageChunkTexts(updates)).toEqual([]);
+    expect(updates.map((notification) => notification.update)).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: "tool_call_update",
+        status: "completed",
+      }),
+    );
+  });
+
+  it("preserves the model response after multiple compactions in one turn", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start-1",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "success",
+        uuid: "compact-completed-1",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start-2",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "success",
+        uuid: "compact-completed-2",
+        session_id: "test-session",
+      },
+      assistantMessage("answer-after-compactions", [{ type: "text", text: "final answer" }]),
+      result(),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "continue" }] });
+
+    expect(messageChunkTexts(updates)).toEqual(["final answer"]);
   });
 
   it("emits a completed compaction tool call for a terminal-only result", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -358,6 +358,7 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration"
   class TestClient {
     files: Map<string, string> = new Map();
     receivedText: string = "";
+    updates: SessionNotification[] = [];
     // Records for the AskUserQuestion elicitation test.
     elicitations: CreateElicitationRequest[] = [];
     permissionToolInputs: unknown[] = [];
@@ -412,6 +413,7 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration"
 
     async sessionUpdate(params: SessionNotification): Promise<void> {
       console.error("RECEIVED", JSON.stringify(params, null, 4));
+      this.updates.push(params);
 
       switch (params.update.sessionUpdate) {
         case "agent_message_chunk": {
@@ -582,7 +584,26 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration"
       sessionId: newSessionResponse.sessionId,
     });
 
-    expect(client.takeReceivedText()).toContain("Compacting...\n\nCompacting completed.");
+    expect(client.takeReceivedText()).toBe("");
+    const compactionUpdates = client.updates
+      .map((notification) => notification.update)
+      .filter(
+        (update) =>
+          (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+          update._meta?.contextCompaction,
+      );
+    expect(compactionUpdates[0]).toMatchObject({
+      sessionUpdate: "tool_call",
+      title: "Compact conversation",
+      kind: "think",
+      status: "in_progress",
+      _meta: { contextCompaction: { version: 1 } },
+    });
+    expect(compactionUpdates.at(-1)).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      status: "completed",
+      _meta: { contextCompaction: { version: 1 } },
+    });
   }, 60000);
 
   // Regression guard for the SDK's AskUserQuestion routing. The built-in
@@ -9391,7 +9412,18 @@ describe("usage_update computation", () => {
     // abandoned (issue #825), and a real compaction turn always produces a
     // result. Here the stream simply ends, settling the prompt end_turn.
     injectSession(agent, [
-      { type: "system", subtype: "compact_boundary", session_id: "test-session" },
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        uuid: "compact-boundary",
+        session_id: "test-session",
+        compact_metadata: {
+          trigger: "auto",
+          pre_tokens: 180000,
+          post_tokens: 12345,
+          duration_ms: 2500,
+        },
+      },
     ]);
     const session = agent.sessions["test-session"];
     // A 1M window learned earlier (e.g. from modelUsage) must survive
@@ -9410,6 +9442,29 @@ describe("usage_update computation", () => {
     // size stays at the session's learned window, NOT getContextUsage's value.
     expect(usageUpdate.update.size).toBe(1000000);
     expect(session.contextWindowSize).toBe(1000000);
+    expect(updates.map((notification) => notification.update)).toContainEqual({
+      sessionUpdate: "tool_call",
+      toolCallId: "compact-boundary",
+      title: "Compact conversation",
+      kind: "think",
+      status: "completed",
+      rawOutput: {
+        trigger: "automatic",
+        preTokens: 180000,
+        postTokens: 12345,
+        durationMs: 2500,
+      },
+      _meta: {
+        contextCompaction: {
+          version: 1,
+          trigger: "automatic",
+          preTokens: 180000,
+          postTokens: 12345,
+          durationMs: 2500,
+        },
+        claudeCode: { toolName: "compact" },
+      },
+    });
   });
 
   it("compact_boundary falls back to used:0 when getContextUsage fails", async () => {
@@ -10371,20 +10426,164 @@ describe("assembled assistant text fallback", () => {
     expect(messageChunkTexts(updates)).toEqual([]);
   });
 
-  it("does not forward the result text of a turn that only emitted status text", async () => {
+  it("does not forward the result text of a turn that only emitted compaction output", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     // `/compact` carries no echo, so it is promoted at its own result, and its
-    // status text is emitted directly rather than through the forwarding loops.
-    // That text still counts as delivered, so the result must not follow it.
+    // synthetic tool call is emitted directly rather than through the assistant
+    // forwarding loops. It still counts as visible output, so the result must
+    // not expose the generated summary afterward.
     injectSession(agent, [
-      { type: "system", subtype: "status", status: "compacting", session_id: "test-session" },
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start",
+        session_id: "test-session",
+      },
       replayedResult("conversation summarized"),
       idle,
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "/compact" }] });
 
-    expect(messageChunkTexts(updates)).toEqual(["Compacting..."]);
+    expect(messageChunkTexts(updates)).toEqual([]);
+    expect(updates.map((notification) => notification.update)).toContainEqual({
+      sessionUpdate: "tool_call",
+      toolCallId: "compact-start",
+      title: "Compact conversation",
+      kind: "think",
+      status: "in_progress",
+      _meta: {
+        contextCompaction: { version: 1 },
+        claudeCode: { toolName: "compact" },
+      },
+    });
+  });
+
+  it("emits one compaction tool lifecycle and ignores duplicate terminal status", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "status",
+        status: "compacting",
+        uuid: "compact-start",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "failed",
+        compact_error: "summary rejected",
+        uuid: "compact-failed-1",
+        session_id: "test-session",
+      },
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "failed",
+        compact_error: "summary rejected",
+        uuid: "compact-failed-2",
+        session_id: "test-session",
+      },
+      result(),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "/compact" }] });
+
+    const toolUpdates = updates
+      .map((notification) => notification.update)
+      .filter(
+        (update) =>
+          update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update",
+      );
+    expect(toolUpdates).toHaveLength(2);
+    expect(toolUpdates[1]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "compact-start",
+      status: "failed",
+      rawOutput: { error: "summary rejected" },
+      _meta: {
+        contextCompaction: { version: 1, error: "summary rejected" },
+        claudeCode: { toolName: "compact" },
+      },
+    });
+  });
+
+  it("emits a completed compaction tool call for a terminal-only result", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "status",
+        status: null,
+        compact_result: "success",
+        uuid: "compact-result",
+        session_id: "test-session",
+      },
+      result(),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "/compact" }] });
+
+    expect(updates.map((notification) => notification.update)).toContainEqual({
+      sessionUpdate: "tool_call",
+      toolCallId: "compact-result",
+      title: "Compact conversation",
+      kind: "think",
+      status: "completed",
+      _meta: {
+        contextCompaction: { version: 1 },
+        claudeCode: { toolName: "compact" },
+      },
+    });
+    expect(messageChunkTexts(updates)).toEqual([]);
+  });
+
+  it("uses compaction deltas as a single heartbeat without exposing the summary", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    const compactionDelta = (uuid: string, content: string) => ({
+      type: "stream_event" as const,
+      parent_tool_use_id: null,
+      uuid,
+      session_id: "test-session",
+      event: {
+        type: "content_block_delta" as const,
+        index: 0,
+        delta: { type: "compaction_delta" as const, content, encrypted_content: null },
+      },
+    });
+    injectSession(agent, [
+      compactionDelta("compact-delta-1", "internal "),
+      compactionDelta("compact-delta-2", "summary"),
+      result(),
+      idle,
+    ]);
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+
+    const toolUpdates = updates
+      .map((notification) => notification.update)
+      .filter(
+        (update) =>
+          update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update",
+      );
+    expect(toolUpdates).toHaveLength(2);
+    expect(toolUpdates[0]).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "compact-delta-1",
+      status: "in_progress",
+    });
+    expect(toolUpdates[1]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "compact-delta-1",
+      status: "in_progress",
+    });
+    expect(JSON.stringify(updates)).not.toContain("internal summary");
   });
 
   // Like injectSession, but serves two prompts: each turn's echo is yielded

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -10586,6 +10586,60 @@ describe("assembled assistant text fallback", () => {
     expect(JSON.stringify(updates)).not.toContain("internal summary");
   });
 
+  it("does not let a previous turn's lagging idle reset the active compaction", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    injectSessionTwoTurns(
+      agent,
+      [result()],
+      [
+        {
+          type: "system",
+          subtype: "status",
+          status: "compacting",
+          uuid: "second-compact-start",
+          session_id: "test-session",
+        },
+        // This is turn 1's owed trailer, delivered after turn 2 started.
+        idle,
+        {
+          type: "system",
+          subtype: "status",
+          status: null,
+          compact_result: "failed",
+          compact_error: "summary rejected",
+          uuid: "second-compact-failed",
+          session_id: "test-session",
+        },
+        result(),
+        idle,
+      ],
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "first" }] });
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact" }],
+    });
+
+    const toolUpdates = updates
+      .map((notification) => notification.update)
+      .filter(
+        (update) =>
+          update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update",
+      );
+    expect(toolUpdates).toHaveLength(2);
+    expect(toolUpdates[0]).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "second-compact-start",
+      status: "in_progress",
+    });
+    expect(toolUpdates[1]).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "second-compact-start",
+      status: "failed",
+    });
+  });
+
   // Like injectSession, but serves two prompts: each turn's echo is yielded
   // when its prompt arrives, followed by that turn's scripted messages.
   function injectSessionTwoTurns(agent: ClaudeAcpAgent, first: any[], second: any[]) {


### PR DESCRIPTION
## Summary

- surface Claude context compaction as a synthetic ACP tool lifecycle instead of assistant text
- emit provider-neutral `_meta.contextCompaction` metadata with schema version 1
- handle status, stream heartbeat, compact-boundary, terminal-only, failure, and duplicate terminal event shapes
- keep the generated compaction summary internal to the agent

## Protocol

Compaction tool calls use `kind: "think"`, title `Compact conversation`, standard ACP lifecycle statuses, and optional metadata fields `trigger`, `preTokens`, `postTokens`, `durationMs`, and `error`.

## Testing

- `npm run test:run` (769 passed, 26 skipped)
- `npm run build`
- `npm run check`
