### PR TITLE
docs: explain per-session authentication settings

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -42,15 +42,39 @@ node dist/index.js
 
 ## Precedence
 
-When an ACP caller provides `settings` via `_meta.claudeCode.options.settings` in the `sessions/create` request, `CLAUDE_MODEL_CONFIG` is ignored entirely. The env var is a deployment-level fallback for cases where the caller does not configure model settings itself.
+When an ACP caller provides `settings` via `_meta.claudeCode.options.settings` in the `session/new` request, `CLAUDE_MODEL_CONFIG` is ignored entirely. The env var is a deployment-level fallback for cases where the caller does not configure model settings itself.
 
 | Source                                       | Priority                                              |
 | -------------------------------------------- | ----------------------------------------------------- |
 | `_meta.claudeCode.options.settings` (caller) | Highest — used if present                             |
 | `CLAUDE_MODEL_CONFIG` (env var)              | Fallback — used only when caller provides no settings |
 
+## Per-session authentication
+
+Claude Code applies `env` values from `settings.json` after the ACP server process environment. As a result, setting `ANTHROPIC_AUTH_TOKEN` only in an ACP server launch configuration can be overridden by a token in the user's Claude Code settings.
+
+An ACP caller that needs a session-specific credential should supply it through the higher-precedence `_meta.claudeCode.options.settings` object in its `session/new` request. This requires the object form of `settings`:
+
+```json
+{
+  "cwd": "/workspace/project",
+  "_meta": {
+    "claudeCode": {
+      "options": {
+        "settings": {
+          "env": {
+            "ANTHROPIC_AUTH_TOKEN": "${SESSION_TOKEN}"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Resolve `${SESSION_TOKEN}` in the client before it sends the request: claude-agent-acp does not interpolate `${SESSION_TOKEN}`. Obtain the real value from secure credential storage and do not commit it to an ACP configuration file or repository. In sessions without managed provider routing, this object is forwarded to the Claude Agent SDK's programmatic settings tier, so its `env` values take precedence over user and project `settings.json` values. Managed provider routing remains authoritative for the environment variables it owns.
+
 ## Format details
 
 - The value must be valid JSON. Invalid JSON will cause session creation to fail with a parse error.
-- Only `modelOverrides` and `availableModels` keys are read; other keys in the JSON are ignored.
-- Both fields map directly to the Claude Agent SDK's `Settings` type.
+- Only `modelOverrides` and `availableModels` keys are read from `CLAUDE_MODEL_CONFIG`; caller-provided settings map directly to the Claude Agent SDK's `Settings` type.


### PR DESCRIPTION
## Summary

- document why an ACP server launch environment can be overridden by Claude Code settings
- show the object-form `_meta.claudeCode.options.settings` workaround for a session-specific credential
- clarify credential handling and the boundary with managed provider routing
- correct the stale `sessions/create` reference to `session/new`

Fixes #1009.

## Verification

- custom documentation acceptance test (RED then GREEN)
- JSON parse of the documented request example
- `git diff --check`
- `npm run check`
- `npm run build`
- `npm run test:run` (802 passed, 20 skipped)

## Review

Independent review completed after one focused wording repair; no blocking security, correctness, or scope findings.