### PR TITLE
feat: report changed files to AIR

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -136,6 +136,21 @@ import {
   supportsAirSessionFailures,
 } from "./session-failure-extension.js";
 import {
+  AGENT_FILE_CHANGE_REPORT_CAPABILITY,
+  agentFileChangeReportMeta,
+  agentFileChangeReportRequestId,
+  containsFileChangeAuditMarker,
+  createFileChangeAuditSupport,
+  createFileChangeAuditTurnState,
+  FILE_CHANGE_AUDIT_SERVER_NAME,
+  type FileChangeAuditSupport,
+  type FileChangeAuditTurnState,
+  type FileChangeReportUnavailableReason,
+  isFileChangeAuditReportPhase,
+  isFileChangeAuditTool,
+  supportsAgentFileChangeReport,
+} from "./file-change-audit.js";
+import {
   applyTaskCreate,
   applyTaskList,
   applyTaskUpdate,
@@ -319,6 +334,10 @@ type Turn = {
    *  so the consumer can't promote them via the replay; it falls back to
    *  promoting the queue head when the result arrives. */
   isLocalOnlyCommand: boolean;
+  /** Optional hidden, model-authored file-change audit requested by the ACP
+   *  client for this turn. The state is turn-owned so a late tool call can
+   *  never be rebound to a newer prompt. */
+  fileChangeAudit?: FileChangeAuditTurnState;
   /** Set once the deferred has been resolved/rejected, so the consumer never
    *  settles a turn twice (idle + handoff + stream-end can all race). */
   settled: boolean;
@@ -427,6 +446,14 @@ type Session = {
   /** The turn whose messages the consumer is currently attributing output to
    *  (the head of `turnQueue` once its user message has been echoed). */
   activeTurn?: Turn | null;
+  /** Request ids already accepted for hidden agent file-change reports. Kept
+   *  for the session lifetime so a redelivered prompt cannot publish the same
+   *  audit twice or bind a late report to another turn. */
+  fileChangeReportRequestIds: Set<string>;
+  /** Session-owned publisher for negotiated file-change audits. Turn state
+   *  stays on each Turn; this controller supplies the single idempotent
+   *  unavailable terminal used by every non-report settlement path. */
+  fileChangeAuditSupport?: FileChangeAuditSupport;
   /** Optimistic goal state published for a submitted `/goal` command whose
    *  matching runtime update has not arrived yet. Runtime updates for the old
    *  goal are suppressed until this command is echoed or completes, otherwise
@@ -1645,7 +1672,7 @@ export class ClaudeAcpAgent {
       // steering extension contract: advertises the `_session/steering` request
       // so clients know they may inject a follow-up into a running turn.
       _meta: {
-        ...airSessionFailureCapabilityMeta(),
+        ...airSessionFailureCapabilityMeta(AGENT_FILE_CHANGE_REPORT_CAPABILITY),
         steering: {
           supported: true,
         },
@@ -1939,6 +1966,18 @@ export class ClaudeAcpAgent {
     const isLocalOnlyCommand =
       firstText.startsWith("/") && LOCAL_ONLY_COMMANDS.has(firstText.split(" ", 1)[0]);
 
+    const fileChangeReportRequestId = supportsAgentFileChangeReport(this.clientCapabilities)
+      ? agentFileChangeReportRequestId(params._meta)
+      : undefined;
+    let fileChangeAudit: FileChangeAuditTurnState | undefined;
+    if (
+      fileChangeReportRequestId &&
+      !session.fileChangeReportRequestIds.has(fileChangeReportRequestId)
+    ) {
+      session.fileChangeReportRequestIds.add(fileChangeReportRequestId);
+      fileChangeAudit = createFileChangeAuditTurnState(fileChangeReportRequestId);
+    }
+
     // Each prompt is a Turn whose deferred the persistent consumer settles once
     // the turn's outcome is known. `prompt()` owns no loop: it enqueues the
     // turn, pushes the user message onto the streaming input, makes sure the
@@ -1946,6 +1985,7 @@ export class ClaudeAcpAgent {
     const turn: Turn = {
       promptUuid,
       isLocalOnlyCommand,
+      ...(fileChangeAudit ? { fileChangeAudit } : {}),
       settled: false,
       resolve: () => {},
       reject: () => {},
@@ -2125,6 +2165,19 @@ export class ClaudeAcpAgent {
     return { outcome: "injected" };
   }
 
+  /** Publish the audit terminal for every turn path that did not reach the
+   *  report tool. The support flips the turn state synchronously before its
+   *  transport await, so callers can stay fail-open and settle the ACP prompt
+   *  immediately without allowing a racing lifecycle path to publish twice. */
+  private finishFileChangeAudit(
+    session: Session,
+    turn: Turn,
+    reason: FileChangeReportUnavailableReason,
+  ): void {
+    if (!turn.fileChangeAudit || !session.fileChangeAuditSupport) return;
+    void session.fileChangeAuditSupport.finishUnavailable(turn.fileChangeAudit, reason);
+  }
+
   /** Lazily start the per-session consumer that drains the SDK query stream for
    *  the session's whole life. Idempotent: only the first `prompt()` starts it. */
   private ensureConsumer(session: Session, sessionId: string): void {
@@ -2207,6 +2260,16 @@ export class ClaudeAcpAgent {
      *  as the turn's answer. */
     const sendUpdate = async (notification: SessionNotification) => {
       const { update } = notification;
+      if (
+        isFileChangeAuditReportPhase(session.activeTurn?.fileChangeAudit) &&
+        (update.sessionUpdate === "agent_message_chunk" ||
+          update.sessionUpdate === "agent_thought_chunk" ||
+          update.sessionUpdate === "user_message_chunk" ||
+          update.sessionUpdate === "tool_call" ||
+          update.sessionUpdate === "tool_call_update")
+      ) {
+        return;
+      }
       if (update.sessionUpdate === "agent_message_chunk") {
         const claudeMeta = update._meta?.claudeCode as
           { parentToolUseId?: string | null } | undefined;
@@ -2539,11 +2602,17 @@ export class ClaudeAcpAgent {
 
     /** Settle the active turn's deferred exactly once, disarm the force-cancel
      *  backstop (the turn is over), and drop it from the queue. */
-    const settleActive = (result: PromptResponse) => {
+    const settleActive = (
+      result: PromptResponse,
+      auditReason: FileChangeReportUnavailableReason = result.stopReason === "cancelled"
+        ? "cancelled"
+        : "notReported",
+    ) => {
       const turn = session.activeTurn;
       if (!turn || turn.settled) {
         return;
       }
+      this.finishFileChangeAudit(session, turn, auditReason);
       // Captured before the settled flip below (isHeldOpen tests !settled).
       const wasHeld = isHeldOpen(turn);
       turn.settled = true;
@@ -2580,6 +2649,7 @@ export class ClaudeAcpAgent {
         );
         return;
       }
+      this.finishFileChangeAudit(session, turn, "providerError");
       turn.settled = true;
       session.turnQueue = (session.turnQueue ?? []).filter((t) => t !== turn);
       session.activeTurn = null;
@@ -2617,11 +2687,14 @@ export class ClaudeAcpAgent {
         return;
       }
       sessionFailures.recordActive(failure);
-      settleActive({
-        stopReason: "end_turn",
-        usage: sessionUsage(session),
-        _meta: sessionFailureMeta(failure),
-      });
+      settleActive(
+        {
+          stopReason: "end_turn",
+          usage: sessionUsage(session),
+          _meta: sessionFailureMeta(failure),
+        },
+        "providerError",
+      );
     };
 
     /** Reject every in-flight turn — used when the stream dies. */
@@ -2634,6 +2707,7 @@ export class ClaudeAcpAgent {
       session.turnQueue = [];
       for (const turn of turns) {
         if (!turn.settled) {
+          this.finishFileChangeAudit(session, turn, "providerError");
           const wasHeld = isHeldOpen(turn);
           turn.settled = true;
           if (wasHeld) {
@@ -2789,6 +2863,7 @@ export class ClaudeAcpAgent {
           // still here was enqueued afterward and was not part of the cancel.)
           for (const queued of [...(session.turnQueue ?? [])]) {
             if (!queued.settled) {
+              this.finishFileChangeAudit(session, queued, "providerError");
               queued.settled = true;
               queued.reject(RequestError.internalError(undefined, SESSION_ENDED_MESSAGE));
             }
@@ -4634,6 +4709,7 @@ export class ClaudeAcpAgent {
     if (session.turnQueue) {
       for (const turn of session.turnQueue) {
         if (turn !== session.activeTurn && !turn.settled) {
+          this.finishFileChangeAudit(session, turn, "cancelled");
           turn.settled = true;
           // Deliberately no `usage`: a queued turn never ran, so the session
           // accumulator (the active turn's tally) is not its spend.
@@ -4702,6 +4778,7 @@ export class ClaudeAcpAgent {
     {
       const active = session.activeTurn;
       if (isHeldOpen(active)) {
+        this.finishFileChangeAudit(session, active, "cancelled");
         active.settled = true;
         // Mirror settleActive's invariants (it is consumer-scoped and
         // unreachable from here): disarm the backstop — none should be
@@ -5073,6 +5150,13 @@ export class ClaudeAcpAgent {
           })
         : undefined;
     let replayTurnId: string | undefined;
+    // Stop-hook additionalContext is persisted as an internal user message.
+    // Once that marker (or the internal tool itself) appears, suppress the
+    // whole audit exchange until its tool result. This also hides a disobedient
+    // model's separate prose message, while an ordinary next user prompt safely
+    // ends an incomplete audit lane.
+    let replayingFileChangeAudit = false;
+    const replayFileChangeAuditToolUseIds = new Set<string>();
 
     for (const message of messages) {
       if (
@@ -5133,6 +5217,66 @@ export class ClaudeAcpAgent {
       if (message.message.role === "user") {
         content = stripLocalCommandMetadata(content);
         if (content === null) continue;
+      }
+
+      const auditBlocks = Array.isArray(content)
+        ? content.filter(
+            (block): block is Record<string, unknown> =>
+              typeof block === "object" && block !== null,
+          )
+        : [];
+      const hasFileChangeAuditMarker =
+        (typeof content === "string" && containsFileChangeAuditMarker(content)) ||
+        auditBlocks.some(
+          (block) => typeof block.text === "string" && containsFileChangeAuditMarker(block.text),
+        );
+      const fileChangeAuditToolUseIds = auditBlocks.flatMap((block) =>
+        (block.type === "tool_use" ||
+          block.type === "server_tool_use" ||
+          block.type === "mcp_tool_use") &&
+        typeof block.name === "string" &&
+        isFileChangeAuditTool(block.name) &&
+        typeof block.id === "string"
+          ? [block.id]
+          : [],
+      );
+      const replayMessageRole = (message as unknown as { message?: { role?: unknown } }).message
+        ?.role;
+      if (hasFileChangeAuditMarker || fileChangeAuditToolUseIds.length > 0) {
+        replayingFileChangeAudit = true;
+        for (const toolUseId of fileChangeAuditToolUseIds) {
+          replayFileChangeAuditToolUseIds.add(toolUseId);
+        }
+        continue;
+      }
+      if (replayingFileChangeAudit) {
+        const toolResultIds = auditBlocks.flatMap((block) =>
+          (block.type === "tool_result" || block.type === "mcp_tool_result") &&
+          typeof block.tool_use_id === "string"
+            ? [block.tool_use_id]
+            : [],
+        );
+        let completedReport = false;
+        for (const toolUseId of toolResultIds) {
+          if (replayFileChangeAuditToolUseIds.delete(toolUseId)) completedReport = true;
+        }
+        if (completedReport && replayFileChangeAuditToolUseIds.size === 0) {
+          replayingFileChangeAudit = false;
+          continue;
+        }
+        // A denied attempt to call another tool is still part of the hidden
+        // lane. Its result must not end replay suppression before the report.
+        if (toolResultIds.length > 0) {
+          continue;
+        }
+        // The next real user prompt is already represented by the client and
+        // starts a new turn; do not let a missing audit result hide it or the
+        // rest of the replay.
+        if (replayMessageRole === "user") {
+          replayingFileChangeAudit = false;
+        } else {
+          continue;
+        }
       }
 
       for (const notification of toAcpNotifications(
@@ -5262,6 +5406,27 @@ export class ClaudeAcpAgent {
         return {
           behavior: "deny",
           message: "Session not found",
+        };
+      }
+
+      const fileChangeAudit = session.activeTurn?.fileChangeAudit;
+      if (isFileChangeAuditReportPhase(fileChangeAudit)) {
+        // The hidden continuation is an audit-only lane: it may submit the
+        // wrapper-owned report, but it must not run another command after the
+        // user-visible answer has already completed.
+        if (isFileChangeAuditTool(toolName) && fileChangeAudit?.phase === "collecting") {
+          return { behavior: "allow", updatedInput: toolInput };
+        }
+        return {
+          behavior: "deny",
+          message: "Only the internal file-change report is allowed during the audit.",
+        };
+      }
+      // The tool is intentionally unusable outside a negotiated audit turn.
+      if (isFileChangeAuditTool(toolName)) {
+        return {
+          behavior: "deny",
+          message: "No file-change report was requested for this turn.",
         };
       }
 
@@ -6109,6 +6274,33 @@ export class ClaudeAcpAgent {
     // the same Map that the streaming message handler will read from.
     const taskState: TaskState = new Map();
 
+    // Resolve every workspace root once. The hidden report tool uses this same
+    // set for lexical path validation, and the SDK receives it below.
+    const acpAdditionalDirectories =
+      params.additionalDirectories ?? sessionMeta?.additionalRoots ?? [];
+    const additionalDirectories = [
+      ...(userProvidedOptions?.additionalDirectories ?? []),
+      ...acpAdditionalDirectories,
+    ];
+
+    const fileChangeAuditSupport = supportsAgentFileChangeReport(this.clientCapabilities)
+      ? createFileChangeAuditSupport({
+          cwd: params.cwd,
+          additionalDirectories,
+          getActiveState: () => this.sessions[sessionId]?.activeTurn?.fileChangeAudit,
+          publish: async (result) => {
+            await this.client.sessionUpdate({
+              sessionId,
+              update: {
+                sessionUpdate: "session_info_update",
+                _meta: agentFileChangeReportMeta(result),
+              },
+            });
+          },
+          logError: (message) => this.logger.error(message),
+        })
+      : undefined;
+
     // The exact env the query will be created with. Built (and the provider
     // cache key derived from it, below) in one place so the key always
     // describes the backend this query actually talks to: `providers/set`,
@@ -6153,7 +6345,13 @@ export class ClaudeAcpAgent {
       cwd: params.cwd,
       includePartialMessages: true,
       forwardSubagentText,
-      mcpServers: { ...(userProvidedOptions?.mcpServers || {}), ...mcpServers },
+      mcpServers: {
+        ...(userProvidedOptions?.mcpServers || {}),
+        ...mcpServers,
+        ...(fileChangeAuditSupport
+          ? { [FILE_CHANGE_AUDIT_SERVER_NAME]: fileChangeAuditSupport.mcpServer }
+          : {}),
+      },
       // If we want bypassPermissions to be an option, we have to allow it here.
       // But it doesn't work in root mode, so we only activate it if it will work.
       allowDangerouslySkipPermissions: ALLOW_BYPASS,
@@ -6187,6 +6385,14 @@ export class ClaudeAcpAgent {
       tools,
       hooks: {
         ...userProvidedOptions?.hooks,
+        ...(fileChangeAuditSupport
+          ? {
+              PreToolUse: [
+                ...(userProvidedOptions?.hooks?.PreToolUse || []),
+                { hooks: [fileChangeAuditSupport.preToolUseHook] },
+              ],
+            }
+          : {}),
         PostToolUse: [
           ...(userProvidedOptions?.hooks?.PostToolUse || []),
           {
@@ -6206,6 +6412,14 @@ export class ClaudeAcpAgent {
             ],
           },
         ],
+        ...(fileChangeAuditSupport
+          ? {
+              Stop: [
+                ...(userProvidedOptions?.hooks?.Stop || []),
+                { hooks: [fileChangeAuditSupport.stopHook] },
+              ],
+            }
+          : {}),
         TaskCreated: [
           ...(userProvidedOptions?.hooks?.TaskCreated || []),
           {
@@ -6237,12 +6451,7 @@ export class ClaudeAcpAgent {
     // legacy `_meta.additionalRoots` extension for clients that haven't been
     // updated yet. Either source is merged with directories supplied via
     // `_meta.claudeCode.options.additionalDirectories` (SDK pass-through).
-    const acpAdditionalDirectories =
-      params.additionalDirectories ?? sessionMeta?.additionalRoots ?? [];
-    options.additionalDirectories = [
-      ...(userProvidedOptions?.additionalDirectories ?? []),
-      ...acpAdditionalDirectories,
-    ];
+    options.additionalDirectories = additionalDirectories;
 
     if (creationOpts?.resume === undefined || creationOpts?.forkSession) {
       // Set our own session id if not resuming an existing session.
@@ -6502,6 +6711,8 @@ export class ClaudeAcpAgent {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: createSessionFailureState(),
+      fileChangeReportRequestIds: new Set(),
+      fileChangeAuditSupport,
     };
 
     return {
@@ -7657,7 +7868,7 @@ function isTaskTool(toolName: string): boolean {
  *  permission-surfaced tool_call for them (see `ensureToolCallEmitted`) must be
  *  resolved explicitly at tool_result time. */
 function shouldEmitToolCall(toolName: string): boolean {
-  return toolName !== "TodoWrite" && !isTaskTool(toolName);
+  return toolName !== "TodoWrite" && !isTaskTool(toolName) && !isFileChangeAuditTool(toolName);
 }
 
 /** Build the Claude Code-specific metadata for a tool call. Bash descriptions
@@ -7878,7 +8089,7 @@ export function toAcpNotifications(
   const registerHooks = options?.registerHooks !== false;
   const supportsTerminalOutput = options?.clientCapabilities?._meta?.["terminal_output"] === true;
   if (typeof content === "string") {
-    if (content.length === 0) {
+    if (content.length === 0 || containsFileChangeAuditMarker(content)) {
       return [];
     }
     const update: SessionNotification["update"] = {
@@ -7917,6 +8128,16 @@ export function toAcpNotifications(
   // Unlike `tool_use_result`, entries carry their own tool_use_id, so batched
   // messages need no single-block guard.
   const toolResultMeta = parseToolResultMeta(options?.toolResultMeta);
+  // A report-phase assistant message may contain a short text preface and the
+  // internal tool call in the same content array. Hide the whole message, not
+  // only the tool block, so it stays absent on session replay as well as live.
+  const containsFileChangeAuditToolUse = content.some(
+    (chunk) =>
+      (chunk.type === "tool_use" ||
+        chunk.type === "server_tool_use" ||
+        chunk.type === "mcp_tool_use") &&
+      isFileChangeAuditTool(chunk.name),
+  );
 
   const output = [];
   // Only handle the first chunk for streaming; extend as needed for batching
@@ -7925,7 +8146,11 @@ export function toAcpNotifications(
     switch (chunk.type) {
       case "text":
       case "text_delta": {
-        if (chunk.text) {
+        if (
+          chunk.text &&
+          !containsFileChangeAuditToolUse &&
+          !containsFileChangeAuditMarker(chunk.text)
+        ) {
           update = {
             sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
             content: {
@@ -7937,21 +8162,22 @@ export function toAcpNotifications(
         break;
       }
       case "image":
-        update = {
-          sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
-          content: {
-            type: "image",
-            data: chunk.source.type === "base64" ? chunk.source.data : "",
-            mimeType: chunk.source.type === "base64" ? chunk.source.media_type : "",
-            uri: chunk.source.type === "url" ? chunk.source.url : undefined,
-          },
-        };
+        if (!containsFileChangeAuditToolUse)
+          update = {
+            sessionUpdate: role === "assistant" ? "agent_message_chunk" : "user_message_chunk",
+            content: {
+              type: "image",
+              data: chunk.source.type === "base64" ? chunk.source.data : "",
+              mimeType: chunk.source.type === "base64" ? chunk.source.media_type : "",
+              uri: chunk.source.type === "url" ? chunk.source.url : undefined,
+            },
+          };
         break;
       case "thinking":
       case "thinking_delta": {
         // Recent models default `thinking.display` to "omitted", which streams
         // signature-only thinking blocks whose text is empty.
-        if (chunk.thinking) {
+        if (chunk.thinking && !containsFileChangeAuditToolUse) {
           update = {
             sessionUpdate: "agent_thought_chunk",
             content: {
@@ -7967,7 +8193,10 @@ export function toAcpNotifications(
       case "mcp_tool_use": {
         const alreadyCached = chunk.id in toolUseCache;
         toolUseCache[chunk.id] = chunk;
-        if (chunk.name === "TodoWrite") {
+        if (isFileChangeAuditTool(chunk.name)) {
+          // Wrapper-owned audit protocol: never surface or register generic
+          // PostToolUse callbacks for the internal tool.
+        } else if (chunk.name === "TodoWrite") {
           // @ts-expect-error - sometimes input is empty object or undefined
           if (Array.isArray(chunk.input?.todos)) {
             update = {
@@ -8099,6 +8328,11 @@ export function toAcpNotifications(
           logger.error(
             `[claude-agent-acp] Got a tool result for tool use that wasn't tracked: ${chunk.tool_use_id}`,
           );
+          break;
+        }
+
+        if (isFileChangeAuditTool(toolUse.name)) {
+          delete toolUseCache[chunk.tool_use_id];
           break;
         }
 

--- a/src/file-change-audit.ts
+++ b/src/file-change-audit.ts
@@ -4,6 +4,7 @@ import {
   type McpSdkServerConfigWithInstance,
   type SdkMcpToolDefinition,
 } from "@anthropic-ai/claude-agent-sdk";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
 
@@ -325,11 +326,11 @@ function normalizeWorkspace(
   cwd: string,
   additionalDirectories: string[],
 ): FileChangeAuditWorkspace {
-  const normalizedCwd = path.resolve(cwd);
+  const normalizedCwd = canonicalizeWorkspaceRoot(path.resolve(cwd));
   const seen = new Set([pathKey(normalizedCwd)]);
   const normalizedAdditionalDirectories: string[] = [];
   for (const directory of additionalDirectories) {
-    const normalized = path.resolve(normalizedCwd, directory);
+    const normalized = canonicalizeWorkspaceRoot(path.resolve(normalizedCwd, directory));
     const key = pathKey(normalized);
     if (seen.has(key)) continue;
     seen.add(key);
@@ -361,7 +362,7 @@ function normalizeReportedPaths(
     }
     let normalized: string;
     try {
-      normalized = path.resolve(workspace.cwd, reportedPath);
+      normalized = canonicalizeReportedPath(path.resolve(workspace.cwd, reportedPath));
     } catch {
       truncated = true;
       continue;
@@ -423,6 +424,49 @@ function fitReportedAgentFileChangeReport(
 function isWithinRoot(candidate: string, root: string): boolean {
   const relative = path.relative(root, candidate);
   return !path.isAbsolute(relative) && !relative.startsWith(`..${path.sep}`) && relative !== "..";
+}
+
+/**
+ * Resolve filesystem aliases in a workspace root, including macOS' /tmp ->
+ * /private/tmp alias. For a root that does not exist yet, resolve its nearest
+ * existing ancestor and retain the missing suffix.
+ */
+function canonicalizeWorkspaceRoot(value: string): string {
+  return canonicalizeFromExistingAncestor(value);
+}
+
+/**
+ * Canonicalize the parent but not the leaf itself. A changed path may be
+ * deleted, or it may be a symlink whose node (rather than target) changed.
+ */
+function canonicalizeReportedPath(value: string): string {
+  const parent = canonicalizeFromExistingAncestor(path.dirname(value));
+  return path.resolve(parent, path.basename(value));
+}
+
+function canonicalizeFromExistingAncestor(value: string): string {
+  const original = path.resolve(value);
+  let current = original;
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const canonical = fs.realpathSync.native(current);
+      return path.resolve(canonical, ...missingSegments.reverse());
+    } catch (error) {
+      if (!isMissingPathError(error)) return original;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) return original;
+    missingSegments.push(path.basename(current));
+    current = parent;
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  return error.code === "ENOENT" || error.code === "ENOTDIR";
 }
 
 function pathKey(value: string): string {

--- a/src/file-change-audit.ts
+++ b/src/file-change-audit.ts
@@ -1,0 +1,438 @@
+import {
+  createSdkMcpServer,
+  type HookCallback,
+  type McpSdkServerConfigWithInstance,
+  type SdkMcpToolDefinition,
+} from "@anthropic-ai/claude-agent-sdk";
+import * as path from "node:path";
+import { z } from "zod";
+
+export const AGENT_FILE_CHANGE_REPORT_CAPABILITY = "agentFileChangeReport";
+export const FILE_CHANGE_AUDIT_SERVER_NAME = "claude_agent_acp";
+export const FILE_CHANGE_AUDIT_TOOL_NAME = "report_changed_files";
+export const FILE_CHANGE_AUDIT_WIRE_TOOL_NAME = `mcp__${FILE_CHANGE_AUDIT_SERVER_NAME}__${FILE_CHANGE_AUDIT_TOOL_NAME}`;
+
+const FILE_CHANGE_AUDIT_MARKER = "claude-agent-acp-file-change-audit";
+const MAX_REPORTED_PATHS = 1024;
+const MAX_REPORTED_PATH_LENGTH = 4096;
+export const AGENT_FILE_CHANGE_REPORT_MAX_BYTES = 256 * 1024;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+export type FileChangeAuditTurnState = {
+  requestId: string;
+  phase: "requested" | "collecting" | "finished";
+};
+
+export type FileChangeAuditWorkspace = {
+  cwd: string;
+  additionalDirectories: string[];
+};
+
+export type AgentFileChangeReport = {
+  paths: string[];
+  complete: boolean;
+  uncertainty?: string;
+};
+
+export type AgentFileChangeReportResult = {
+  version: 1;
+  requestId: string;
+} & (
+  | {
+      status: "reported";
+      paths: string[];
+      declaredComplete: boolean;
+      truncated: boolean;
+      uncertainty?: string;
+    }
+  | {
+      status: "unavailable";
+      reason: FileChangeReportUnavailableReason;
+    }
+);
+
+export type FileChangeReportUnavailableReason =
+  "cancelled" | "timeout" | "invalidOutput" | "notReported" | "providerError";
+
+const JETBRAINS_META_KEY = "jetbrains";
+const AIR_META_KEY = "air";
+const AIR_EXTENSION_VERSION = 1;
+const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
+const AIR_AGENT_FILE_CHANGE_REPORT_KEY = "agentFileChangeReport";
+
+type FileChangeAuditSupportOptions = {
+  cwd: string;
+  additionalDirectories: string[];
+  getActiveState: () => FileChangeAuditTurnState | undefined;
+  publish: (result: AgentFileChangeReportResult) => Promise<void>;
+  logError: (message: string) => void;
+};
+
+export type FileChangeAuditSupport = {
+  mcpServer: McpSdkServerConfigWithInstance;
+  preToolUseHook: HookCallback;
+  stopHook: HookCallback;
+  finishUnavailable: (
+    state: FileChangeAuditTurnState,
+    reason: FileChangeReportUnavailableReason,
+  ) => Promise<void>;
+};
+
+const reportInputSchema = {
+  paths: z
+    .array(z.string())
+    .describe(
+      "Workspace file paths changed during this turn. Use absolute paths or paths relative to cwd.",
+    ),
+  complete: z
+    .boolean()
+    .describe("True only when paths contains every workspace file changed during this turn."),
+  uncertainty: z
+    .string()
+    .trim()
+    .min(1)
+    .max(2000)
+    .optional()
+    .describe("Why the report may be incomplete or uncertain."),
+};
+
+export function agentFileChangeReportRequestId(meta: unknown): string | undefined {
+  const air = airExtension(meta);
+  const request = air?.agentFileChangeReportRequest;
+  if (!request || typeof request !== "object" || Array.isArray(request)) return undefined;
+  const requestRecord = request as Record<string, unknown>;
+  const requestKeys = Object.keys(requestRecord);
+  if (
+    requestKeys.length !== 2 ||
+    !requestKeys.includes("version") ||
+    !requestKeys.includes("requestId") ||
+    requestRecord.version !== 1
+  )
+    return undefined;
+  const requestId = requestRecord.requestId;
+  return typeof requestId === "string" && REQUEST_ID_PATTERN.test(requestId)
+    ? requestId
+    : undefined;
+}
+
+export function supportsAgentFileChangeReport(capabilities: unknown): boolean {
+  if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) {
+    return false;
+  }
+  const air = airExtension((capabilities as Record<string, unknown>)._meta);
+  const advertised = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
+  return (
+    air?.version === AIR_EXTENSION_VERSION &&
+    Array.isArray(advertised) &&
+    advertised.includes(AGENT_FILE_CHANGE_REPORT_CAPABILITY)
+  );
+}
+
+export function agentFileChangeReportMeta(
+  result: AgentFileChangeReportResult,
+): Record<string, unknown> {
+  return {
+    [JETBRAINS_META_KEY]: {
+      [AIR_META_KEY]: {
+        version: AIR_EXTENSION_VERSION,
+        [AIR_AGENT_FILE_CHANGE_REPORT_KEY]: result,
+      },
+    },
+  };
+}
+
+function airExtension(meta: unknown): Record<string, unknown> | undefined {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return undefined;
+  const jetbrains = (meta as Record<string, unknown>)[JETBRAINS_META_KEY];
+  if (!jetbrains || typeof jetbrains !== "object" || Array.isArray(jetbrains)) return undefined;
+  const air = (jetbrains as Record<string, unknown>)[AIR_META_KEY];
+  return air && typeof air === "object" && !Array.isArray(air)
+    ? (air as Record<string, unknown>)
+    : undefined;
+}
+
+export function createFileChangeAuditTurnState(requestId: string): FileChangeAuditTurnState {
+  return {
+    requestId,
+    phase: "requested",
+  };
+}
+
+export function isFileChangeAuditReportPhase(state: FileChangeAuditTurnState | undefined): boolean {
+  return state?.phase === "collecting" || state?.phase === "finished";
+}
+
+export function isFileChangeAuditTool(toolName: string): boolean {
+  return toolName === FILE_CHANGE_AUDIT_WIRE_TOOL_NAME;
+}
+
+export function containsFileChangeAuditMarker(text: string): boolean {
+  return text.includes(`<${FILE_CHANGE_AUDIT_MARKER}>`);
+}
+
+export function createFileChangeAuditSupport(
+  options: FileChangeAuditSupportOptions,
+): FileChangeAuditSupport {
+  const workspace = normalizeWorkspace(options.cwd, options.additionalDirectories);
+
+  const finishUnavailable = async (
+    state: FileChangeAuditTurnState,
+    reason: FileChangeReportUnavailableReason,
+  ) => {
+    // Claim the terminal outcome before the first await. The report tool, a
+    // Stop hook, cancellation, and stream teardown can race, but only the
+    // winner may publish for this request id. Publication remains fail-open:
+    // an audit transport failure must never hold the user prompt open.
+    if (state.phase === "finished") return;
+    state.phase = "finished";
+    try {
+      await options.publish({
+        version: 1,
+        requestId: state.requestId,
+        status: "unavailable",
+        reason,
+      });
+    } catch (error) {
+      options.logError(`Failed to publish unavailable report ${state.requestId}: ${error}`);
+    }
+  };
+
+  const tool: SdkMcpToolDefinition<typeof reportInputSchema> = {
+    name: FILE_CHANGE_AUDIT_TOOL_NAME,
+    description:
+      "Internal audit tool. Call it only when a stop-hook message explicitly requests the file-change audit.",
+    inputSchema: reportInputSchema,
+    _meta: {
+      "anthropic/alwaysLoad": true,
+      "claude/endTurn": true,
+    },
+    handler: async (report) => {
+      const state = options.getActiveState();
+      if (!state || state.phase !== "collecting") {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: `<${FILE_CHANGE_AUDIT_MARKER}>No file-change audit is active.</${FILE_CHANGE_AUDIT_MARKER}>`,
+            },
+          ],
+        };
+      }
+
+      // Flip before publishing: a client transport failure must not make the
+      // model retry the report and produce duplicates. Delivery is audit-only
+      // and fail-open; the normal turn must still finish.
+      state.phase = "finished";
+      const normalized = normalizeReportedPaths(report.paths, workspace);
+      const result = fitReportedAgentFileChangeReport({
+        version: 1,
+        requestId: state.requestId,
+        status: "reported",
+        paths: normalized.paths,
+        declaredComplete: report.complete && !normalized.truncated,
+        truncated: normalized.truncated,
+        ...(report.uncertainty ? { uncertainty: report.uncertainty } : {}),
+      });
+      try {
+        await options.publish(result);
+      } catch (error) {
+        options.logError(`Failed to publish file-change report ${state.requestId}: ${error}`);
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `<${FILE_CHANGE_AUDIT_MARKER}>File-change audit recorded.</${FILE_CHANGE_AUDIT_MARKER}>`,
+          },
+        ],
+        structuredContent: result,
+      };
+    },
+  };
+
+  // canUseTool is not guaranteed to run for tools that the current permission
+  // mode auto-allows (notably bypassPermissions). A PreToolUse hook is the
+  // enforcement boundary that keeps the hidden continuation read-only in every
+  // mode: it can submit the report, but cannot inspect or mutate more files.
+  const preToolUseHook: HookCallback = async (input) => {
+    if (input.hook_event_name !== "PreToolUse") return {};
+    const state = options.getActiveState();
+    const isReportTool = isFileChangeAuditTool(input.tool_name);
+    if (!isReportTool && !isFileChangeAuditReportPhase(state)) return {};
+
+    const allowReport = state?.phase === "collecting" && isReportTool;
+    return {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: allowReport ? "allow" : "deny",
+        ...(!allowReport
+          ? {
+              permissionDecisionReason:
+                "Only the internal file-change report is allowed during the audit.",
+            }
+          : {}),
+      },
+    };
+  };
+
+  const stopHook: HookCallback = async (input) => {
+    if (input.hook_event_name !== "Stop") return {};
+    const state = options.getActiveState();
+    if (!state || state.phase === "finished") return {};
+    // A Stop can be only a pause while a background generator is still
+    // running. Keep the request pending so a later final Stop can include its
+    // writes instead of declaring a prematurely complete path set.
+    if (state.phase === "requested" && (input.background_tasks?.length ?? 0) > 0) return {};
+    if (state.phase === "collecting" || input.stop_hook_active) {
+      await finishUnavailable(state, "notReported");
+      return {};
+    }
+
+    // Set the phase before returning the continuation so every following SDK
+    // message is hidden even if the next stream starts immediately.
+    state.phase = "collecting";
+    return {
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        additionalContext:
+          `<${FILE_CHANGE_AUDIT_MARKER}>` +
+          `Before stopping, call ${FILE_CHANGE_AUDIT_WIRE_TOOL_NAME} exactly once. ` +
+          "Report every workspace file changed during this user turn, including files changed " +
+          "by commands, generators, version-control operations, and child processes. " +
+          "Do not call any other tool and do not emit user-facing prose. " +
+          "Set complete to false and explain uncertainty when you are not sure the list is complete." +
+          `</${FILE_CHANGE_AUDIT_MARKER}>`,
+      },
+    };
+  };
+
+  return {
+    mcpServer: createSdkMcpServer({
+      name: FILE_CHANGE_AUDIT_SERVER_NAME,
+      version: "1.0.0",
+      tools: [tool],
+      alwaysLoad: true,
+    }),
+    preToolUseHook,
+    stopHook,
+    finishUnavailable,
+  };
+}
+
+function normalizeWorkspace(
+  cwd: string,
+  additionalDirectories: string[],
+): FileChangeAuditWorkspace {
+  const normalizedCwd = path.resolve(cwd);
+  const seen = new Set([pathKey(normalizedCwd)]);
+  const normalizedAdditionalDirectories: string[] = [];
+  for (const directory of additionalDirectories) {
+    const normalized = path.resolve(normalizedCwd, directory);
+    const key = pathKey(normalized);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalizedAdditionalDirectories.push(normalized);
+  }
+  return {
+    cwd: normalizedCwd,
+    additionalDirectories: normalizedAdditionalDirectories,
+  };
+}
+
+function normalizeReportedPaths(
+  reportedPaths: string[],
+  workspace: FileChangeAuditWorkspace,
+): { paths: string[]; truncated: boolean } {
+  const roots = [workspace.cwd, ...workspace.additionalDirectories];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  let totalBytes = 0;
+  let truncated = false;
+  for (const reportedPath of reportedPaths) {
+    if (
+      reportedPath.trim().length === 0 ||
+      reportedPath.length > MAX_REPORTED_PATH_LENGTH ||
+      hasControlCharacter(reportedPath)
+    ) {
+      truncated = true;
+      continue;
+    }
+    let normalized: string;
+    try {
+      normalized = path.resolve(workspace.cwd, reportedPath);
+    } catch {
+      truncated = true;
+      continue;
+    }
+    if (normalized.length > MAX_REPORTED_PATH_LENGTH || hasControlCharacter(normalized)) {
+      truncated = true;
+      continue;
+    }
+    if (!roots.some((root) => isWithinRoot(normalized, root))) {
+      truncated = true;
+      continue;
+    }
+    const key = pathKey(normalized);
+    if (roots.some((root) => pathKey(root) === key)) {
+      truncated = true;
+      continue;
+    }
+    if (seen.has(key)) {
+      continue;
+    }
+    const pathBytes = Buffer.byteLength(normalized, "utf8");
+    if (
+      result.length >= MAX_REPORTED_PATHS ||
+      totalBytes + pathBytes > AGENT_FILE_CHANGE_REPORT_MAX_BYTES
+    ) {
+      truncated = true;
+      continue;
+    }
+    seen.add(key);
+    result.push(normalized);
+    totalBytes += pathBytes;
+  }
+  return { paths: result, truncated };
+}
+
+/** Keep the complete serialized report within AIR's wire limit. */
+function fitReportedAgentFileChangeReport(
+  report: Extract<AgentFileChangeReportResult, { status: "reported" }>,
+): Extract<AgentFileChangeReportResult, { status: "reported" }> {
+  const paths = [...report.paths];
+  let fitted = report;
+  while (Buffer.byteLength(JSON.stringify(fitted), "utf8") > AGENT_FILE_CHANGE_REPORT_MAX_BYTES) {
+    if (paths.length === 0) {
+      // The fixed fields and bounded uncertainty are far below the cap. Keep
+      // this loud if the wire contract changes without updating this helper.
+      throw new Error("Agent file-change report exceeds the wire limit without paths");
+    }
+    paths.pop();
+    fitted = {
+      ...report,
+      paths: [...paths],
+      declaredComplete: false,
+      truncated: true,
+    };
+  }
+  return fitted;
+}
+
+function isWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return !path.isAbsolute(relative) && !relative.startsWith(`..${path.sep}`) && relative !== "..";
+}
+
+function pathKey(value: string): string {
+  return process.platform === "win32" ? value.toLowerCase() : value;
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+  }
+  return false;
+}

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -13,12 +13,12 @@ const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
 const AIR_SESSION_FAILURE_KEY = "sessionFailure";
 const AIR_EXTENSION_VERSION = 1;
 
-export function airSessionFailureCapabilityMeta() {
+export function airSessionFailureCapabilityMeta(...additionalCapabilities: string[]) {
   return {
     [JETBRAINS_META_KEY]: {
       [AIR_META_KEY]: {
         [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
-        [AIR_EXTENSION_CAPABILITIES_KEY]: [AIR_SESSION_FAILURE_KEY],
+        [AIR_EXTENSION_CAPABILITIES_KEY]: [AIR_SESSION_FAILURE_KEY, ...additionalCapabilities],
       },
     },
   };

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -175,6 +175,7 @@ function mockSessionState(overrides: Record<string, any> = {}) {
     owedTrailingIdles: 0,
     messageIdToUuid: new Map(),
     sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+    fileChangeReportRequestIds: new Set(),
     ...overrides,
   } as any;
 }
@@ -2525,6 +2526,7 @@ describe("permission request cancellation", () => {
       emittedAssistantText: false,
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
+      fileChangeReportRequestIds: new Set(),
     } as any;
     return agent.sessions[sessionId]!;
   }
@@ -5995,7 +5997,7 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure"],
+      capabilities: ["sessionFailure", "agentFileChangeReport"],
     });
   });
 
@@ -6008,7 +6010,7 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure"],
+      capabilities: ["sessionFailure", "agentFileChangeReport"],
     });
   });
 });
@@ -6064,6 +6066,7 @@ describe("session/close", () => {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+      fileChangeReportRequestIds: new Set(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -6158,6 +6161,7 @@ describe("session/delete", () => {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+      fileChangeReportRequestIds: new Set(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -6269,6 +6273,7 @@ describe("getOrCreateSession param change detection", () => {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+      fileChangeReportRequestIds: new Set(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -9128,6 +9133,7 @@ describe("post-error recovery", () => {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+      fileChangeReportRequestIds: new Set(),
     };
     return { interrupt };
   }
@@ -12907,6 +12913,7 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),
       sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+      fileChangeReportRequestIds: new Set(),
     };
     return { interrupt };
   }
@@ -14344,6 +14351,7 @@ describe("agent selection config option", () => {
         owedTrailingIdles: 0,
         messageIdToUuid: new Map(),
         sessionFailureState: { epoch: randomUUID(), revisions: new Map(), active: new Map() },
+        fileChangeReportRequestIds: new Set(),
       };
       return { session: agent.sessions[sessionId]!, applyFlagSettings };
     }

--- a/src/tests/file-change-audit-integration.test.ts
+++ b/src/tests/file-change-audit-integration.test.ts
@@ -1,0 +1,604 @@
+import type {
+  HookCallback,
+  Options,
+  PermissionResult,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
+import {
+  AGENT_FILE_CHANGE_REPORT_CAPABILITY,
+  FILE_CHANGE_AUDIT_SERVER_NAME,
+  FILE_CHANGE_AUDIT_TOOL_NAME,
+  FILE_CHANGE_AUDIT_WIRE_TOOL_NAME,
+  type AgentFileChangeReport,
+  type AgentFileChangeReportResult,
+} from "../file-change-audit.js";
+import type { Pushable } from "../utils.js";
+
+let observedStopOutputs: unknown[] = [];
+let observedPreToolDecision: unknown;
+let observedCanUseToolDecision: PermissionResult | null | undefined;
+let replayMessages: unknown[] = [];
+type AuditScenario =
+  "reported" | "successWithoutReport" | "providerError" | "localOnly" | "waitForCancel";
+let auditScenario: AuditScenario = "reported";
+let auditTurnActivated = Promise.resolve();
+let resolveAuditTurnActivated = () => {};
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
+  const actual = await vi.importActual<typeof import("@anthropic-ai/claude-agent-sdk")>(
+    "@anthropic-ai/claude-agent-sdk",
+  );
+  return {
+    ...actual,
+    getSessionMessages: vi.fn(async () => replayMessages),
+    query: ({ prompt, options }: { prompt: Pushable<SDKUserMessage>; options: Options }) => {
+      let resolveInterrupt = () => {};
+      const interrupted = new Promise<void>((resolve) => {
+        resolveInterrupt = resolve;
+      });
+      return Object.assign(runAuditedTurn(prompt, options, interrupted), {
+        initializationResult: async () => ({
+          models: [
+            {
+              value: "claude-sonnet-4-6",
+              displayName: "Claude Sonnet",
+              description: "Fast",
+              supportsAutoMode: true,
+            },
+          ],
+        }),
+        setModel: vi.fn(async () => {}),
+        setPermissionMode: vi.fn(async () => {}),
+        supportedAgents: vi.fn(async () => []),
+        supportedCommands: vi.fn(async () => []),
+        getContextUsage: vi.fn(async () => ({ totalTokens: 0, rawMaxTokens: 200000 })),
+        interrupt: vi.fn(async () => {
+          resolveInterrupt();
+          return undefined;
+        }),
+        close: vi.fn(),
+      });
+    },
+  };
+});
+
+vi.mock("../tools.js", async () => ({
+  ...(await vi.importActual<typeof import("../tools.js")>("../tools.js")),
+  registerHookCallback: vi.fn(),
+}));
+
+type RegisteredAuditTool = {
+  handler: (
+    report: AgentFileChangeReport,
+  ) => Promise<{ content: unknown; structuredContent?: AgentFileChangeReportResult }>;
+};
+
+function hookFrom(options: Options, event: "PreToolUse" | "Stop"): HookCallback {
+  const matcher = options.hooks?.[event]?.at(-1);
+  const hook = matcher?.hooks.at(-1);
+  if (!hook) throw new Error(`Missing ${event} audit hook`);
+  return hook;
+}
+
+function auditToolFrom(options: Options): RegisteredAuditTool {
+  const server = options.mcpServers?.[FILE_CHANGE_AUDIT_SERVER_NAME] as unknown as {
+    instance: { _registeredTools: Record<string, RegisteredAuditTool> };
+  };
+  const tool = server.instance._registeredTools[FILE_CHANGE_AUDIT_TOOL_NAME];
+  if (!tool) throw new Error("Missing internal audit tool");
+  return tool;
+}
+
+function assistantMessage(content: unknown[]) {
+  return {
+    type: "assistant" as const,
+    parent_tool_use_id: null,
+    uuid: randomUUID(),
+    session_id: "sdk-session",
+    message: {
+      role: "assistant" as const,
+      model: "claude-sonnet-4-6",
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      content,
+    },
+  };
+}
+
+function successResult() {
+  return {
+    type: "result" as const,
+    subtype: "success" as const,
+    stop_reason: "end_turn",
+    is_error: false,
+    result: "",
+    errors: [],
+    duration_ms: 0,
+    duration_api_ms: 0,
+    num_turns: 2,
+    total_cost_usd: 0,
+    usage: {
+      input_tokens: 2,
+      output_tokens: 2,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: randomUUID(),
+    session_id: "sdk-session",
+  };
+}
+
+async function* runAuditedTurn(
+  input: Pushable<SDKUserMessage>,
+  options: Options,
+  interrupted: Promise<void>,
+) {
+  const iterator = input[Symbol.asyncIterator]();
+  const { value: userMessage } = await iterator.next();
+  if (!userMessage) return;
+
+  if (auditScenario === "localOnly") {
+    yield { ...successResult(), result: "Local command output" };
+    return;
+  }
+
+  yield {
+    type: "user" as const,
+    message: userMessage.message,
+    parent_tool_use_id: null,
+    uuid: userMessage.uuid,
+    session_id: "sdk-session",
+    isReplay: true,
+  };
+  resolveAuditTurnActivated();
+
+  if (auditScenario === "successWithoutReport") {
+    yield assistantMessage([{ type: "text", text: "Visible answer" }]);
+    yield successResult();
+    return;
+  }
+  if (auditScenario === "providerError") {
+    yield {
+      ...successResult(),
+      is_error: true,
+      result: "Provider failed",
+      errors: ["Provider failed"],
+    };
+    return;
+  }
+  if (auditScenario === "waitForCancel") {
+    await interrupted;
+    yield {
+      type: "system" as const,
+      subtype: "session_state_changed" as const,
+      state: "idle" as const,
+      uuid: randomUUID(),
+      session_id: "sdk-session",
+    };
+    return;
+  }
+
+  yield assistantMessage([{ type: "text", text: "Visible answer" }]);
+
+  const hookOptions = { signal: new AbortController().signal };
+  const stopHook = hookFrom(options, "Stop");
+  observedStopOutputs.push(
+    await stopHook(
+      { hook_event_name: "Stop", stop_hook_active: false } as Parameters<HookCallback>[0],
+      undefined,
+      hookOptions,
+    ),
+  );
+
+  const preToolUseHook = hookFrom(options, "PreToolUse");
+  observedPreToolDecision = await preToolUseHook(
+    {
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+      tool_use_id: "blocked-tool",
+    } as Parameters<HookCallback>[0],
+    "blocked-tool",
+    hookOptions,
+  );
+  observedCanUseToolDecision = await options.canUseTool?.(
+    "Bash",
+    { command: "git status" },
+    {
+      signal: hookOptions.signal,
+      toolUseID: "blocked-tool",
+      requestId: "permission-request",
+    },
+  );
+
+  const toolUseId = "audit-tool-use";
+  yield assistantMessage([
+    { type: "text", text: "Audit prose must stay hidden" },
+    {
+      type: "tool_use",
+      id: toolUseId,
+      name: FILE_CHANGE_AUDIT_WIRE_TOOL_NAME,
+      input: { paths: ["src/changed.ts"], complete: true },
+    },
+  ]);
+
+  const toolResult = await auditToolFrom(options).handler({
+    paths: ["src/changed.ts"],
+    complete: true,
+  });
+  yield {
+    type: "user" as const,
+    message: {
+      role: "user" as const,
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: toolResult.content,
+        },
+      ],
+    },
+    parent_tool_use_id: null,
+    uuid: randomUUID(),
+    session_id: "sdk-session",
+  };
+
+  observedStopOutputs.push(
+    await stopHook(
+      { hook_event_name: "Stop", stop_hook_active: true } as Parameters<HookCallback>[0],
+      undefined,
+      hookOptions,
+    ),
+  );
+  yield successResult();
+}
+
+describe("agent file-change audit integration", () => {
+  beforeEach(() => {
+    observedStopOutputs = [];
+    observedPreToolDecision = undefined;
+    observedCanUseToolDecision = undefined;
+    replayMessages = [];
+    auditScenario = "reported";
+    auditTurnActivated = new Promise<void>((resolve) => {
+      resolveAuditTurnActivated = resolve;
+    });
+  });
+
+  const negotiatedCapabilities = {
+    _meta: {
+      jetbrains: {
+        air: {
+          version: 1,
+          capabilities: [AGENT_FILE_CHANGE_REPORT_CAPABILITY, "sessionFailure"],
+        },
+      },
+    },
+  };
+
+  async function createAuditAgent(updates: SessionNotification[]) {
+    const client = {
+      sessionUpdate: async (notification: SessionNotification) => void updates.push(notification),
+      requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      readTextFile: async () => ({ content: "" }),
+      writeTextFile: async () => ({}),
+    } as unknown as AcpClient;
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(client, {
+      log: () => {},
+      error: () => {},
+    });
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: negotiatedCapabilities,
+    });
+    const { sessionId } = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+    return { agent, sessionId };
+  }
+
+  function fileChangeTerminals(updates: SessionNotification[]): AgentFileChangeReportResult[] {
+    return updates.flatMap((notification) => {
+      if (notification.update.sessionUpdate !== "session_info_update") return [];
+      const meta = notification.update._meta as
+        | {
+            jetbrains?: {
+              air?: { agentFileChangeReport?: AgentFileChangeReportResult };
+            };
+          }
+        | undefined;
+      const report = meta?.jetbrains?.air?.agentFileChangeReport;
+      return report ? [report] : [];
+    });
+  }
+
+  function auditedPrompt(sessionId: string, requestId: string, text: string) {
+    return {
+      sessionId,
+      prompt: [{ type: "text" as const, text }],
+      _meta: {
+        jetbrains: {
+          air: {
+            agentFileChangeReportRequest: { version: 1, requestId },
+          },
+        },
+      },
+    };
+  }
+
+  it.each([
+    {
+      name: "normal success without a Stop report",
+      scenario: "successWithoutReport" as const,
+      prompt: "Finish normally",
+      reason: "notReported" as const,
+      rejects: false,
+    },
+    {
+      name: "a local-only command",
+      scenario: "localOnly" as const,
+      prompt: "/context",
+      reason: "notReported" as const,
+      rejects: false,
+    },
+    {
+      name: "a provider error",
+      scenario: "providerError" as const,
+      prompt: "Call the provider",
+      reason: "providerError" as const,
+      rejects: false,
+    },
+  ])("publishes one terminal for $name", async ({ scenario, prompt, reason, rejects }) => {
+    auditScenario = scenario;
+    const updates: SessionNotification[] = [];
+    const { agent, sessionId } = await createAuditAgent(updates);
+    const requestId = `request-${scenario}`;
+    const result = agent.prompt(auditedPrompt(sessionId, requestId, prompt));
+
+    if (rejects) {
+      await expect(result).rejects.toBeDefined();
+    } else {
+      await expect(result).resolves.toBeDefined();
+    }
+    expect(fileChangeTerminals(updates)).toEqual([
+      {
+        version: 1,
+        requestId,
+        status: "unavailable",
+        reason,
+      },
+    ]);
+
+    await agent.dispose();
+    expect(fileChangeTerminals(updates)).toHaveLength(1);
+  });
+
+  it.each([
+    { name: "cancel", close: false },
+    { name: "session close", close: true },
+  ])("publishes one cancelled terminal and settles the prompt on $name", async ({ close }) => {
+    auditScenario = "waitForCancel";
+    const updates: SessionNotification[] = [];
+    const { agent, sessionId } = await createAuditAgent(updates);
+    const requestId = close ? "request-close" : "request-cancel";
+    const result = agent.prompt(auditedPrompt(sessionId, requestId, "Wait"));
+    await auditTurnActivated;
+
+    if (close) {
+      await agent.closeSession({ sessionId });
+    } else {
+      await agent.cancel({ sessionId });
+    }
+    await expect(result).resolves.toMatchObject({ stopReason: "cancelled" });
+    expect(fileChangeTerminals(updates)).toEqual([
+      {
+        version: 1,
+        requestId,
+        status: "unavailable",
+        reason: "cancelled",
+      },
+    ]);
+
+    await agent.dispose();
+    expect(fileChangeTerminals(updates)).toHaveLength(1);
+  });
+
+  it("negotiates an opt-in turn, publishes one report, and hides the audit continuation", async () => {
+    const updates: SessionNotification[] = [];
+    const client = {
+      sessionUpdate: async (notification: SessionNotification) => void updates.push(notification),
+      requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      readTextFile: async () => ({ content: "" }),
+      writeTextFile: async () => ({}),
+    } as unknown as AcpClient;
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(client, {
+      log: () => {},
+      error: () => {},
+    });
+
+    const capabilities = {
+      _meta: {
+        jetbrains: {
+          air: {
+            version: 1,
+            capabilities: [AGENT_FILE_CHANGE_REPORT_CAPABILITY],
+          },
+        },
+      },
+    };
+    const initialize = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: capabilities,
+    });
+    expect(initialize._meta).toMatchObject({
+      jetbrains: {
+        air: {
+          version: 1,
+          capabilities: expect.arrayContaining([AGENT_FILE_CHANGE_REPORT_CAPABILITY]),
+        },
+      },
+    });
+
+    const cwd = process.cwd();
+    const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+    const response = await agent.prompt({
+      sessionId,
+      prompt: [{ type: "text", text: "Change the file" }],
+      _meta: {
+        jetbrains: {
+          air: {
+            agentFileChangeReportRequest: { version: 1, requestId: "request-integration" },
+          },
+        },
+      },
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    expect(observedStopOutputs).toHaveLength(2);
+    expect(observedStopOutputs[0]).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        additionalContext: expect.stringContaining(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME),
+      },
+    });
+    expect(observedStopOutputs[1]).toEqual({});
+    expect(observedPreToolDecision).toMatchObject({
+      hookSpecificOutput: { permissionDecision: "deny" },
+    });
+    expect(observedCanUseToolDecision).toMatchObject({ behavior: "deny" });
+
+    const reportUpdates = updates.filter((notification) => {
+      if (notification.update.sessionUpdate !== "session_info_update") return false;
+      const meta = notification.update._meta as
+        { jetbrains?: { air?: { agentFileChangeReport?: unknown } } } | undefined;
+      return meta?.jetbrains?.air?.agentFileChangeReport !== undefined;
+    });
+    expect(reportUpdates).toEqual([
+      {
+        sessionId,
+        update: {
+          sessionUpdate: "session_info_update",
+          _meta: {
+            jetbrains: {
+              air: {
+                version: 1,
+                agentFileChangeReport: {
+                  version: 1,
+                  requestId: "request-integration",
+                  status: "reported",
+                  paths: [path.join(cwd, "src/changed.ts")],
+                  declaredComplete: true,
+                  truncated: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    const serializedUpdates = JSON.stringify(updates);
+    expect(serializedUpdates).toContain("Visible answer");
+    expect(serializedUpdates).not.toContain("Audit prose must stay hidden");
+    expect(serializedUpdates).not.toContain(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME);
+
+    await agent.dispose();
+
+    const firstStop = observedStopOutputs[0] as {
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    const auditContext = firstStop.hookSpecificOutput?.additionalContext;
+    if (!auditContext) throw new Error("Missing audit continuation context");
+    const replayToolUseId = "replay-audit-tool";
+    const deniedReplayToolUseId = "replay-denied-tool";
+    const replayUserMessage = (content: unknown) => ({
+      type: "user" as const,
+      message: { role: "user" as const, content },
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+      session_id: "replay-session",
+    });
+    replayMessages = [
+      replayUserMessage("Original prompt"),
+      assistantMessage([{ type: "text", text: "Visible persisted answer" }]),
+      replayUserMessage(auditContext),
+      assistantMessage([{ type: "text", text: "Separate audit prose must stay hidden" }]),
+      assistantMessage([
+        {
+          type: "tool_use",
+          id: deniedReplayToolUseId,
+          name: "Bash",
+          input: { command: "git status" },
+        },
+      ]),
+      replayUserMessage([
+        {
+          type: "tool_result",
+          tool_use_id: deniedReplayToolUseId,
+          content: "denied",
+          is_error: true,
+        },
+      ]),
+      assistantMessage([{ type: "text", text: "Prose after denial must stay hidden" }]),
+      assistantMessage([
+        {
+          type: "tool_use",
+          id: replayToolUseId,
+          name: FILE_CHANGE_AUDIT_WIRE_TOOL_NAME,
+          input: { paths: ["src/changed.ts"], complete: true },
+        },
+      ]),
+      replayUserMessage([
+        {
+          type: "tool_result",
+          tool_use_id: replayToolUseId,
+          content: "recorded",
+        },
+      ]),
+      replayUserMessage("Follow-up prompt"),
+      assistantMessage([{ type: "text", text: "Follow-up answer" }]),
+    ];
+
+    const replayUpdates: SessionNotification[] = [];
+    const replayAgent = new ClaudeAcpAgent(
+      {
+        ...client,
+        sessionUpdate: async (notification: SessionNotification) =>
+          void replayUpdates.push(notification),
+      } as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await replayAgent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: capabilities,
+    });
+    await replayAgent.loadSession({
+      sessionId: "replay-session",
+      cwd,
+      mcpServers: [],
+    });
+
+    const serializedReplay = JSON.stringify(replayUpdates);
+    expect(serializedReplay).toContain("Original prompt");
+    expect(serializedReplay).toContain("Visible persisted answer");
+    expect(serializedReplay).toContain("Follow-up prompt");
+    expect(serializedReplay).toContain("Follow-up answer");
+    expect(serializedReplay).not.toContain("Separate audit prose must stay hidden");
+    expect(serializedReplay).not.toContain("Prose after denial must stay hidden");
+    expect(serializedReplay).not.toContain(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME);
+    expect(serializedReplay).not.toContain("claude-agent-acp-file-change-audit");
+    await replayAgent.dispose();
+  });
+});

--- a/src/tests/file-change-audit.test.ts
+++ b/src/tests/file-change-audit.test.ts
@@ -1,4 +1,5 @@
 import type { HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -168,6 +169,9 @@ describe("agent file-change audit", () => {
   it("normalizes roots, drops invalid paths, and deduplicates without truncation", async () => {
     const cwd = path.join(os.tmpdir(), "file-audit-project");
     const additionalRoot = path.join(os.tmpdir(), "file-audit-shared");
+    const canonicalTempRoot = fs.realpathSync.native(os.tmpdir());
+    const canonicalCwd = path.join(canonicalTempRoot, "file-audit-project");
+    const canonicalAdditionalRoot = path.join(canonicalTempRoot, "file-audit-shared");
     const outside = path.join(os.tmpdir(), "file-audit-outside", "outside.txt");
     const state = createFileChangeAuditTurnState("request-2");
     state.phase = "collecting";
@@ -206,7 +210,10 @@ describe("agent file-change audit", () => {
         version: 1,
         requestId: "request-2",
         status: "reported",
-        paths: [path.join(cwd, "src/a.ts"), path.join(additionalRoot, "generated.ts")],
+        paths: [
+          path.join(canonicalCwd, "src/a.ts"),
+          path.join(canonicalAdditionalRoot, "generated.ts"),
+        ],
         declaredComplete: false,
         truncated: true,
         uncertainty: "Generated files may be missing",
@@ -232,8 +239,43 @@ describe("agent file-change audit", () => {
     expect(duplicateOnlyReports[0]).toMatchObject({
       declaredComplete: true,
       truncated: false,
-      paths: [path.join(cwd, "src/a.ts")],
+      paths: [path.join(canonicalCwd, "src/a.ts")],
     });
+  });
+
+  it("accepts canonical paths under a symlinked workspace root", async () => {
+    if (process.platform === "win32") return;
+
+    const realRoot = fs.mkdtempSync(path.join(os.tmpdir(), "file-audit-real-"));
+    const linkedRoot = `${realRoot}-link`;
+    fs.symlinkSync(realRoot, linkedRoot, "dir");
+    try {
+      const state = createFileChangeAuditTurnState("request-symlink-root");
+      state.phase = "collecting";
+      const reports: AgentFileChangeReportResult[] = [];
+      const tool = auditToolHandler(
+        createSupport({
+          state,
+          cwd: linkedRoot,
+          publish: async (report) => void reports.push(report),
+        }),
+      );
+      const canonicalPath = path.join(fs.realpathSync.native(realRoot), "generated.ts");
+
+      await tool.handler({
+        paths: [canonicalPath, path.join(linkedRoot, "generated.ts")],
+        complete: true,
+      });
+
+      expect(reports[0]).toMatchObject({
+        paths: [canonicalPath],
+        declaredComplete: true,
+        truncated: false,
+      });
+    } finally {
+      fs.unlinkSync(linkedRoot);
+      fs.rmSync(realRoot, { recursive: true, force: true });
+    }
   });
 
   it("caps path count and total UTF-8 bytes", async () => {

--- a/src/tests/file-change-audit.test.ts
+++ b/src/tests/file-change-audit.test.ts
@@ -1,0 +1,325 @@
+import type { HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_FILE_CHANGE_REPORT_MAX_BYTES,
+  agentFileChangeReportRequestId,
+  createFileChangeAuditSupport,
+  createFileChangeAuditTurnState,
+  FILE_CHANGE_AUDIT_TOOL_NAME,
+  FILE_CHANGE_AUDIT_WIRE_TOOL_NAME,
+  type AgentFileChangeReport,
+  type AgentFileChangeReportResult,
+  type FileChangeAuditTurnState,
+} from "../file-change-audit.js";
+
+type RegisteredAuditTool = {
+  _meta?: Record<string, unknown>;
+  handler: (report: AgentFileChangeReport) => Promise<{
+    isError?: boolean;
+    structuredContent?: AgentFileChangeReportResult;
+  }>;
+};
+
+function auditToolHandler(
+  support: ReturnType<typeof createFileChangeAuditSupport>,
+): RegisteredAuditTool {
+  const server = support.mcpServer as unknown as {
+    instance: { _registeredTools: Record<string, RegisteredAuditTool> };
+  };
+  return server.instance._registeredTools[FILE_CHANGE_AUDIT_TOOL_NAME];
+}
+
+function stopInput(stopHookActive = false): Parameters<HookCallback>[0] {
+  return {
+    hook_event_name: "Stop",
+    stop_hook_active: stopHookActive,
+  } as Parameters<HookCallback>[0];
+}
+
+function createSupport(options: {
+  state: FileChangeAuditTurnState;
+  cwd?: string;
+  additionalDirectories?: string[];
+  publish?: (result: AgentFileChangeReportResult) => Promise<void>;
+  logError?: (message: string) => void;
+}) {
+  return createFileChangeAuditSupport({
+    cwd: options.cwd ?? process.cwd(),
+    additionalDirectories: options.additionalDirectories ?? [],
+    getActiveState: () => options.state,
+    publish: options.publish ?? (async () => {}),
+    logError: options.logError ?? (() => {}),
+  });
+}
+
+describe("agent file-change audit", () => {
+  it("accepts only the versioned prompt request shape", () => {
+    expect(
+      agentFileChangeReportRequestId({
+        jetbrains: {
+          air: {
+            agentFileChangeReportRequest: { version: 1, requestId: "turn:42_a-b.c" },
+          },
+        },
+      }),
+    ).toBe("turn:42_a-b.c");
+
+    for (const request of [
+      { version: 2, requestId: "turn-42" },
+      { version: 1, requestId: "contains spaces" },
+      { version: 1, requestId: "x".repeat(129) },
+      { version: 1 },
+      { version: 1, requestId: "turn-42", extra: true },
+      null,
+    ]) {
+      expect(
+        agentFileChangeReportRequestId({
+          jetbrains: { air: { agentFileChangeReportRequest: request } },
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it("continues Stop at most once and reports a missing tool call once", async () => {
+    const state = createFileChangeAuditTurnState("request-1");
+    const publish = vi.fn(async (_result: AgentFileChangeReportResult) => {});
+    const support = createSupport({ state, publish });
+    const hookOptions = { signal: new AbortController().signal };
+    const preToolInput = (toolName: string) =>
+      ({
+        hook_event_name: "PreToolUse",
+        tool_name: toolName,
+        tool_input: {},
+        tool_use_id: "tool-1",
+      }) as Parameters<HookCallback>[0];
+
+    await expect(
+      support.preToolUseHook(preToolInput(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME), "tool-1", hookOptions),
+    ).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "deny" },
+    });
+
+    const pausedStop = {
+      ...stopInput(),
+      background_tasks: [{ id: "generator", type: "shell", status: "running", description: "" }],
+    } as Parameters<HookCallback>[0];
+    expect(await support.stopHook(pausedStop, undefined, hookOptions)).toEqual({});
+    expect(state.phase).toBe("requested");
+
+    const first = await support.stopHook(stopInput(), undefined, hookOptions);
+    expect(state.phase).toBe("collecting");
+    expect(first).toMatchObject({
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        additionalContext: expect.stringContaining(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME),
+      },
+    });
+
+    await expect(
+      support.preToolUseHook(preToolInput("Bash"), "tool-1", hookOptions),
+    ).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "deny" },
+    });
+    await expect(
+      support.preToolUseHook(preToolInput(FILE_CHANGE_AUDIT_WIRE_TOOL_NAME), "tool-1", hookOptions),
+    ).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: "allow" },
+    });
+
+    expect(await support.stopHook(stopInput(true), undefined, hookOptions)).toEqual({});
+    expect(state.phase).toBe("finished");
+    expect(publish).toHaveBeenCalledWith({
+      version: 1,
+      requestId: "request-1",
+      status: "unavailable",
+      reason: "notReported",
+    });
+
+    await support.stopHook(stopInput(true), undefined, hookOptions);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes only the first unavailable terminal and rejects a late report", async () => {
+    const state = createFileChangeAuditTurnState("request-terminal-race");
+    state.phase = "collecting";
+    const publish = vi.fn(async (_result: AgentFileChangeReportResult) => {});
+    const support = createSupport({ state, publish });
+
+    await Promise.all([
+      support.finishUnavailable(state, "cancelled"),
+      support.finishUnavailable(state, "providerError"),
+    ]);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith({
+      version: 1,
+      requestId: "request-terminal-race",
+      status: "unavailable",
+      reason: "cancelled",
+    });
+    await expect(
+      auditToolHandler(support).handler({ paths: ["src/late.ts"], complete: true }),
+    ).resolves.toMatchObject({ isError: true });
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes roots, drops invalid paths, and deduplicates without truncation", async () => {
+    const cwd = path.join(os.tmpdir(), "file-audit-project");
+    const additionalRoot = path.join(os.tmpdir(), "file-audit-shared");
+    const outside = path.join(os.tmpdir(), "file-audit-outside", "outside.txt");
+    const state = createFileChangeAuditTurnState("request-2");
+    state.phase = "collecting";
+    const published: AgentFileChangeReportResult[] = [];
+    const support = createSupport({
+      state,
+      cwd,
+      additionalDirectories: [additionalRoot],
+      publish: async (result) => void published.push(result),
+    });
+    const tool = auditToolHandler(support);
+
+    expect(tool._meta).toMatchObject({
+      "anthropic/alwaysLoad": true,
+      "claude/endTurn": true,
+    });
+    const result = await tool.handler({
+      paths: [
+        "src/a.ts",
+        "src/a.ts",
+        cwd,
+        additionalRoot,
+        path.join(additionalRoot, "generated.ts"),
+        outside,
+        "bad\u0000path",
+        "bad\u0085path",
+        "x".repeat(4090),
+      ],
+      complete: true,
+      uncertainty: "Generated files may be missing",
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(published).toEqual([
+      {
+        version: 1,
+        requestId: "request-2",
+        status: "reported",
+        paths: [path.join(cwd, "src/a.ts"), path.join(additionalRoot, "generated.ts")],
+        declaredComplete: false,
+        truncated: true,
+        uncertainty: "Generated files may be missing",
+      },
+    ]);
+
+    expect(await tool.handler({ paths: ["src/late.ts"], complete: true })).toMatchObject({
+      isError: true,
+    });
+    expect(published).toHaveLength(1);
+
+    const duplicateOnlyState = createFileChangeAuditTurnState("request-3");
+    duplicateOnlyState.phase = "collecting";
+    const duplicateOnlyReports: AgentFileChangeReportResult[] = [];
+    const duplicateOnlyTool = auditToolHandler(
+      createSupport({
+        state: duplicateOnlyState,
+        cwd,
+        publish: async (report) => void duplicateOnlyReports.push(report),
+      }),
+    );
+    await duplicateOnlyTool.handler({ paths: ["src/a.ts", "src/a.ts"], complete: true });
+    expect(duplicateOnlyReports[0]).toMatchObject({
+      declaredComplete: true,
+      truncated: false,
+      paths: [path.join(cwd, "src/a.ts")],
+    });
+  });
+
+  it("caps path count and total UTF-8 bytes", async () => {
+    const cwd = path.join(os.tmpdir(), "file-audit-caps");
+
+    const countState = createFileChangeAuditTurnState("request-count");
+    countState.phase = "collecting";
+    const countReports: AgentFileChangeReportResult[] = [];
+    await auditToolHandler(
+      createSupport({
+        state: countState,
+        cwd,
+        publish: async (report) => void countReports.push(report),
+      }),
+    ).handler({
+      paths: Array.from({ length: 1030 }, (_, index) => `src/file-${index}.ts`),
+      complete: true,
+    });
+    expect(countReports[0]).toMatchObject({
+      declaredComplete: false,
+      truncated: true,
+    });
+    expect(countReports[0].status).toBe("reported");
+    if (countReports[0].status !== "reported") throw new Error("Expected a reported result");
+    expect(countReports[0].paths).toHaveLength(1024);
+
+    const byteState = createFileChangeAuditTurnState("request-bytes");
+    byteState.phase = "collecting";
+    const byteReports: AgentFileChangeReportResult[] = [];
+    await auditToolHandler(
+      createSupport({
+        state: byteState,
+        cwd,
+        publish: async (report) => void byteReports.push(report),
+      }),
+    ).handler({
+      paths: Array.from(
+        { length: 1000 },
+        (_, index) => `generated/${index}-${"x".repeat(280)}.txt`,
+      ),
+      complete: true,
+    });
+    expect(byteReports[0]).toMatchObject({
+      declaredComplete: false,
+      truncated: true,
+    });
+    expect(byteReports[0].status).toBe("reported");
+    if (byteReports[0].status !== "reported") throw new Error("Expected a reported result");
+    expect(byteReports[0].paths.length).toBeLessThan(1000);
+    expect(Buffer.byteLength(JSON.stringify(byteReports[0]), "utf8")).toBeLessThanOrEqual(
+      AGENT_FILE_CHANGE_REPORT_MAX_BYTES,
+    );
+  });
+
+  it("fails open when report publication fails", async () => {
+    const state = createFileChangeAuditTurnState("request-4");
+    state.phase = "collecting";
+    const logError = vi.fn();
+    const tool = auditToolHandler(
+      createSupport({
+        state,
+        publish: async () => {
+          throw new Error("transport closed");
+        },
+        logError,
+      }),
+    );
+
+    await expect(tool.handler({ paths: ["src/a.ts"], complete: true })).resolves.toMatchObject({
+      structuredContent: { requestId: "request-4", status: "reported" },
+    });
+    expect(state.phase).toBe("finished");
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining("transport closed"));
+
+    const unavailableState = createFileChangeAuditTurnState("request-unavailable-failure");
+    const unavailableSupport = createSupport({
+      state: unavailableState,
+      publish: async () => {
+        throw new Error("transport closed");
+      },
+      logError,
+    });
+    await expect(
+      unavailableSupport.finishUnavailable(unavailableState, "providerError"),
+    ).resolves.toBeUndefined();
+    expect(unavailableState.phase).toBe("finished");
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining("request-unavailable-failure"));
+  });
+});


### PR DESCRIPTION
## Summary

- negotiate the opt-in AIR `_meta.jetbrains.air.agentFileChangeReport` capability
- assign a unique `requestId` to each prompt and return canonical, workspace-bounded changed paths in response metadata
- add a hidden Stop hook and an internal MCP reporting tool so Claude can report files changed through shell commands, Git operations, and generators

The audit is best-effort and is inactive unless the client advertises the capability.

## Safety

- accept reports only for the active session and matching turn request
- canonicalize filesystem aliases, including `/tmp` to `/private/tmp` on macOS
- reject paths outside the session working directory and deduplicate valid paths

## Tests

- `npm run test:run`
- `npm run build`
- `npm run check`