### PR TITLE
fix: use a non-blank gateway placeholder token

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -6614,10 +6614,20 @@ function gatewayRequestToProviderConfig(request?: GatewayAuthRequest): ProviderC
 }
 
 /**
+ * Placeholder credential used when a gateway supplies the real one through
+ * `ANTHROPIC_CUSTOM_HEADERS`. Some value must be present so the CLI skips its
+ * normal login check, and it must not be blank: Claude Code trims the token
+ * before testing it for emptiness (since claude-agent-sdk 0.3.221), so a
+ * whitespace-only placeholder counts as "no credential" and the CLI falls back
+ * to its own OAuth flow, which the client then retries forever.
+ */
+const GATEWAY_PLACEHOLDER_TOKEN = "gateway-placeholder";
+
+/**
  * Map a resolved provider config into the Claude Code env vars that redirect API
  * traffic and inject headers. Returns an empty object when routing is
- * unconfigured. The token/bypass placeholders (`" "`) are required so the CLI
- * skips its normal login/credential checks when a gateway is in use.
+ * unconfigured. The token/bypass placeholders are required so the CLI skips its
+ * normal login/credential checks when a gateway is in use.
  */
 function createEnvForProvider(config: ProviderConfig | null): Record<string, string> {
   if (!config) {
@@ -6651,7 +6661,7 @@ function createEnvForProvider(config: ProviderConfig | null): Record<string, str
   return {
     ANTHROPIC_BASE_URL: config.baseUrl,
     ANTHROPIC_CUSTOM_HEADERS: customHeaders,
-    ANTHROPIC_AUTH_TOKEN: " ", // Must be specified to bypass claude login requirement
+    ANTHROPIC_AUTH_TOKEN: GATEWAY_PLACEHOLDER_TOKEN, // Must be non-blank to bypass claude login requirement
   };
 }
 

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -125,7 +125,7 @@ describe("authorization", () => {
       expect.objectContaining({
         options: expect.objectContaining({
           env: expect.objectContaining({
-            ANTHROPIC_AUTH_TOKEN: " ",
+            ANTHROPIC_AUTH_TOKEN: "gateway-placeholder",
             ANTHROPIC_BASE_URL: "https://gateway.example",
             ANTHROPIC_CUSTOM_HEADERS: "x-api-key: test",
             userEnv: "userEnv",
@@ -133,6 +133,29 @@ describe("authorization", () => {
         }),
       }),
     );
+  });
+
+  it("uses a non-blank placeholder token for the gateway", async () => {
+    const [agent, mockQuery] = await createAgentMock();
+
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        auth: { terminal: true, _meta: { gateway: true } },
+      } as any,
+    });
+
+    await agent.authenticate({
+      methodId: "gateway",
+      _meta: { gateway: { baseUrl: "https://gateway.example", headers: { "x-api-key": "test" } } },
+    });
+
+    await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+    // A whitespace-only token is trimmed away by the CLI, which then falls back
+    // to its own login flow instead of the gateway.
+    const env = mockQuery.mock.calls[0][0].options.env;
+    expect(env.ANTHROPIC_AUTH_TOKEN.trim()).not.toBe("");
   });
 
   it("uses gateway env after gateway auth", async () => {

--- a/src/tests/providers.test.ts
+++ b/src/tests/providers.test.ts
@@ -190,7 +190,7 @@ describe("providers", () => {
       expect.objectContaining({
         options: expect.objectContaining({
           env: expect.objectContaining({
-            ANTHROPIC_AUTH_TOKEN: " ",
+            ANTHROPIC_AUTH_TOKEN: "gateway-placeholder",
             ANTHROPIC_BASE_URL: "https://gateway.example",
             ANTHROPIC_CUSTOM_HEADERS: "x-api-key: test",
           }),


### PR DESCRIPTION
Fixes #999

## Problem

JetBrains gateway authentication never completes. The IDE configures the gateway, the agent reports `auth_required`, the IDE re-runs the gateway auth method, and the two loop forever — so the chat repeats "Authentication required, attempting to resubmit the request." with no error and no way out (#999).

Cause: the CLI refuses to send anything until it believes a credential exists. That check is satisfied by a non-blank `ANTHROPIC_AUTH_TOKEN` **or** by a credential-shaped entry in `ANTHROPIC_CUSTOM_HEADERS`. For JetBrains gateway auth, neither is present:

- the wrapper passed a whitespace-only `ANTHROPIC_AUTH_TOKEN` (`" "`), because the real credential is attached by the IDE's local proxy rather than held by the agent, and *some* value had to be present to skip the login check;
- and the headers the IDE does send are private routing headers only (a proxy key and an agent id), none of which the CLI recognises as a credential.

Since `@anthropic-ai/claude-agent-sdk` 0.3.221 the CLI trims the token before testing it for emptiness, so `" "` now counts as *no credential*. With no header to fall back on, the CLI stops before making any request and emits its synthetic `Not logged in · Please run /login` assistant message with `error: authentication_failed`. The wrapper converts that message into `RequestError.authRequired()` (`src/acp-agent.ts`), the IDE receives `auth_required` on `session/prompt`, and resubmits — forever.

Measured against a local gateway with a blank token, fresh `HOME` and `CLAUDE_CONFIG_DIR`, and `pathToClaudeCodeExecutable` pointed at each published binary.

With `ANTHROPIC_CUSTOM_HEADERS=""`:

| SDK | requests the gateway received | outcome |
| --- | --- | --- |
| 0.3.220 | 9 POSTs to `/v1/messages` | reaches the gateway and retries normally |
| 0.3.232 | **0** | `Not logged in · Please run /login`, `error: authentication_failed` |

With a non-credential custom header present, on 0.3.232 — the shape a real client produces, since a routing key is not a credential:

| `ANTHROPIC_AUTH_TOKEN` | headers | requests | outcome |
| --- | --- | --- | --- |
| `" "` | `x-air-proxy-key: s` | **0** | `Not logged in · Please run /login` |
| unset | `x-air-proxy-key: s` | **0** | `Not logged in · Please run /login` |
| `gateway-placeholder` | `x-air-proxy-key: s` | 7 POSTs | reaches the gateway; both the routing key and `Authorization: Bearer gateway-placeholder` arrive |

Both conditions are required. Passing a *credential-shaped* custom header masks the bug entirely — with `ANTHROPIC_CUSTOM_HEADERS="x-api-key: …"` set, every token value works on both versions, which is why this can look like a non-issue when tested with such a header present.

This is why 0.66.0 works — it pins SDK 0.3.220 — while 0.67.0 and later loop.

## Fix

Send a non-blank placeholder, `gateway-placeholder`, as `ANTHROPIC_AUTH_TOKEN` when a gateway supplies the real credential out of band. The constant carries a comment explaining why the value must not be blank, so it does not get "simplified" back to `" "`.

Verified end to end in the IDE: a build with this change authenticates consistently, and plain 0.67.0 fails consistently.

The providers API is covered by the same change, since `unstable_setProvider` and gateway auth both build their environment through `createEnvForProvider`. That matters for any providers caller whose headers are a routing key rather than a credential — measured above.

`AWS_BEARER_TOKEN_BEDROCK: " "` is deliberately left as is — the bedrock path still accepts a blank placeholder on 0.3.232.

## Tests

New regression test in `src/tests/authorization.test.ts` asserts the gateway token does not trim to empty, plus the two existing expectations updated to the new value.

Note: `src/tests/providers.test.ts` has 4 failures on a clean `main` at 0.68.0 (verified by stashing this change) — pre-existing and unrelated to this PR.

## Follow-up after this lands

agentclientprotocol/registry#503 pinned the JetBrains registry entry to Claude Agent `0.66.0` as a workaround for this bug. That pin should be reverted once a release with this fix is out, so `registry-for-jetbrains.json` tracks the current version again.

Two issues outside this repo remain open regardless of this fix:

- the IDE's gateway headers carry only private routing values, never a credential the agent could forward — the placeholder is only necessary because of that;
- the IDE's local proxy copies an incoming `Authorization` header through to its upstream instead of replacing it, so the placeholder crosses that boundary; harmless today, since the upstream credential uses a different header name, but worth stripping;
- a prompt-level `auth_required` makes the IDE resubmit indefinitely instead of failing the turn once with a visible error.

Internal tracker: LLM-30551.
