### PR TITLE
feat: expose native subagents and async tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ metadata is optional for clients: ignoring it preserves normal ACP tool-call ren
 
 ### Subagent sessions
 
-Subagents are exposed only when the client advertises native ACP `subagents` support and the agent
-returns the matching session capability. Without bilateral negotiation, Agent/Task lifecycle,
-child output, and child elicitations remain hidden; child permission requests are still forwarded
-on the root session. There is no legacy tool-shaped subagent fallback.
+Subagents are exposed only after bilateral capability negotiation. Until the released ACP SDKs
+preserve the draft `clientCapabilities.subagents` field, a supporting client may advertise
+`nativeSubagentSessions` in `_meta.jetbrains.air.capabilities`; the adapter mirrors the capability
+in its initialize response. The canonical field remains supported and takes precedence once it is
+available. Without either client signal, Agent/Task lifecycle, child output, and child elicitations
+remain hidden; child permission requests are still forwarded on the root session. There is no
+legacy tool-shaped subagent fallback.
 
 ## Contribution Policy
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Subagents are exposed only after bilateral capability negotiation. Until the rel
 preserve the draft `clientCapabilities.subagents` field, a supporting client may advertise
 `nativeSubagentSessions` in `_meta.jetbrains.air.capabilities`; the adapter mirrors the capability
 in its initialize response. The canonical field remains supported and takes precedence once it is
-available. Without either client signal, Agent/Task lifecycle, child output, and child elicitations
-remain hidden; child permission requests are still forwarded on the root session. There is no
-legacy tool-shaped subagent fallback.
+available. Without either client signal, Agent/Task lifecycle keeps its legacy ordinary ACP
+tool-call representation and child interactions stay on the root session. Clients that use the
+historical `_meta["subagent-transcript"]` capability or `forwardSubagentText` session option retain
+the flattened child transcript behavior.
 
 ## Contribution Policy
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,17 @@ This tool implements an ACP agent by using the official [Claude Agent SDK](https
 - Session-scoped long-running goals through the provider-neutral [goal extension](docs/goal-extension.md)
 - Structured errors, recovery, and warnings through the opt-in [session failure extension](docs/session-failure-extension.md)
 - Tool permission presentation, editable choices, and durable effects through the [permission extension](docs/permission-extension.md)
+- Color-coded tool category metadata for richer client rendering
 
 Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
+
+### Tool category tags
+
+Each `tool_call` and input-refinement `tool_call_update` includes a compact presentation hint in
+`_meta.claudeCode.tags`. A tag has a user-visible `label` and a CSS-compatible `color`, for example
+`[{ "label": "Execute", "color": "#D97706" }]` for Bash. Built-in tools are grouped as Execute,
+Edit, Search, Delegate, Plan, or Skill; unknown tools receive a neutral Tool tag. This namespaced
+metadata is optional for clients: ignoring it preserves normal ACP tool-call rendering.
 
 ### Subagent sessions
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ This tool implements an ACP agent by using the official [Claude Agent SDK](https
 
 Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
 
-### Nested subagent transcripts
+### Subagent sessions
 
-ACP 1.2 has no standard subagent tool kind or nested-message relationship. Clients that can render
-nested transcripts can opt in with `clientCapabilities._meta["subagent-transcript"] = true`.
-The agent then forwards subagent text, thinking, and tool calls, relating nested updates to the
-launching Agent/Task call through `_meta.claudeCode.parentToolUseId`. Agent/Task calls are marked
-with `_meta.claudeCode.subagent = true`.
-
-Clients that do not advertise the capability retain the legacy flattened behavior. In both modes,
-the normal Agent/Task tool result is preserved as the protocol-compatible fallback.
+Subagents are exposed only when the client advertises native ACP `subagents` support and the agent
+returns the matching session capability. Without bilateral negotiation, Agent/Task lifecycle,
+child output, and child elicitations remain hidden; child permission requests are still forwarded
+on the root session. There is no legacy tool-shaped subagent fallback.
 
 ## Contribution Policy
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,8 @@ This tool implements an ACP agent by using the official [Claude Agent SDK](https
 - Session-scoped long-running goals through the provider-neutral [goal extension](docs/goal-extension.md)
 - Structured errors, recovery, and warnings through the opt-in [session failure extension](docs/session-failure-extension.md)
 - Tool permission presentation, editable choices, and durable effects through the [permission extension](docs/permission-extension.md)
-- Color-coded tool category metadata for richer client rendering
 
 Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
-
-### Tool category tags
-
-Each `tool_call` and input-refinement `tool_call_update` includes a compact presentation hint in
-`_meta.claudeCode.tags`. A tag has a user-visible `label` and a CSS-compatible `color`, for example
-`[{ "label": "Execute", "color": "#D97706" }]` for Bash. Built-in tools are grouped as Execute,
-Edit, Search, Delegate, Plan, or Skill; unknown tools receive a neutral Tool tag. This namespaced
-metadata is optional for clients: ignoring it preserves normal ACP tool-call rendering.
 
 ### Subagent sessions
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -108,7 +108,11 @@ import {
   NativeSubagentRuntime,
 } from "./native-subagents.js";
 import { AIR_ASYNC_TASKS_CAPABILITY } from "./air-extension.js";
-import { AsyncTaskRuntime, clientSupportsAsyncTasks } from "./async-tasks.js";
+import {
+  AsyncTaskRuntime,
+  backgroundBashTaskFromToolResult,
+  clientSupportsAsyncTasks,
+} from "./async-tasks.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -4587,7 +4591,15 @@ export class ClaudeAcpAgent {
               content = message.message.content;
             }
 
-            const acceptedPlanToolUseId = observeExitPlanToolResults(message, content, session);
+      const acceptedPlanToolUseId = observeExitPlanToolResults(message, content, session);
+      if (message.type === "user") {
+        const backgroundBashTask = backgroundBashTaskFromToolResult(
+          content,
+          message.tool_use_result,
+          session.toolUseCache,
+        );
+        if (backgroundBashTask) await asyncTasks.taskStarted(backgroundBashTask);
+      }
 
             for (const notification of toAcpNotifications(
               content,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1038,12 +1038,6 @@ export type ToolUpdateMeta = {
   };
 };
 
-const SUBAGENT_TRANSCRIPT_CAPABILITY = "subagent-transcript";
-
-function supportsSubagentTranscript(capabilities?: ClientCapabilities | null): boolean {
-  return capabilities?._meta?.[SUBAGENT_TRANSCRIPT_CAPABILITY] === true;
-}
-
 function nativeSubagentState(status: unknown): SubagentState | undefined {
   switch (status) {
     case "completed":
@@ -2300,14 +2294,20 @@ export class ClaudeAcpAgent {
       const { update } = notification;
       const claudeMeta = update._meta?.claudeCode as
         { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
-
-      if (
-        nativeSubagentsEnabled &&
+      const isSubagentControl =
         (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
         (claudeMeta?.subagent === true ||
           claudeMeta?.toolName === "Agent" ||
-          claudeMeta?.toolName === "Task")
-      ) {
+          claudeMeta?.toolName === "Task");
+
+      if (!nativeSubagentsEnabled && (isSubagentControl || claudeMeta?.parentToolUseId)) {
+        // Child sessions are a bilateral capability. Without negotiation, do
+        // not fall back to provider-specific Agent/Task tools or nested output.
+        // Permission requests bypass this notification path and remain rooted.
+        return;
+      }
+
+      if (nativeSubagentsEnabled && isSubagentControl) {
         const parentTaskId = claudeMeta.parentToolUseId
           ? nativeSubagentTaskByToolUse.get(claudeMeta.parentToolUseId)
           : undefined;
@@ -4685,13 +4685,10 @@ export class ClaudeAcpAgent {
               streamedBlocks.length = 0;
             } else if (
               message.type === "assistant" &&
-              !(session.forwardSubagentText || supportsSubagentTranscript(this.clientCapabilities))
+              !clientSupportsSubagents(this.clientCapabilities)
             ) {
-              // Legacy clients don't understand nested transcripts. Keep the
-              // historical behavior for them: subagent text/thinking remains
-              // internal to the tool call instead of leaking into the top-level
-              // feed. Capable clients opt into the branch above unchanged, with
-              // `parentToolUseId` stamped by toAcpNotifications.
+              // Child content has no visible fallback. Only bilaterally
+              // negotiated native sessions can receive it.
               content = message.message.content.filter(
                 (item) => item.type !== "text" && item.type !== "thinking",
               );
@@ -5373,8 +5370,7 @@ export class ClaudeAcpAgent {
     const toolUseCache: ToolUseCache = {};
     const messages = await getSessionMessages(sessionId);
     const session = this.sessions[sessionId];
-    const forwardSubagentText =
-      session?.forwardSubagentText ?? supportsSubagentTranscript(this.clientCapabilities);
+    const forwardSubagentText = clientSupportsSubagents(this.clientCapabilities);
     const supportsTypedFailures = supportsAirSessionFailures(this.clientCapabilities);
     const activeUsageLimit = supportsTypedFailures ? activeUsageLimitMessage(messages) : undefined;
     const sessionFailures =
@@ -5586,15 +5582,17 @@ export class ClaudeAcpAgent {
     // so emit it now if it hasn't been sent yet. The streamed tool_use chunk
     // later refines it with a `tool_call_update` rather than emitting a
     // duplicate (see `emittedToolCalls` in `toAcpNotifications`).
-    await this.ensureToolCallEmitted(
-      ownerSessionId,
-      toolName,
-      params.toolCall.toolCallId,
-      params.toolCall.rawInput,
-      parentToolUseId,
-      signal,
-      params.sessionId,
-    );
+    if (!parentToolUseId || clientSupportsSubagents(this.clientCapabilities)) {
+      await this.ensureToolCallEmitted(
+        ownerSessionId,
+        toolName,
+        params.toolCall.toolCallId,
+        params.toolCall.rawInput,
+        parentToolUseId,
+        signal,
+        params.sessionId,
+      );
+    }
     if (signal.aborted) throw new Error("Tool use aborted");
 
     // Do not rely on every ACP client settling requestPermission after the
@@ -5752,6 +5750,17 @@ export class ClaudeAcpAgent {
       // routes it through canUseTool whenever a callback is registered, rather
       // than the interactive dialog). Present it as an ACP form elicitation and
       // feed the answers back as updatedInput for the tool's own call() to read.
+      if (
+        toolName === "AskUserQuestion" &&
+        parentToolUseId &&
+        !clientSupportsSubagents(this.clientCapabilities)
+      ) {
+        return {
+          behavior: "deny",
+          message:
+            "Subagent input is unavailable because native subagent sessions were not negotiated.",
+        };
+      }
       if (toolName === "AskUserQuestion" && this.clientCapabilities?.elicitation?.form) {
         // Like permission requests, the elicitation references this toolUseID, so
         // make sure the tool_call has surfaced to the client before we send it.
@@ -6433,9 +6442,7 @@ export class ClaudeAcpAgent {
     // Extract options from _meta if provided
     const sessionMeta = params._meta as NewSessionMeta | undefined;
     const userProvidedOptions = sessionMeta?.claudeCode?.options;
-    const forwardSubagentText =
-      supportsSubagentTranscript(this.clientCapabilities) ||
-      userProvidedOptions?.forwardSubagentText === true;
+    const forwardSubagentText = clientSupportsSubagents(this.clientCapabilities);
 
     // Configure thinking behavior from environment variable
     const thinking = resolveThinkingConfig(process.env.MAX_THINKING_TOKENS, this.logger);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -103,7 +103,8 @@ import {
   SubagentAwareSessionCapabilities,
 } from "./acp-subagents.js";
 import {
-  finishNativeSubagents,
+  isNativeSubagentControlTool,
+  isNativeSubagentControlUpdate,
   NativeSubagent,
   NativeSubagentRuntime,
 } from "./native-subagents.js";
@@ -176,6 +177,8 @@ import {
   applyTaskList,
   applyTaskUpdate,
   ClaudePlanEntry,
+  clearHookCallbacks,
+  completeHookCallback,
   createPostToolUseHook,
   createTaskHook,
   parseTaskCreateOutput,
@@ -188,6 +191,7 @@ import {
   toolInfoFromToolUse,
   toolUpdateFromDiffToolResponse,
   toolUpdateFromToolResult,
+  unregisterHookCallback,
 } from "./tools.js";
 import { nodeToWebReadable, nodeToWebWritable, Pushable, unreachable } from "./utils.js";
 import {
@@ -532,9 +536,11 @@ export type Session = {
    *  lane); a count can't express command coalescing — N queued commands can
    *  fold into ONE turn emitting one result, leaving a stale skip of N-1. */
   pendingOrphanResults?: number;
-  /** Empty user-interruption diagnostics expected from prompts cancelled
-   * before their SDK echo. The next ordinary result clears stale tokens. */
-  pendingEmptyInterruptionDiagnostics?: number;
+  /** UUIDs of cancelled-before-echo commands that can still emit Claude's
+   * empty user-interruption diagnostic. Interrupt receipts and command
+   * lifecycle frames remove commands that were dropped before dispatch; the
+   * next ordinary result clears any stale survivors. */
+  pendingEmptyInterruptionDiagnosticCommands?: Set<string>;
   /** msg_lifecycle_v1 lane of the orphan accounting (see
    *  `pendingOrphanResults` for the count lane): the uuids of cancelled queued
    *  turns whose SDK-side command may still produce an unaccounted result,
@@ -776,6 +782,14 @@ export type Session = {
    *  supplies the immediate parent for nested `task_started` notifications,
    *  whose SDK payload has no lineage field of its own. */
   nativeSubagentParentByToolUseId?: Map<string, string>;
+  /** Session-owned lifecycle controller shared by the consumer, cancel, reset,
+   *  and teardown paths. */
+  nativeSubagentRuntime?: NativeSubagentRuntime;
+  /** Child-aware delivery closure paired with {@link nativeSubagentRuntime}. */
+  nativeSubagentDeliver?: (notification: AcpSessionNotification) => Promise<void>;
+  /** Session-owned async task controller. Prompt cancellation intentionally
+   *  does not finish it because background work may outlive a prompt. */
+  asyncTaskRuntime?: AsyncTaskRuntime;
   /** Whether any top-level assistant text reached the client since the last
    *  stretch boundary. Set as a side effect of sending in the consumer's
    *  `sendUpdate`, never at an emission site; read at the terminal `result`
@@ -1065,6 +1079,28 @@ function supportsSubagentTranscript(capabilities?: ClientCapabilities | null): b
 function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | null {
   if (!("parent_tool_use_id" in message)) return null;
   return typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : null;
+}
+
+function replaySubagentTerminalState(
+  block: Record<string, unknown>,
+): "completed" | "failed" | "cancelled" {
+  if (block.is_error !== true) return "completed";
+  const text = replayContentText(block.content).toLowerCase();
+  return /\b(?:cancelled|canceled|interrupted|stopped|killed)\b/.test(text)
+    ? "cancelled"
+    : "failed";
+}
+
+function replayContentText(value: unknown, seen = new Set<unknown>()): string {
+  if (typeof value === "string") return value;
+  if (typeof value !== "object" || value === null || seen.has(value)) return "";
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => replayContentText(item, seen)).join(" ");
+  const record = value as Record<string, unknown>;
+  return [record.text, record.content, record.message]
+    .map((item) => replayContentText(item, seen))
+    .filter(Boolean)
+    .join(" ");
 }
 
 function stripSubagentTextAndThinking(content: unknown): unknown {
@@ -1480,6 +1516,10 @@ export class ClaudeAcpAgent {
         session.cancelController?.abort();
         this.closeQueryStream(session);
         session.abortController.abort();
+        session.eagerToolCallSessions?.clear();
+        clearHookCallbacks(id);
+        session.nativeSubagentRuntime?.clear();
+        session.asyncTaskRuntime?.clear();
         if (this.sessions[id] === session) delete this.sessions[id];
       },
       settleCancelledTurn: (original, session, turn) => {
@@ -1622,7 +1662,7 @@ export class ClaudeAcpAgent {
       fork: {},
       list: {},
       resume: {},
-      ...(clientSupportsSubagents(request.clientCapabilities) ? { subagents: {} } : {}),
+      subagents: {},
     };
 
     return {
@@ -2251,18 +2291,18 @@ export class ClaudeAcpAgent {
      *  recognizable by the `parentToolUseId` meta that toAcpNotifications
      *  stamps from `parent_tool_use_id`, and never reach the top-level feed
      *  as the turn's answer. */
-    const subagents = new NativeSubagentRuntime(
+    const subagents = (session.nativeSubagentRuntime ??= new NativeSubagentRuntime(
       clientSupportsSubagents(this.clientCapabilities),
       params.sessionId,
       session,
       async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
       this.logger,
-    );
-    const asyncTasks = new AsyncTaskRuntime(
+    ));
+    const asyncTasks = (session.asyncTaskRuntime ??= new AsyncTaskRuntime(
       clientSupportsAsyncTasks(this.clientCapabilities),
       params.sessionId,
       async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
-    );
+    ));
 
     const sendUpdate = async (notification: AcpSessionNotification) => {
       const { update } = notification;
@@ -2284,12 +2324,7 @@ export class ClaudeAcpAgent {
         // Native Agent/Task control calls are intentionally not transcript
         // tools. Do not let the mapper's pre-send de-duplication mark make a
         // later permission request believe that a suppressed call exists.
-        if (
-          toolCallId &&
-          (claudeMeta?.subagent === true ||
-            claudeMeta?.toolName === "Agent" ||
-            claudeMeta?.toolName === "Task")
-        ) {
+        if (toolCallId && isNativeSubagentControlUpdate(update)) {
           session.emittedToolCalls.delete(toolCallId);
         }
         return;
@@ -2323,6 +2358,32 @@ export class ClaudeAcpAgent {
     // the client passed to it. Keep those later updates on the same child-aware
     // routing path as the immediate notifications.
     const routedNotificationClient = { sessionUpdate: sendUpdate } as unknown as AcpClient;
+    session.nativeSubagentDeliver = sendUpdate;
+
+    const finishLifecycle = async (
+      nativeState: "completed" | "failed" | "cancelled",
+      asyncState: "failed" | "stopped",
+      context: string,
+    ): Promise<void> => {
+      await Promise.all([
+        subagents
+          .finishAll(nativeState, sendUpdate)
+          .catch((error) =>
+            this.logger.error(
+              `Session ${params.sessionId}: failed to publish terminal subagent state ${context}`,
+              error,
+            ),
+          ),
+        asyncTasks
+          .finishAll(asyncState)
+          .catch((error) =>
+            this.logger.error(
+              `Session ${params.sessionId}: failed to publish terminal async task state ${context}`,
+              error,
+            ),
+          ),
+      ]);
+    };
 
     let pendingWorkerShutdown = false;
     const isCurrentConsumer = () => this.sessions[params.sessionId] === session;
@@ -2897,15 +2958,11 @@ export class ClaudeAcpAgent {
           // a deferred turn's stored outcome (followup results never mutate
           // it), but the stored one is the authoritative source.
           const inFlight = session.activeTurn;
-          try {
-            await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
-            await asyncTasks.finishAll(session.cancelled ? "stopped" : "failed");
-          } catch (error) {
-            this.logger.error(
-              `Session ${params.sessionId}: failed to publish terminal subagent state`,
-              error,
-            );
-          }
+          await finishLifecycle(
+            session.cancelled ? "cancelled" : "failed",
+            session.cancelled ? "stopped" : "failed",
+            "at end of stream",
+          );
           settleActive(
             session.cancelled
               ? turnOutcome(session, "cancelled")
@@ -3003,6 +3060,7 @@ export class ClaudeAcpAgent {
                 const state = session.orphanCommands?.get(frame.command_uuid);
                 if (state === "pending") {
                   session.orphanCommands?.delete(frame.command_uuid);
+                  session.pendingEmptyInterruptionDiagnosticCommands?.delete(frame.command_uuid);
                 } else if (state === "started") {
                   session.orphanCommands?.set(frame.command_uuid, "zombie");
                 }
@@ -3017,6 +3075,7 @@ export class ClaudeAcpAgent {
               // by receive-side policy before dispatch; never a prompt-lane
               // command of ours, and no result will ever come.
               session.orphanCommands?.delete(frame.command_uuid);
+              session.pendingEmptyInterruptionDiagnosticCommands?.delete(frame.command_uuid);
               break;
             }
             default:
@@ -3358,6 +3417,7 @@ export class ClaudeAcpAgent {
                 break;
               }
               case "permission_denied": {
+                unregisterHookCallback(message.tool_use_id);
                 // A tool call was auto-denied (by a rule, the classifier,
                 // dontAsk mode, etc.) before running. The tool_use block was
                 // already emitted as a `tool_call`, so mark it failed with the
@@ -3385,9 +3445,11 @@ export class ClaudeAcpAgent {
                 const parentToolUseId = message.agent_id
                   ? session.liveBackgroundTasks.get(message.agent_id)?.parentToolUseId
                   : undefined;
+                const eagerOwnerSessionId = session.eagerToolCallSessions?.get(message.tool_use_id);
                 if (
                   message.agent_id &&
                   !parentToolUseId &&
+                  !eagerOwnerSessionId &&
                   clientSupportsSubagents(this.clientCapabilities)
                 ) {
                   // An agent-scoped denial with missing lineage cannot safely
@@ -3510,7 +3572,12 @@ export class ClaudeAcpAgent {
               case "task_notification":
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
-                await subagents.finishTask(message.task_id, message.status, sendUpdate);
+                await subagents.finishTask(
+                  message.task_id,
+                  message.status,
+                  sendUpdate,
+                  message.tool_use_id,
+                );
                 await asyncTasks.taskNotification({
                   task_id: message.task_id,
                   status: message.status,
@@ -3981,16 +4048,21 @@ export class ClaudeAcpAgent {
               if (
                 message.is_error &&
                 isEmptyUserInterruptionDiagnostic(message) &&
-                (session.pendingEmptyInterruptionDiagnostics ?? 0) > 0
+                (session.pendingEmptyInterruptionDiagnosticCommands?.size ?? 0) > 0
               ) {
-                session.pendingEmptyInterruptionDiagnostics!--;
+                const commandUuid = session
+                  .pendingEmptyInterruptionDiagnosticCommands!.values()
+                  .next().value;
+                if (commandUuid) {
+                  session.pendingEmptyInterruptionDiagnosticCommands!.delete(commandUuid);
+                }
                 break;
               }
 
               // Some CLI versions omit the cancelled cycle's diagnostic. Do
               // not let an unused hand-off token swallow a later turn's real
               // interruption failure.
-              session.pendingEmptyInterruptionDiagnostics = 0;
+              session.pendingEmptyInterruptionDiagnosticCommands?.clear();
 
               await clearFailuresFromEarlierTurns();
 
@@ -4783,17 +4855,11 @@ export class ClaudeAcpAgent {
             // and task store are independent of the previous transcript.
             // Clear both the in-memory snapshot and the client's visible plan
             // before any follow-up prompt can republish stale tasks.
-            try {
-              await subagents.finishAll("failed", sendUpdate);
-              await asyncTasks.finishAll("failed");
-            } catch (error) {
-              this.logger.error(
-                `Session ${params.sessionId}: failed to publish reset subagent state`,
-                error,
-              );
-            }
+            await finishLifecycle("failed", "failed", "during conversation reset");
             subagents.clear();
             asyncTasks.clear();
+            session.eagerToolCallSessions?.clear();
+            clearHookCallbacks(params.sessionId);
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
             // A reset mounts a fresh transcript (`new_conversation_id`), so our
@@ -4830,15 +4896,11 @@ export class ClaudeAcpAgent {
           message.includes("process exited with") ||
           message.includes("process terminated by signal") ||
           message.includes("Failed to write to process stdin"));
-      try {
-        await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
-        await asyncTasks.finishAll(session.cancelled ? "stopped" : "failed");
-      } catch (finishError) {
-        this.logger.error(
-          `Session ${params.sessionId}: failed to publish terminal subagent state after stream error`,
-          finishError,
-        );
-      }
+      await finishLifecycle(
+        session.cancelled ? "cancelled" : "failed",
+        session.cancelled ? "stopped" : "failed",
+        "after stream error",
+      );
       if (supportsAirSessionFailures(this.clientCapabilities) && session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
           await failActiveWithSessionFailure(
@@ -4867,6 +4929,10 @@ export class ClaudeAcpAgent {
           ),
         );
         this.closeQueryStream(session);
+        session.eagerToolCallSessions?.clear();
+        clearHookCallbacks(params.sessionId);
+        session.nativeSubagentRuntime?.clear();
+        session.asyncTaskRuntime?.clear();
         delete this.sessions[params.sessionId];
       } else {
         this.logger.error(`Session ${params.sessionId}: query stream error: ${message}`);
@@ -4922,11 +4988,26 @@ export class ClaudeAcpAgent {
     // query.interrupt() on a finished iterator could reject and surface from
     // this fire-and-forget notification, so there is nothing to do here.
     if (session.queryClosed) {
+      session.eagerToolCallSessions?.clear();
+      clearHookCallbacks(params.sessionId);
       return;
     }
-    await finishNativeSubagents(session, "cancelled", async (notification) =>
-      this.client.sessionUpdate(asSdkSessionNotification(notification)),
-    );
+    try {
+      await session.nativeSubagentRuntime?.finishAll(
+        "cancelled",
+        session.nativeSubagentDeliver ??
+          (async (notification) =>
+            this.client.sessionUpdate(asSdkSessionNotification(notification))),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Session ${params.sessionId}: failed to publish cancelled subagent state`,
+        error,
+      );
+    } finally {
+      session.eagerToolCallSessions?.clear();
+      clearHookCallbacks(params.sessionId);
+    }
     // A priority steer may still be queued in the SDK when cancellation
     // settles its owning turn. Its later echo matches no live turn, and its
     // result must be skipped rather than promoted onto the next prompt.
@@ -5009,9 +5090,23 @@ export class ClaudeAcpAgent {
         (turn) => turn === session.activeTurn && !turn.settled,
       );
     }
-    if (orphanedTurns.length > 0) {
-      session.pendingEmptyInterruptionDiagnostics =
-        (session.pendingEmptyInterruptionDiagnostics ?? 0) + orphanedTurns.length;
+    const diagnosticTurns = orphanedTurns.filter((turn) => {
+      if (
+        turn.commandFinished === "completed" ||
+        turn.commandFinished === "discarded" ||
+        turn.commandFinished === "refused"
+      ) {
+        return false;
+      }
+      if (turn.commandStarted && turn.commandResultSeen) return false;
+      if (turn.commandFinished === "cancelled" && !turn.commandStarted) return false;
+      return true;
+    });
+    if (diagnosticTurns.length > 0) {
+      session.pendingEmptyInterruptionDiagnosticCommands ??= new Set();
+      for (const turn of diagnosticTurns) {
+        session.pendingEmptyInterruptionDiagnosticCommands.add(turn.promptUuid);
+      }
     }
 
     // A deferred active turn (see Turn.deferredSettle) already has its
@@ -5125,6 +5220,11 @@ export class ClaudeAcpAgent {
     // activation-time self-heal.
     if (Array.isArray(receipt?.still_queued) && orphanedTurns.length > 0) {
       const stillQueued = new Set(receipt.still_queued);
+      const droppedTurns = orphanedTurns.filter((turn) => !stillQueued.has(turn.promptUuid));
+      const droppedCount = droppedTurns.length;
+      for (const turn of droppedTurns) {
+        session.pendingEmptyInterruptionDiagnosticCommands?.delete(turn.promptUuid);
+      }
       if (lifecycleLane) {
         // Lifecycle lane: forget dropped orphans by uuid. Only entries still
         // "pending" — an orphan absent from `still_queued` because it was
@@ -5144,9 +5244,11 @@ export class ClaudeAcpAgent {
           }
         }
       } else {
-        const dropped = orphanedTurns.filter((turn) => !stillQueued.has(turn.promptUuid)).length;
-        if (dropped > 0) {
-          session.pendingOrphanResults = Math.max(0, (session.pendingOrphanResults ?? 0) - dropped);
+        if (droppedCount > 0) {
+          session.pendingOrphanResults = Math.max(
+            0,
+            (session.pendingOrphanResults ?? 0) - droppedCount,
+          );
         }
       }
     }
@@ -5209,6 +5311,10 @@ export class ClaudeAcpAgent {
     // here the client has asked us to close the session, so signalling abort is
     // appropriate; query.close() above has already torn the subprocess down.
     session.abortController.abort();
+    session.eagerToolCallSessions?.clear();
+    clearHookCallbacks(sessionId);
+    session.nativeSubagentRuntime?.clear();
+    session.asyncTaskRuntime?.clear();
     delete this.sessions[sessionId];
   }
 
@@ -5363,6 +5469,128 @@ export class ClaudeAcpAgent {
     // ends an incomplete audit lane.
     let replayingFileChangeAudit = false;
     const replayFileChangeAuditToolUseIds = new Set<string>();
+    const nativeReplayEnabled = clientSupportsSubagents(this.clientCapabilities);
+    const replayTerminalStates = new Map<string, "completed" | "failed" | "cancelled">();
+    const replayChildren = new Map<
+      string,
+      {
+        sessionId: string;
+        parentToolUseId?: string;
+        name: string;
+        task: string;
+        reconstructable: boolean;
+        announced: boolean;
+        terminalState?: "completed" | "failed" | "cancelled";
+      }
+    >();
+
+    if (nativeReplayEnabled) {
+      for (const message of messages) {
+        const content = (message as unknown as { message?: { content?: unknown } }).message
+          ?.content;
+        if (!Array.isArray(content)) continue;
+        const ownerToolUseId = parentToolUseIdOf(message);
+        for (const block of content) {
+          if (
+            typeof block === "object" &&
+            block !== null &&
+            "type" in block &&
+            (block.type === "tool_result" || block.type === "mcp_tool_result") &&
+            "tool_use_id" in block &&
+            typeof block.tool_use_id === "string"
+          ) {
+            replayTerminalStates.set(block.tool_use_id, replaySubagentTerminalState(block));
+          }
+          if (
+            typeof block !== "object" ||
+            block === null ||
+            !("type" in block) ||
+            !["tool_use", "server_tool_use", "mcp_tool_use"].includes(String(block.type)) ||
+            !("id" in block) ||
+            typeof block.id !== "string" ||
+            !("name" in block) ||
+            !isNativeSubagentControlTool(block.name)
+          ) {
+            continue;
+          }
+          const input =
+            "input" in block && typeof block.input === "object" && block.input !== null
+              ? (block.input as Record<string, unknown>)
+              : {};
+          const task =
+            [input.prompt, input.description]
+              .find(
+                (value): value is string => typeof value === "string" && value.trim().length > 0,
+              )
+              ?.trim() ?? "Delegated task restored from session history";
+          const name =
+            [input.name, input.description, input.subagent_type]
+              .find(
+                (value): value is string => typeof value === "string" && value.trim().length > 0,
+              )
+              ?.trim() ?? "Restored agent";
+          replayChildren.set(block.id, {
+            sessionId: `${sessionId}:replay-subagent:${block.id}`,
+            ...(ownerToolUseId ? { parentToolUseId: ownerToolUseId } : {}),
+            name,
+            task,
+            reconstructable: true,
+            announced: false,
+            terminalState: replayTerminalStates.get(block.id),
+          });
+        }
+      }
+      for (const [toolUseId, terminalState] of replayTerminalStates) {
+        const child = replayChildren.get(toolUseId);
+        if (child) child.terminalState = terminalState;
+      }
+    }
+
+    const announceReplayChild = async (
+      parentToolUseId: string,
+      ancestors = new Set<string>(),
+    ): Promise<string> => {
+      let child = replayChildren.get(parentToolUseId);
+      if (!child) {
+        child = {
+          sessionId: `${sessionId}:replay-subagent:${parentToolUseId}`,
+          name: "Disconnected agent",
+          task: "Subagent restored without persisted launch metadata",
+          reconstructable: false,
+          announced: false,
+        };
+        replayChildren.set(parentToolUseId, child);
+      }
+      if (ancestors.has(parentToolUseId)) {
+        child.reconstructable = false;
+        child.terminalState = undefined;
+        child.parentToolUseId = undefined;
+      }
+      if (child.parentToolUseId) {
+        const nextAncestors = new Set(ancestors);
+        nextAncestors.add(parentToolUseId);
+        await announceReplayChild(child.parentToolUseId, nextAncestors);
+      }
+      if (!child.announced) {
+        const parentSessionId = child.parentToolUseId
+          ? (replayChildren.get(child.parentToolUseId)?.sessionId ?? sessionId)
+          : sessionId;
+        await this.client.sessionUpdate(
+          asSdkSessionNotification({
+            sessionId: parentSessionId,
+            update: {
+              sessionUpdate: "subagent_spawned",
+              subagentSessionId: child.sessionId,
+              name: child.name,
+              task: child.task,
+              capabilities: {},
+            },
+          }),
+        );
+        child.announced = true;
+      }
+      return child.sessionId;
+    };
 
     for (const message of messages) {
       if (
@@ -5416,16 +5644,16 @@ export class ClaudeAcpAgent {
       // @ts-expect-error - untyped in SDK but we handle all of these
       let content: unknown = message.message.content;
       const parentToolUseId = parentToolUseIdOf(message);
-      if (parentToolUseId && clientSupportsSubagents(this.clientCapabilities)) {
-        // Persisted SDK sidechains do not contain the authoritative
-        // task_started/task_updated lifecycle needed to reconstruct a native
-        // child session. Never replay them into the root transcript: an
-        // unsupported client must not see a legacy child representation, and
-        // a capable client must not receive child output without a preceding
-        // subagent_spawned event.
-        continue;
-      }
-      if (message.type === "assistant" && parentToolUseId && !forwardSubagentText) {
+      const replayTargetSessionId =
+        nativeReplayEnabled && parentToolUseId
+          ? await announceReplayChild(parentToolUseId)
+          : sessionId;
+      if (
+        message.type === "assistant" &&
+        parentToolUseId &&
+        !nativeReplayEnabled &&
+        !forwardSubagentText
+      ) {
         content = stripSubagentTextAndThinking(content);
       }
       // @ts-expect-error - untyped in SDK but we handle all of these
@@ -5512,7 +5740,43 @@ export class ClaudeAcpAgent {
           parentToolUseId,
         },
       )) {
-        await this.client.sessionUpdate(notification);
+        const toolName = (
+          notification.update._meta?.claudeCode as { toolName?: string } | undefined
+        )?.toolName;
+        if (
+          nativeReplayEnabled &&
+          (notification.update.sessionUpdate === "tool_call" ||
+            notification.update.sessionUpdate === "tool_call_update") &&
+          isNativeSubagentControlTool(toolName)
+        ) {
+          continue;
+        }
+        await this.client.sessionUpdate({ ...notification, sessionId: replayTargetSessionId });
+      }
+    }
+
+    if (nativeReplayEnabled) {
+      // Claude history persists sidechain messages and Agent/Task tool uses,
+      // but not task_started/task_updated lifecycle frames. Recover terminal
+      // state from the launch tool_result. Missing results and malformed or
+      // orphan lineage use the draft protocol's deterministic disconnected state.
+      for (const child of [...replayChildren.values()].reverse()) {
+        if (!child.announced) continue;
+        const parentSessionId = child.parentToolUseId
+          ? (replayChildren.get(child.parentToolUseId)?.sessionId ?? sessionId)
+          : sessionId;
+        await this.client.sessionUpdate(
+          asSdkSessionNotification({
+            sessionId: parentSessionId,
+            update: {
+              sessionUpdate: "subagent_state_update",
+              subagentSessionId: child.sessionId,
+              state: child.reconstructable
+                ? (child.terminalState ?? "disconnected")
+                : "disconnected",
+            },
+          }),
+        );
       }
     }
   }
@@ -8470,37 +8734,44 @@ export function toAcpNotifications(
             // closing over the name keeps the diff working without depending on
             // (or pinning) the cache entry's lifetime.
             const toolName = chunk.name;
-            registerHookCallback(chunk.id, {
-              onPostToolUseHook: async (toolUseId, toolInput, toolResponse) => {
-                // Both `Edit` and `Write` produce a structuredPatch in their
-                // PostToolUse tool_response. For Edit the diff replaces the
-                // optimistic content built at tool_use time. For Write the
-                // optimistic content (built from `input.content` alone with
-                // `oldText: null`) shows "creation" semantics regardless of
-                // whether the file existed; the structuredPatch from the
-                // hook lets us emit the real diff for `type: "update"`. The
-                // helper returns `{}` if the response shape isn't usable.
-                const editDiff =
-                  toolName === "Edit" || toolName === "Write"
-                    ? toolUpdateFromDiffToolResponse(toolResponse)
-                    : {};
-                const update: SessionNotification["update"] = {
-                  _meta: {
-                    claudeCode: {
-                      toolResponse,
-                      toolName,
-                    },
-                  } satisfies ToolUpdateMeta,
-                  toolCallId: toolUseId,
-                  sessionUpdate: "tool_call_update",
-                  ...editDiff,
-                };
-                await client.sessionUpdate({
-                  sessionId,
-                  update,
-                });
+            registerHookCallback(
+              chunk.id,
+              {
+                onPostToolUseHook: async (toolUseId, toolInput, toolResponse) => {
+                  // Both `Edit` and `Write` produce a structuredPatch in their
+                  // PostToolUse tool_response. For Edit the diff replaces the
+                  // optimistic content built at tool_use time. For Write the
+                  // optimistic content (built from `input.content` alone with
+                  // `oldText: null`) shows "creation" semantics regardless of
+                  // whether the file existed; the structuredPatch from the
+                  // hook lets us emit the real diff for `type: "update"`. The
+                  // helper returns `{}` if the response shape isn't usable.
+                  const editDiff =
+                    toolName === "Edit" || toolName === "Write"
+                      ? toolUpdateFromDiffToolResponse(toolResponse)
+                      : {};
+                  const update: SessionNotification["update"] = {
+                    _meta: {
+                      claudeCode: {
+                        toolResponse,
+                        toolName,
+                        ...(options?.parentToolUseId
+                          ? { parentToolUseId: options.parentToolUseId }
+                          : {}),
+                      },
+                    } satisfies ToolUpdateMeta,
+                    toolCallId: toolUseId,
+                    sessionUpdate: "tool_call_update",
+                    ...editDiff,
+                  };
+                  await client.sessionUpdate({
+                    sessionId,
+                    update,
+                  });
+                },
               },
-            });
+              sessionId,
+            );
           }
 
           let rawInput;
@@ -8550,6 +8821,7 @@ export function toAcpNotifications(
       case "mcp_tool_result": {
         const wasEmitted = options?.emittedToolCalls?.has(chunk.tool_use_id) === true;
         options?.emittedToolCalls?.delete(chunk.tool_use_id);
+        completeHookCallback(chunk.tool_use_id);
         // Why this is_error result carries harness prose instead of tool
         // output (user-rejected / interrupted / …), when the SDK said so.
         // Spread into the claudeCode meta of every update emitted below; the

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2812,7 +2812,14 @@ export class ClaudeAcpAgent {
           // a deferred turn's stored outcome (followup results never mutate
           // it), but the stored one is the authoritative source.
           const inFlight = session.activeTurn;
-          await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+          try {
+            await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+          } catch (error) {
+            this.logger.error(
+              `Session ${params.sessionId}: failed to publish terminal subagent state`,
+              error,
+            );
+          }
           settleActive(
             session.cancelled
               ? turnOutcome(session, "cancelled")
@@ -4627,7 +4634,14 @@ export class ClaudeAcpAgent {
             // and task store are independent of the previous transcript.
             // Clear both the in-memory snapshot and the client's visible plan
             // before any follow-up prompt can republish stale tasks.
-            await subagents.finishAll("failed", sendUpdate);
+            try {
+              await subagents.finishAll("failed", sendUpdate);
+            } catch (error) {
+              this.logger.error(
+                `Session ${params.sessionId}: failed to publish reset subagent state`,
+                error,
+              );
+            }
             subagents.clear();
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
@@ -4665,7 +4679,14 @@ export class ClaudeAcpAgent {
           message.includes("process exited with") ||
           message.includes("process terminated by signal") ||
           message.includes("Failed to write to process stdin"));
-      await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+      try {
+        await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+      } catch (finishError) {
+        this.logger.error(
+          `Session ${params.sessionId}: failed to publish terminal subagent state after stream error`,
+          finishError,
+        );
+      }
       if (supportsAirSessionFailures(this.clientCapabilities) && session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
           await failActiveWithSessionFailure(
@@ -5012,7 +5033,11 @@ export class ClaudeAcpAgent {
     if (!session) {
       return;
     }
-    await this.cancel({ sessionId });
+    try {
+      await this.cancel({ sessionId });
+    } catch (error) {
+      this.logger.error(`Session ${sessionId}: cancellation failed during teardown`, error);
+    }
     // cancel() arms the force-cancel floor and interrupts gracefully, but a
     // wedged consumer only wakes when `cancelController` aborts — closeQueryStream
     // below doesn't touch it. Since we're tearing the session down anyway, wake
@@ -5368,6 +5393,7 @@ export class ClaudeAcpAgent {
     signal: AbortSignal,
     parentToolUseId?: string,
     ownerSessionId: string = params.sessionId,
+    originatesFromSubagent: boolean = false,
   ): Promise<RequestPermissionResponse> {
     if (signal.aborted) throw new Error("Tool use aborted");
     // The SDK may invoke `canUseTool` (and therefore this permission request)
@@ -5376,7 +5402,10 @@ export class ClaudeAcpAgent {
     // so emit it now if it hasn't been sent yet. The streamed tool_use chunk
     // later refines it with a `tool_call_update` rather than emitting a
     // duplicate (see `emittedToolCalls` in `toAcpNotifications`).
-    if (!parentToolUseId || clientSupportsSubagents(this.clientCapabilities)) {
+    if (
+      (!originatesFromSubagent && !parentToolUseId) ||
+      clientSupportsSubagents(this.clientCapabilities)
+    ) {
       await this.ensureToolCallEmitted(
         ownerSessionId,
         toolName,
@@ -5544,17 +5573,6 @@ export class ClaudeAcpAgent {
       // routes it through canUseTool whenever a callback is registered, rather
       // than the interactive dialog). Present it as an ACP form elicitation and
       // feed the answers back as updatedInput for the tool's own call() to read.
-      if (
-        toolName === "AskUserQuestion" &&
-        parentToolUseId &&
-        !clientSupportsSubagents(this.clientCapabilities)
-      ) {
-        return {
-          behavior: "deny",
-          message:
-            "Subagent input is unavailable because native subagent sessions were not negotiated.",
-        };
-      }
       if (toolName === "AskUserQuestion" && this.clientCapabilities?.elicitation?.form) {
         // Like permission requests, the elicitation references this toolUseID, so
         // make sure the tool_call has surfaced to the client before we send it.
@@ -5629,6 +5647,7 @@ export class ClaudeAcpAgent {
         signal,
         parentToolUseId,
         sessionId,
+        agentID !== undefined,
       );
       if (signal.aborted) throw new Error("Tool use aborted");
       const decodedPermission = decodeClaudePermissionResponse(

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -100,8 +100,12 @@ import {
   asSdkSessionNotification,
   clientSupportsSubagents,
   SubagentAwareSessionCapabilities,
-  SubagentState,
 } from "./acp-subagents.js";
+import {
+  finishNativeSubagents,
+  NativeSubagent,
+  NativeSubagentRuntime,
+} from "./native-subagents.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -454,20 +458,6 @@ type Turn = {
   /** Settles after the ACP prompt request completes, regardless of outcome. */
   completion?: Promise<void>;
 };
-
-type NativeSubagent = {
-  sessionId: string;
-  parentSessionId: string;
-  parentToolUseId?: string;
-  name: string;
-  task: string;
-  announced?: boolean;
-  terminalState?: SubagentState;
-};
-
-const MAX_PENDING_NATIVE_SUBAGENT_PARENTS = 64;
-const MAX_PENDING_NATIVE_SUBAGENT_UPDATES = 256;
-const MAX_PENDING_NATIVE_SUBAGENT_UPDATES_PER_PARENT = 32;
 
 export type Session = {
   query: Query;
@@ -1037,33 +1027,6 @@ export type ToolUpdateMeta = {
     signal: string | null;
   };
 };
-
-function nativeSubagentState(status: unknown): SubagentState | undefined {
-  switch (status) {
-    case "completed":
-      return "completed";
-    case "failed":
-      return "failed";
-    case "killed":
-    case "stopped":
-    case "cancelled":
-      return "cancelled";
-    default:
-      return undefined;
-  }
-}
-
-function subagentDisplayName(type: unknown, taskId: string): string {
-  if (typeof type === "string" && type.trim().length > 0) return type.trim();
-  const suffix = taskId.length > 8 ? taskId.slice(-8) : taskId;
-  return `Agent ${suffix}`;
-}
-
-function subagentTask(description: unknown): string {
-  return typeof description === "string" && description.trim().length > 0
-    ? description.trim()
-    : "Delegated task";
-}
 
 function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | null {
   if (!("parent_tool_use_id" in message)) return null;
@@ -2239,105 +2202,20 @@ export class ClaudeAcpAgent {
      *  recognizable by the `parentToolUseId` meta that toAcpNotifications
      *  stamps from `parent_tool_use_id`, and never reach the top-level feed
      *  as the turn's answer. */
-    const nativeSubagentsEnabled = clientSupportsSubagents(this.clientCapabilities);
-    const nativeSubagents = (session.nativeSubagentsByTaskId ??= new Map());
-    const nativeSubagentTaskByToolUse = (session.nativeSubagentTaskIdByToolUseId ??= new Map());
-    const nativeSubagentParentByToolUse = (session.nativeSubagentParentByToolUseId ??= new Map());
-    const pendingNativeSubagentUpdates = new Map<string, AcpSessionNotification[]>();
-    let pendingNativeSubagentUpdateCount = 0;
-
-    const takePendingNativeSubagentUpdates = (parentToolUseId: string) => {
-      const pending = pendingNativeSubagentUpdates.get(parentToolUseId) ?? [];
-      if (pending.length > 0) {
-        pendingNativeSubagentUpdates.delete(parentToolUseId);
-        pendingNativeSubagentUpdateCount -= pending.length;
-      }
-      return pending;
-    };
-
-    const bufferNativeSubagentUpdate = (
-      parentToolUseId: string,
-      notification: AcpSessionNotification,
-    ) => {
-      const pending = pendingNativeSubagentUpdates.get(parentToolUseId);
-      if (
-        pendingNativeSubagentUpdateCount >= MAX_PENDING_NATIVE_SUBAGENT_UPDATES ||
-        (pending === undefined &&
-          pendingNativeSubagentUpdates.size >= MAX_PENDING_NATIVE_SUBAGENT_PARENTS) ||
-        (pending?.length ?? 0) >= MAX_PENDING_NATIVE_SUBAGENT_UPDATES_PER_PARENT
-      ) {
-        this.logger.log(
-          `Session ${params.sessionId}: dropping unattributed subagent update for ${parentToolUseId}; pending buffer limit reached`,
-        );
-        return;
-      }
-      if (pending) {
-        pending.push(notification);
-      } else {
-        pendingNativeSubagentUpdates.set(parentToolUseId, [notification]);
-      }
-      pendingNativeSubagentUpdateCount++;
-    };
+    const subagents = new NativeSubagentRuntime(
+      clientSupportsSubagents(this.clientCapabilities),
+      params.sessionId,
+      session,
+      async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
+      this.logger,
+    );
 
     const sendUpdate = async (notification: AcpSessionNotification) => {
       const { update } = notification;
       const claudeMeta = update._meta?.claudeCode as
         { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
-      const isSubagentControl =
-        (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
-        (claudeMeta?.subagent === true ||
-          claudeMeta?.toolName === "Agent" ||
-          claudeMeta?.toolName === "Task");
-
-      if (!nativeSubagentsEnabled && (isSubagentControl || claudeMeta?.parentToolUseId)) {
-        // Child sessions are a bilateral capability. Without negotiation, do
-        // not fall back to provider-specific Agent/Task tools or nested output.
-        // Permission requests bypass this notification path and remain rooted.
-        return;
-      }
-
-      if (nativeSubagentsEnabled && isSubagentControl) {
-        const parentTaskId = claudeMeta.parentToolUseId
-          ? nativeSubagentTaskByToolUse.get(claudeMeta.parentToolUseId)
-          : undefined;
-        const parentSessionId = parentTaskId
-          ? nativeSubagents.get(parentTaskId)?.sessionId
-          : params.sessionId;
-        nativeSubagentParentByToolUse.set(update.toolCallId, parentSessionId ?? params.sessionId);
-        // `task_started` and the assistant frame containing its Agent/Task
-        // tool_use are separate SDK events with no ordering guarantee. If the
-        // start arrived first, it was deliberately left unannounced until this
-        // frame supplied the immediate parent for a nested child.
-        for (const child of nativeSubagents.values()) {
-          if (child.parentToolUseId !== update.toolCallId || child.announced) continue;
-          child.parentSessionId = parentSessionId ?? params.sessionId;
-          await this.announceNativeSubagent(child);
-          for (const pending of takePendingNativeSubagentUpdates(update.toolCallId)) {
-            await sendUpdate(pending);
-          }
-        }
-        // Native clients receive a dedicated subagent session and timeline
-        // lifecycle. Emitting the legacy Agent/Task tool call as well would
-        // create a duplicate representation of the same worker.
-        return;
-      }
-
-      let routedNotification = notification;
-      if (nativeSubagentsEnabled && claudeMeta?.parentToolUseId) {
-        const taskId = nativeSubagentTaskByToolUse.get(claudeMeta.parentToolUseId);
-        const child = taskId ? nativeSubagents.get(taskId) : undefined;
-        if (!child || !child.announced) {
-          bufferNativeSubagentUpdate(claudeMeta.parentToolUseId, notification);
-          return;
-        }
-        if (child.terminalState !== undefined) {
-          this.logger.log(
-            `Session ${params.sessionId}: ignoring late update for terminal subagent ${child.sessionId}`,
-          );
-          return;
-        }
-        routedNotification = { ...notification, sessionId: child.sessionId };
-      }
+      const routedNotification = await subagents.route(notification, sendUpdate);
+      if (!routedNotification) return;
       if (
         isFileChangeAuditReportPhase(session.activeTurn?.fileChangeAudit) &&
         (update.sessionUpdate === "agent_message_chunk" ||
@@ -2360,31 +2238,6 @@ export class ClaudeAcpAgent {
     // the client passed to it. Keep those later updates on the same child-aware
     // routing path as the immediate notifications.
     const routedNotificationClient = { sessionUpdate: sendUpdate } as unknown as AcpClient;
-
-    const finishNativeSubagent = async (taskId: string, status: unknown): Promise<void> => {
-      if (!nativeSubagentsEnabled) return;
-      const state = nativeSubagentState(status);
-      const child = nativeSubagents.get(taskId);
-      if (!state || !child || child.terminalState !== undefined) return;
-      // A provider may omit or reorder the assistant Agent/Task frame. The
-      // lifecycle must still be well-formed, so fall back to the root parent
-      // only when the task is already terminal and no lineage frame arrived.
-      await this.announceNativeSubagent(child);
-      if (child.parentToolUseId) {
-        for (const pending of takePendingNativeSubagentUpdates(child.parentToolUseId)) {
-          await sendUpdate(pending);
-        }
-      }
-      await this.finishNativeSubagent(session, taskId, state);
-    };
-
-    const finishNativeSubagents = async (state: SubagentState): Promise<void> => {
-      for (const taskId of [...nativeSubagents.keys()].reverse()) {
-        await finishNativeSubagent(taskId, state);
-      }
-      pendingNativeSubagentUpdates.clear();
-      pendingNativeSubagentUpdateCount = 0;
-    };
 
     let pendingWorkerShutdown = false;
     const isCurrentConsumer = () => this.sessions[params.sessionId] === session;
@@ -2959,7 +2812,7 @@ export class ClaudeAcpAgent {
           // a deferred turn's stored outcome (followup results never mutate
           // it), but the stored one is the authoritative source.
           const inFlight = session.activeTurn;
-          await finishNativeSubagents(session.cancelled ? "cancelled" : "failed");
+          await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
           settleActive(
             session.cancelled
               ? turnOutcome(session, "cancelled")
@@ -3525,41 +3378,15 @@ export class ClaudeAcpAgent {
                   parentToolUseId: message.tool_use_id,
                   isSubagent: !!message.subagent_type,
                 });
-                if (nativeSubagentsEnabled && message.subagent_type) {
-                  const existing = nativeSubagents.get(message.task_id);
-                  if (!existing) {
-                    const knownParentSessionId = message.tool_use_id
-                      ? nativeSubagentParentByToolUse.get(message.tool_use_id)
-                      : undefined;
-                    const child: NativeSubagent = {
-                      sessionId: message.task_id,
-                      parentSessionId: knownParentSessionId ?? params.sessionId,
-                      parentToolUseId: message.tool_use_id,
-                      name: subagentDisplayName(message.subagent_type, message.task_id),
-                      task: subagentTask(message.description),
-                    };
-                    nativeSubagents.set(message.task_id, child);
-                    if (message.tool_use_id) {
-                      nativeSubagentTaskByToolUse.set(message.tool_use_id, message.task_id);
-                    }
-                    // If the spawning tool frame has already supplied lineage,
-                    // announce immediately. Otherwise wait for that frame so a
-                    // nested child is not incorrectly attached to the root.
-                    if (knownParentSessionId || !message.tool_use_id) {
-                      await this.announceNativeSubagent(child);
-                      for (const notification of message.tool_use_id
-                        ? takePendingNativeSubagentUpdates(message.tool_use_id)
-                        : []) {
-                        await sendUpdate(notification);
-                      }
-                    }
-                  }
-                } else if (nativeSubagentsEnabled && message.tool_use_id) {
-                  // Early output carrying this id cannot belong to a native
-                  // subagent once task_started identifies it as another kind
-                  // of background task.
-                  takePendingNativeSubagentUpdates(message.tool_use_id);
-                }
+                await subagents.taskStarted(
+                  {
+                    taskId: message.task_id,
+                    toolUseId: message.tool_use_id,
+                    subagentType: message.subagent_type,
+                    description: message.description,
+                  },
+                  sendUpdate,
+                );
                 if (message.subagent_type && session.activeTurn && !session.activeTurn.settled) {
                   (session.activeTurn.spawnedTaskIds ??= new Set()).add(message.task_id);
                 }
@@ -3567,10 +3394,8 @@ export class ClaudeAcpAgent {
               case "task_notification":
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
-                await finishNativeSubagent(message.task_id, message.status);
-                if (nativeSubagentsEnabled && message.tool_use_id) {
-                  takePendingNativeSubagentUpdates(message.tool_use_id);
-                }
+                await subagents.finishTask(message.task_id, message.status, sendUpdate);
+                if (message.tool_use_id) subagents.discardPending(message.tool_use_id);
                 session.liveBackgroundTasks.delete(message.task_id);
                 break;
               case "task_updated":
@@ -3584,7 +3409,7 @@ export class ClaudeAcpAgent {
                   message.patch.status === "failed" ||
                   message.patch.status === "killed"
                 ) {
-                  await finishNativeSubagent(message.task_id, message.patch.status);
+                  await subagents.finishTask(message.task_id, message.patch.status, sendUpdate);
                   session.liveBackgroundTasks.delete(message.task_id);
                 }
                 break;
@@ -4802,10 +4627,8 @@ export class ClaudeAcpAgent {
             // and task store are independent of the previous transcript.
             // Clear both the in-memory snapshot and the client's visible plan
             // before any follow-up prompt can republish stale tasks.
-            await finishNativeSubagents("failed");
-            nativeSubagents.clear();
-            nativeSubagentTaskByToolUse.clear();
-            nativeSubagentParentByToolUse.clear();
+            await subagents.finishAll("failed", sendUpdate);
+            subagents.clear();
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
             // A reset mounts a fresh transcript (`new_conversation_id`), so our
@@ -4842,7 +4665,7 @@ export class ClaudeAcpAgent {
           message.includes("process exited with") ||
           message.includes("process terminated by signal") ||
           message.includes("Failed to write to process stdin"));
-      await finishNativeSubagents(session.cancelled ? "cancelled" : "failed");
+      await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
       if (supportsAirSessionFailures(this.clientCapabilities) && session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
           await failActiveWithSessionFailure(
@@ -4881,47 +4704,6 @@ export class ClaudeAcpAgent {
         );
         this.closeQueryStream(session);
       }
-    }
-  }
-
-  private async announceNativeSubagent(child: NativeSubagent): Promise<void> {
-    if (child.announced) return;
-    await this.client.sessionUpdate({
-      sessionId: child.parentSessionId,
-      update: {
-        sessionUpdate: "subagent_spawned",
-        subagentSessionId: child.sessionId,
-        name: child.name,
-        task: child.task,
-        capabilities: {},
-      },
-    });
-    child.announced = true;
-  }
-
-  private async finishNativeSubagent(
-    session: Session,
-    taskId: string,
-    state: SubagentState,
-  ): Promise<void> {
-    const child = session.nativeSubagentsByTaskId?.get(taskId);
-    if (!child || child.terminalState !== undefined) return;
-    await this.announceNativeSubagent(child);
-    child.terminalState = state;
-    await this.client.sessionUpdate({
-      sessionId: child.parentSessionId,
-      update: {
-        sessionUpdate: "subagent_state_update",
-        subagentSessionId: child.sessionId,
-        state,
-      },
-    });
-  }
-
-  private async finishNativeSubagents(session: Session, state: SubagentState): Promise<void> {
-    const taskIds = [...(session.nativeSubagentsByTaskId?.keys() ?? [])].reverse();
-    for (const taskId of taskIds) {
-      await this.finishNativeSubagent(session, taskId, state);
     }
   }
 
@@ -4969,7 +4751,9 @@ export class ClaudeAcpAgent {
     if (session.queryClosed) {
       return;
     }
-    await this.finishNativeSubagents(session, "cancelled");
+    await finishNativeSubagents(session, "cancelled", async (notification) =>
+      this.client.sessionUpdate(asSdkSessionNotification(notification)),
+    );
     // A priority steer may still be queued in the SDK when cancellation
     // settles its owning turn. Its later echo matches no live turn, and its
     // result must be skipped rather than promoted onto the next prompt.

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3458,6 +3458,7 @@ export class ClaudeAcpAgent {
                   subagentType: message.subagent_type,
                   workflowName: message.workflow_name,
                   skipTranscript: message.skip_transcript,
+                  toolCallId: message.tool_use_id,
                 });
                 if (message.subagent_type && session.activeTurn && !session.activeTurn.settled) {
                   (session.activeTurn.spawnedTaskIds ??= new Set()).add(message.task_id);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -210,6 +210,25 @@ const execFileAsync = promisify(execFile);
 
 const MAX_INLINE_FAILURE_TITLE_LENGTH = 256;
 
+/** Claude CLI emits this synthetic result when an interrupted cycle ends on
+ *  queued user input before producing any assistant content. It is a hand-off
+ *  marker, not the outcome of the replacement prompt that may already be
+ *  active by the time the SDK stream delivers it. */
+function isEmptyUserInterruptionDiagnostic(
+  message: Extract<SDKMessage, { type: "result" }>,
+): boolean {
+  const diagnostic =
+    "result" in message
+      ? message.result
+      : message.errors.find((error) => error.startsWith("[ede_diagnostic]"));
+  return (
+    diagnostic?.startsWith("[ede_diagnostic]") === true &&
+    /(?:^|\s)result_type=user(?:\s|$)/.test(diagnostic) &&
+    /(?:^|\s)last_content_type=n\/a(?:\s|$)/.test(diagnostic) &&
+    /(?:^|\s)stop_reason=null(?:\s|$)/.test(diagnostic)
+  );
+}
+
 /**
  * Logger interface for customizing logging output
  */
@@ -513,6 +532,9 @@ export type Session = {
    *  lane); a count can't express command coalescing — N queued commands can
    *  fold into ONE turn emitting one result, leaving a stale skip of N-1. */
   pendingOrphanResults?: number;
+  /** Empty user-interruption diagnostics expected from prompts cancelled
+   * before their SDK echo. The next ordinary result clears stale tokens. */
+  pendingEmptyInterruptionDiagnostics?: number;
   /** msg_lifecycle_v1 lane of the orphan accounting (see
    *  `pendingOrphanResults` for the count lane): the uuids of cancelled queued
    *  turns whose SDK-side command may still produce an unaccounted result,
@@ -670,6 +692,8 @@ export type Session = {
    *  tool_use block streams; this set makes the two paths converge regardless of
    *  order. Pruned at `tool_result` time alongside `toolUseCache`. */
   emittedToolCalls: Set<string>;
+  /** ACP session affinity for calls emitted eagerly by permission handling. */
+  eagerToolCallSessions?: Map<string, string>;
   /** ExitPlanMode denial that intentionally interrupts the current Claude
    *  cycle. Correlated by tool-use id until the terminal result arrives. */
   pendingExitPlanModeInterruption?: {
@@ -2244,8 +2268,32 @@ export class ClaudeAcpAgent {
       const { update } = notification;
       const claudeMeta = update._meta?.claudeCode as
         { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
-      const routedNotification = await subagents.route(notification, sendUpdate);
-      if (!routedNotification) return;
+      const toolCallId =
+        update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update"
+          ? update.toolCallId
+          : undefined;
+      const eagerOwnerSessionId = toolCallId
+        ? session.eagerToolCallSessions?.get(toolCallId)
+        : undefined;
+      const routedNotification = await subagents.route(
+        notification,
+        sendUpdate,
+        eagerOwnerSessionId,
+      );
+      if (!routedNotification) {
+        // Native Agent/Task control calls are intentionally not transcript
+        // tools. Do not let the mapper's pre-send de-duplication mark make a
+        // later permission request believe that a suppressed call exists.
+        if (
+          toolCallId &&
+          (claudeMeta?.subagent === true ||
+            claudeMeta?.toolName === "Agent" ||
+            claudeMeta?.toolName === "Task")
+        ) {
+          session.emittedToolCalls.delete(toolCallId);
+        }
+        return;
+      }
       if (
         isFileChangeAuditReportPhase(session.activeTurn?.fileChangeAudit) &&
         (update.sessionUpdate === "agent_message_chunk" ||
@@ -2263,6 +2311,13 @@ export class ClaudeAcpAgent {
         }
       }
       await this.client.sessionUpdate(routedNotification);
+      if (
+        toolCallId &&
+        update.sessionUpdate === "tool_call_update" &&
+        (update.status === "completed" || update.status === "failed")
+      ) {
+        session.eagerToolCallSessions?.delete(toolCallId);
+      }
     };
     // toAcpNotifications registers deferred tool hooks that publish through
     // the client passed to it. Keep those later updates on the same child-aware
@@ -3398,10 +3453,10 @@ export class ClaudeAcpAgent {
                 break;
               case "task_progress":
                 await asyncTasks.taskProgress({
-                  taskId: message.task_id,
+                  task_id: message.task_id,
                   description: message.description,
                   summary: message.summary,
-                  lastToolName: message.last_tool_name,
+                  last_tool_name: message.last_tool_name,
                   usage: message.usage,
                 });
                 break;
@@ -3439,13 +3494,14 @@ export class ClaudeAcpAgent {
                   sendUpdate,
                 );
                 await asyncTasks.taskStarted({
-                  taskId: message.task_id,
-                  taskType: message.task_type,
+                  task_id: message.task_id,
+                  task_type: message.task_type,
                   description: message.description,
-                  subagentType: message.subagent_type,
-                  workflowName: message.workflow_name,
-                  skipTranscript: message.skip_transcript,
-                  toolCallId: message.tool_use_id,
+                  subagent_type: message.subagent_type,
+                  is_backgrounded: message.is_backgrounded,
+                  workflow_name: message.workflow_name,
+                  skip_transcript: message.skip_transcript,
+                  tool_use_id: message.tool_use_id,
                 });
                 if (message.subagent_type && session.activeTurn && !session.activeTurn.settled) {
                   (session.activeTurn.spawnedTaskIds ??= new Set()).add(message.task_id);
@@ -3455,7 +3511,12 @@ export class ClaudeAcpAgent {
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
                 await subagents.finishTask(message.task_id, message.status, sendUpdate);
-                await asyncTasks.taskNotification(message.task_id, message.status, message.summary);
+                await asyncTasks.taskNotification({
+                  task_id: message.task_id,
+                  status: message.status,
+                  summary: message.summary,
+                  output_file: message.output_file,
+                });
                 if (message.tool_use_id) subagents.discardPending(message.tool_use_id);
                 session.liveBackgroundTasks.delete(message.task_id);
                 break;
@@ -3615,6 +3676,7 @@ export class ClaudeAcpAgent {
               case "control_request_progress":
                 break;
               case "background_tasks_changed":
+                await asyncTasks.backgroundTasksChanged(message.tasks);
                 // A level signal: the full live background-task set on every
                 // membership change, with REPLACE semantics. Used only to
                 // reconcile `liveBackgroundTasks` — dropping (or, for
@@ -3906,6 +3968,29 @@ export class ClaudeAcpAgent {
                 }
                 break;
               }
+
+              // A cancel can race startup before the original prompt's echo.
+              // The CLI then replays the cancelled prompt, its interruption
+              // marker, and the replacement prompt before yielding this
+              // error-shaped diagnostic for the OLD cycle. The replacement's
+              // echo has already made it active, so treating the diagnostic as
+              // its result rejects a healthy prompt and leaves its real output
+              // arriving after session/prompt completed. Ignore only the
+              // diagnostic's exact empty-user-interruption signature; ordinary
+              // provider errors still follow the failure lanes below.
+              if (
+                message.is_error &&
+                isEmptyUserInterruptionDiagnostic(message) &&
+                (session.pendingEmptyInterruptionDiagnostics ?? 0) > 0
+              ) {
+                session.pendingEmptyInterruptionDiagnostics!--;
+                break;
+              }
+
+              // Some CLI versions omit the cancelled cycle's diagnostic. Do
+              // not let an unused hand-off token swallow a later turn's real
+              // interruption failure.
+              session.pendingEmptyInterruptionDiagnostics = 0;
 
               await clearFailuresFromEarlierTurns();
 
@@ -4924,6 +5009,10 @@ export class ClaudeAcpAgent {
         (turn) => turn === session.activeTurn && !turn.settled,
       );
     }
+    if (orphanedTurns.length > 0) {
+      session.pendingEmptyInterruptionDiagnostics =
+        (session.pendingEmptyInterruptionDiagnostics ?? 0) + orphanedTurns.length;
+    }
 
     // A deferred active turn (see Turn.deferredSettle) already has its
     // result — it is only held open for its background subagents, which the
@@ -5528,6 +5617,7 @@ export class ClaudeAcpAgent {
       return;
     }
     session.emittedToolCalls.add(toolCallId);
+    (session.eagerToolCallSessions ??= new Map()).set(toolCallId, notificationSessionId);
     const supportsTerminalOutput = this.clientCapabilities?._meta?.["terminal_output"] === true;
     const update = toolCallNotification(
       { id: toolCallId, name: toolName, input: toolInput },
@@ -5552,6 +5642,7 @@ export class ClaudeAcpAgent {
       // tool_use. Keep it truthful: if emission failed, that path must still
       // be allowed to publish the tool call instead of refining a phantom one.
       session.emittedToolCalls.delete(toolCallId);
+      session.eagerToolCallSessions?.delete(toolCallId);
       throw error;
     }
   }
@@ -5649,8 +5740,9 @@ export class ClaudeAcpAgent {
           toolInput,
           parentToolUseId,
           signal,
+          permissionSessionId,
         );
-        return this.handleAskUserQuestion(sessionId, toolInput, toolUseID, signal);
+        return this.handleAskUserQuestion(permissionSessionId, toolInput, toolUseID, signal);
       }
 
       // Do not auto-allow here based on the session's advertised mode. Claude
@@ -6782,6 +6874,7 @@ export class ClaudeAcpAgent {
       taskState,
       toolUseCache: {},
       emittedToolCalls: new Set(),
+      eagerToolCallSessions: new Map(),
       liveBackgroundTasks: new Map(),
       nativeSubagentsByTaskId: new Map(),
       nativeSubagentTaskIdByToolUseId: new Map(),

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -294,6 +294,40 @@ const TURN_NO_RESULT_MESSAGE =
  *  `InitializeResponse._meta.steering.supported`. */
 const STEER_METHOD = "_session/steering";
 
+/** Stops one Claude background task without cancelling the parent prompt turn. */
+const ASYNC_TASK_STOP_METHOD = "_session/async_task/stop";
+
+type AsyncTaskStopRequest = {
+  sessionId: string;
+  asyncTaskId: string;
+};
+
+type AsyncTaskStopResponse = {
+  stopped: boolean;
+};
+
+function parseAsyncTaskStopRequest(value: unknown): AsyncTaskStopRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw RequestError.invalidParams(undefined, "async task stop params must be an object");
+  }
+  const params = value as Record<string, unknown>;
+  const sessionId = typeof params.sessionId === "string" ? params.sessionId.trim() : "";
+  const asyncTaskId = typeof params.asyncTaskId === "string" ? params.asyncTaskId.trim() : "";
+  if (!sessionId) {
+    throw RequestError.invalidParams(
+      undefined,
+      "async task stop params require a non-empty sessionId",
+    );
+  }
+  if (!asyncTaskId) {
+    throw RequestError.invalidParams(
+      undefined,
+      "async task stop params require a non-empty asyncTaskId",
+    );
+  }
+  return { sessionId, asyncTaskId };
+}
+
 /** How urgently the SDK delivers a steered message relative to the running
  *  turn — an internal Claude implementation detail, not part of the wire
  *  contract. `now` pre-empts the current generation, while `later` waits for a
@@ -2196,6 +2230,21 @@ export class ClaudeAcpAgent {
     const firstText = params.prompt[0]?.type === "text" ? params.prompt[0].text : "";
     await this.publishGoalFromPrompt(sessionId, firstText, steeredUuid);
     return { outcome: "injected" };
+  }
+
+  async stopAsyncTask(params: AsyncTaskStopRequest): Promise<AsyncTaskStopResponse> {
+    const session = this.sessions[params.sessionId];
+    const asyncTasks = session?.asyncTaskRuntime;
+    if (!session || !asyncTasks?.claimStop(params.asyncTaskId)) return { stopped: false };
+
+    try {
+      await session.query.stopTask(params.asyncTaskId);
+      await asyncTasks.taskStopped(params.asyncTaskId);
+      return { stopped: true };
+    } catch (error) {
+      asyncTasks.releaseStop(params.asyncTaskId);
+      throw error;
+    }
   }
 
   /** Publish the audit terminal for every turn path that did not reach the
@@ -9242,6 +9291,11 @@ export function runAcp(logger?: Logger) {
     .onNotification(methods.agent.session.cancel, (ctx) => agent.cancel(ctx.params))
     .onRequest<SteerRequest, SteerResponse>(STEER_METHOD, { parse: parseSteerRequest }, (ctx) =>
       agent.steer(ctx.params),
+    )
+    .onRequest<AsyncTaskStopRequest, AsyncTaskStopResponse>(
+      ASYNC_TASK_STOP_METHOD,
+      { parse: parseAsyncTaskStopRequest },
+      (ctx) => agent.stopAsyncTask(ctx.params),
     )
     .onRequest<GoalRequest, GoalControlResponse>(
       GOAL_CONTROL_METHOD,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -108,12 +108,13 @@ import {
   NativeSubagent,
   NativeSubagentRuntime,
 } from "./native-subagents.js";
-import { AIR_ASYNC_TASKS_CAPABILITY } from "./air-extension.js";
+import { AIR_ASYNC_TASKS_CAPABILITY, withAirMeta } from "./air-extension.js";
 import {
   AsyncTaskRuntime,
   backgroundBashTaskFromToolResult,
   clientSupportsAsyncTasks,
 } from "./async-tasks.js";
+import type { AsyncTaskStarted } from "./async-tasks.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -4786,8 +4787,9 @@ export class ClaudeAcpAgent {
             }
 
             const acceptedPlanToolUseId = observeExitPlanToolResults(message, content, session);
+            let backgroundBashTask: AsyncTaskStarted | undefined;
             if (message.type === "user") {
-              const backgroundBashTask = backgroundBashTaskFromToolResult(
+              backgroundBashTask = backgroundBashTaskFromToolResult(
                 content,
                 message.tool_use_result,
                 session.toolUseCache,
@@ -4822,7 +4824,13 @@ export class ClaudeAcpAgent {
               // filtered out of `content` above; blocks that do pass through
               // (e.g. a subagent image) carry the stamped parentToolUseId
               // meta and are excluded there.
-              await sendUpdate(acceptedPlanToolResult(notification, acceptedPlanToolUseId));
+              await sendUpdate(
+                backgroundedBashToolCall(
+                  acceptedPlanToolResult(notification, acceptedPlanToolUseId),
+                  backgroundBashTask,
+                  asyncTasks.enabled,
+                ),
+              );
             }
             break;
           }
@@ -8498,6 +8506,53 @@ function claudeCodeMetaFromToolUse(
     ...(skillName ? { skill: skillName } : {}),
     ...(skillPath ? { skillPath } : {}),
   };
+}
+
+/**
+ * Marks the Bash `tool_call_update` whose command detached into the background.
+ *
+ * A backgrounded Bash call returns as soon as the command is handed off, so the
+ * card reaches `completed` while the command itself runs on for minutes. ACP has
+ * no tool-call status for "still running elsewhere", so this marker is what lets
+ * a client render the card as backgrounded work instead of finished work. It
+ * rides the update the tool result already emits, so it costs no extra
+ * notification and cannot arrive out of order.
+ *
+ * The command's own lifecycle -- progress, completion, the stop control -- is
+ * published separately as an async task; this says only that the card has one.
+ * Hence the AIR namespace rather than `claudeCode`: to a client without the
+ * `asyncTasks` capability, which is never sent that lifecycle, the marker would
+ * promise a card state it has no way to ever resolve.
+ */
+function backgroundedBashToolCall(
+  notification: SessionNotification,
+  task: AsyncTaskStarted | undefined,
+  asyncTasksSupported: boolean,
+): SessionNotification {
+  const update = notification.update;
+  const toolCallId = task ? nonBlankTaskField(task.toolCallId ?? task.tool_use_id) : undefined;
+  if (
+    !asyncTasksSupported ||
+    !toolCallId ||
+    update.sessionUpdate !== "tool_call_update" ||
+    update.toolCallId !== toolCallId
+  ) {
+    return notification;
+  }
+  return {
+    ...notification,
+    update: {
+      ...update,
+      _meta: withAirMeta(update._meta, AIR_ASYNC_TASKS_CAPABILITY, { backgrounded: true }),
+    },
+  };
+}
+
+/** The task fields arrive as `unknown` off the wire; only non-blank strings carry a link. */
+function nonBlankTaskField(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 /** Roots a skill's directory may sit under, relative to the directory the scope resolves to. */

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -95,6 +95,13 @@ import {
   toGoalSnapshot,
 } from "./goal-extension.js";
 import { sanitizeTitle, SessionTitles } from "./session-titles.js";
+import {
+  AcpSessionNotification,
+  asSdkSessionNotification,
+  clientSupportsSubagents,
+  SubagentAwareSessionCapabilities,
+  SubagentState,
+} from "./acp-subagents.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -448,6 +455,20 @@ type Turn = {
   completion?: Promise<void>;
 };
 
+type NativeSubagent = {
+  sessionId: string;
+  parentSessionId: string;
+  parentToolUseId?: string;
+  name: string;
+  task: string;
+  announced?: boolean;
+  terminalState?: SubagentState;
+};
+
+const MAX_PENDING_NATIVE_SUBAGENT_PARENTS = 64;
+const MAX_PENDING_NATIVE_SUBAGENT_UPDATES = 256;
+const MAX_PENDING_NATIVE_SUBAGENT_UPDATES_PER_PARENT = 32;
+
 export type Session = {
   query: Query;
   input: Pushable<SDKUserMessage>;
@@ -723,6 +744,17 @@ export type Session = {
       endedPerLevel?: "ended" | "sweep-armed";
     }
   >;
+  /** Native ACP subagent sessions negotiated through PR #1992. Records are
+   *  retained for the parent session lifetime so late child output cannot be
+   *  rebound to another task after the SDK prunes its live-task registry. */
+  nativeSubagentsByTaskId?: Map<string, NativeSubagent>;
+  /** Resolves the spawning Agent/Task tool use carried by child messages to
+   *  the corresponding native ACP child session. */
+  nativeSubagentTaskIdByToolUseId?: Map<string, string>;
+  /** Captures the ACP session in which an Agent/Task tool call was made. This
+   *  supplies the immediate parent for nested `task_started` notifications,
+   *  whose SDK payload has no lineage field of its own. */
+  nativeSubagentParentByToolUseId?: Map<string, string>;
   /** Whether any top-level assistant text reached the client since the last
    *  stretch boundary. Set as a side effect of sending in the consumer's
    *  `sendUpdate`, never at an emission site; read at the terminal `result`
@@ -1012,6 +1044,33 @@ function supportsSubagentTranscript(capabilities?: ClientCapabilities | null): b
   return capabilities?._meta?.[SUBAGENT_TRANSCRIPT_CAPABILITY] === true;
 }
 
+function nativeSubagentState(status: unknown): SubagentState | undefined {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "killed":
+    case "stopped":
+    case "cancelled":
+      return "cancelled";
+    default:
+      return undefined;
+  }
+}
+
+function subagentDisplayName(type: unknown, taskId: string): string {
+  if (typeof type === "string" && type.trim().length > 0) return type.trim();
+  const suffix = taskId.length > 8 ? taskId.slice(-8) : taskId;
+  return `Agent ${suffix}`;
+}
+
+function subagentTask(description: unknown): string {
+  return typeof description === "string" && description.trim().length > 0
+    ? description.trim()
+    : "Delegated task";
+}
+
 function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | null {
   if (!("parent_tool_use_id" in message)) return null;
   return typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : null;
@@ -1296,7 +1355,7 @@ export function isSyntheticLoginMessage(apiMessage: unknown): boolean {
  * {@link ClientConnection} over the SDK's typed `AgentContext`.
  */
 export interface AcpClient {
-  sessionUpdate(params: SessionNotification): Promise<void>;
+  sessionUpdate(params: AcpSessionNotification): Promise<void>;
   /** `signal`, when aborted, sends `$/cancel_request` for the in-flight
    *  permission request so the client can dismiss its prompt (and settle our
    *  await) instead of leaving the dialog open after the turn was cancelled. */
@@ -1326,8 +1385,8 @@ export interface AcpClient {
 class ClientConnection implements AcpClient {
   constructor(private readonly ctx: AgentContext) {}
 
-  sessionUpdate(params: SessionNotification): Promise<void> {
-    return this.ctx.notify(methods.client.session.update, params);
+  sessionUpdate(params: AcpSessionNotification): Promise<void> {
+    return this.ctx.notify(methods.client.session.update, asSdkSessionNotification(params));
   }
 
   requestPermission(
@@ -1565,6 +1624,16 @@ export class ClaudeAcpAgent {
       }
     }
 
+    const sessionCapabilities: SubagentAwareSessionCapabilities = {
+      additionalDirectories: {},
+      close: {},
+      delete: {},
+      fork: {},
+      list: {},
+      resume: {},
+      ...(clientSupportsSubagents(request.clientCapabilities) ? { subagents: {} } : {}),
+    };
+
     return {
       protocolVersion: 1,
       agentCapabilities: {
@@ -1589,14 +1658,7 @@ export class ClaudeAcpAgent {
         // capability prerequisite for the provider methods.
         providers: {},
         loadSession: true,
-        sessionCapabilities: {
-          additionalDirectories: {},
-          close: {},
-          delete: {},
-          fork: {},
-          list: {},
-          resume: {},
-        },
+        sessionCapabilities,
       },
       agentInfo: {
         name: packageJson.name,
@@ -2194,8 +2256,99 @@ export class ClaudeAcpAgent {
      *  recognizable by the `parentToolUseId` meta that toAcpNotifications
      *  stamps from `parent_tool_use_id`, and never reach the top-level feed
      *  as the turn's answer. */
-    const sendUpdate = async (notification: SessionNotification) => {
+    const nativeSubagentsEnabled = clientSupportsSubagents(this.clientCapabilities);
+    const nativeSubagents = (session.nativeSubagentsByTaskId ??= new Map());
+    const nativeSubagentTaskByToolUse = (session.nativeSubagentTaskIdByToolUseId ??= new Map());
+    const nativeSubagentParentByToolUse = (session.nativeSubagentParentByToolUseId ??= new Map());
+    const pendingNativeSubagentUpdates = new Map<string, AcpSessionNotification[]>();
+    let pendingNativeSubagentUpdateCount = 0;
+
+    const takePendingNativeSubagentUpdates = (parentToolUseId: string) => {
+      const pending = pendingNativeSubagentUpdates.get(parentToolUseId) ?? [];
+      if (pending.length > 0) {
+        pendingNativeSubagentUpdates.delete(parentToolUseId);
+        pendingNativeSubagentUpdateCount -= pending.length;
+      }
+      return pending;
+    };
+
+    const bufferNativeSubagentUpdate = (
+      parentToolUseId: string,
+      notification: AcpSessionNotification,
+    ) => {
+      const pending = pendingNativeSubagentUpdates.get(parentToolUseId);
+      if (
+        pendingNativeSubagentUpdateCount >= MAX_PENDING_NATIVE_SUBAGENT_UPDATES ||
+        (pending === undefined &&
+          pendingNativeSubagentUpdates.size >= MAX_PENDING_NATIVE_SUBAGENT_PARENTS) ||
+        (pending?.length ?? 0) >= MAX_PENDING_NATIVE_SUBAGENT_UPDATES_PER_PARENT
+      ) {
+        this.logger.log(
+          `Session ${params.sessionId}: dropping unattributed subagent update for ${parentToolUseId}; pending buffer limit reached`,
+        );
+        return;
+      }
+      if (pending) {
+        pending.push(notification);
+      } else {
+        pendingNativeSubagentUpdates.set(parentToolUseId, [notification]);
+      }
+      pendingNativeSubagentUpdateCount++;
+    };
+
+    const sendUpdate = async (notification: AcpSessionNotification) => {
       const { update } = notification;
+      const claudeMeta = update._meta?.claudeCode as
+        { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
+
+      if (
+        nativeSubagentsEnabled &&
+        (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+        (claudeMeta?.subagent === true ||
+          claudeMeta?.toolName === "Agent" ||
+          claudeMeta?.toolName === "Task")
+      ) {
+        const parentTaskId = claudeMeta.parentToolUseId
+          ? nativeSubagentTaskByToolUse.get(claudeMeta.parentToolUseId)
+          : undefined;
+        const parentSessionId = parentTaskId
+          ? nativeSubagents.get(parentTaskId)?.sessionId
+          : params.sessionId;
+        nativeSubagentParentByToolUse.set(update.toolCallId, parentSessionId ?? params.sessionId);
+        // `task_started` and the assistant frame containing its Agent/Task
+        // tool_use are separate SDK events with no ordering guarantee. If the
+        // start arrived first, it was deliberately left unannounced until this
+        // frame supplied the immediate parent for a nested child.
+        for (const child of nativeSubagents.values()) {
+          if (child.parentToolUseId !== update.toolCallId || child.announced) continue;
+          child.parentSessionId = parentSessionId ?? params.sessionId;
+          await this.announceNativeSubagent(child);
+          for (const pending of takePendingNativeSubagentUpdates(update.toolCallId)) {
+            await sendUpdate(pending);
+          }
+        }
+        // Native clients receive a dedicated subagent session and timeline
+        // lifecycle. Emitting the legacy Agent/Task tool call as well would
+        // create a duplicate representation of the same worker.
+        return;
+      }
+
+      let routedNotification = notification;
+      if (nativeSubagentsEnabled && claudeMeta?.parentToolUseId) {
+        const taskId = nativeSubagentTaskByToolUse.get(claudeMeta.parentToolUseId);
+        const child = taskId ? nativeSubagents.get(taskId) : undefined;
+        if (!child || !child.announced) {
+          bufferNativeSubagentUpdate(claudeMeta.parentToolUseId, notification);
+          return;
+        }
+        if (child.terminalState !== undefined) {
+          this.logger.log(
+            `Session ${params.sessionId}: ignoring late update for terminal subagent ${child.sessionId}`,
+          );
+          return;
+        }
+        routedNotification = { ...notification, sessionId: child.sessionId };
+      }
       if (
         isFileChangeAuditReportPhase(session.activeTurn?.fileChangeAudit) &&
         (update.sessionUpdate === "agent_message_chunk" ||
@@ -2207,14 +2360,41 @@ export class ClaudeAcpAgent {
         return;
       }
       if (update.sessionUpdate === "agent_message_chunk") {
-        const claudeMeta = update._meta?.claudeCode as
-          { parentToolUseId?: string | null } | undefined;
         if (!claudeMeta?.parentToolUseId) {
           session.emittedAssistantText = true;
           session.titles.onAssistantText(update.content);
         }
       }
-      await this.client.sessionUpdate(notification);
+      await this.client.sessionUpdate(routedNotification);
+    };
+    // toAcpNotifications registers deferred tool hooks that publish through
+    // the client passed to it. Keep those later updates on the same child-aware
+    // routing path as the immediate notifications.
+    const routedNotificationClient = { sessionUpdate: sendUpdate } as unknown as AcpClient;
+
+    const finishNativeSubagent = async (taskId: string, status: unknown): Promise<void> => {
+      if (!nativeSubagentsEnabled) return;
+      const state = nativeSubagentState(status);
+      const child = nativeSubagents.get(taskId);
+      if (!state || !child || child.terminalState !== undefined) return;
+      // A provider may omit or reorder the assistant Agent/Task frame. The
+      // lifecycle must still be well-formed, so fall back to the root parent
+      // only when the task is already terminal and no lineage frame arrived.
+      await this.announceNativeSubagent(child);
+      if (child.parentToolUseId) {
+        for (const pending of takePendingNativeSubagentUpdates(child.parentToolUseId)) {
+          await sendUpdate(pending);
+        }
+      }
+      await this.finishNativeSubagent(session, taskId, state);
+    };
+
+    const finishNativeSubagents = async (state: SubagentState): Promise<void> => {
+      for (const taskId of [...nativeSubagents.keys()].reverse()) {
+        await finishNativeSubagent(taskId, state);
+      }
+      pendingNativeSubagentUpdates.clear();
+      pendingNativeSubagentUpdateCount = 0;
     };
 
     let pendingWorkerShutdown = false;
@@ -2790,6 +2970,7 @@ export class ClaudeAcpAgent {
           // a deferred turn's stored outcome (followup results never mutate
           // it), but the stored one is the authoritative source.
           const inFlight = session.activeTurn;
+          await finishNativeSubagents(session.cancelled ? "cancelled" : "failed");
           settleActive(
             session.cancelled
               ? turnOutcome(session, "cancelled")
@@ -3349,6 +3530,41 @@ export class ClaudeAcpAgent {
                   parentToolUseId: message.tool_use_id,
                   isSubagent: !!message.subagent_type,
                 });
+                if (nativeSubagentsEnabled && message.subagent_type) {
+                  const existing = nativeSubagents.get(message.task_id);
+                  if (!existing) {
+                    const knownParentSessionId = message.tool_use_id
+                      ? nativeSubagentParentByToolUse.get(message.tool_use_id)
+                      : undefined;
+                    const child: NativeSubagent = {
+                      sessionId: message.task_id,
+                      parentSessionId: knownParentSessionId ?? params.sessionId,
+                      parentToolUseId: message.tool_use_id,
+                      name: subagentDisplayName(message.subagent_type, message.task_id),
+                      task: subagentTask(message.description),
+                    };
+                    nativeSubagents.set(message.task_id, child);
+                    if (message.tool_use_id) {
+                      nativeSubagentTaskByToolUse.set(message.tool_use_id, message.task_id);
+                    }
+                    // If the spawning tool frame has already supplied lineage,
+                    // announce immediately. Otherwise wait for that frame so a
+                    // nested child is not incorrectly attached to the root.
+                    if (knownParentSessionId || !message.tool_use_id) {
+                      await this.announceNativeSubagent(child);
+                      for (const notification of message.tool_use_id
+                        ? takePendingNativeSubagentUpdates(message.tool_use_id)
+                        : []) {
+                        await sendUpdate(notification);
+                      }
+                    }
+                  }
+                } else if (nativeSubagentsEnabled && message.tool_use_id) {
+                  // Early output carrying this id cannot belong to a native
+                  // subagent once task_started identifies it as another kind
+                  // of background task.
+                  takePendingNativeSubagentUpdates(message.tool_use_id);
+                }
                 if (message.subagent_type && session.activeTurn && !session.activeTurn.settled) {
                   (session.activeTurn.spawnedTaskIds ??= new Set()).add(message.task_id);
                 }
@@ -3356,6 +3572,10 @@ export class ClaudeAcpAgent {
               case "task_notification":
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
+                await finishNativeSubagent(message.task_id, message.status);
+                if (nativeSubagentsEnabled && message.tool_use_id) {
+                  takePendingNativeSubagentUpdates(message.tool_use_id);
+                }
                 session.liveBackgroundTasks.delete(message.task_id);
                 break;
               case "task_updated":
@@ -3369,6 +3589,7 @@ export class ClaudeAcpAgent {
                   message.patch.status === "failed" ||
                   message.patch.status === "killed"
                 ) {
+                  await finishNativeSubagent(message.task_id, message.patch.status);
                   session.liveBackgroundTasks.delete(message.task_id);
                 }
                 break;
@@ -3944,7 +4165,7 @@ export class ClaudeAcpAgent {
                       "assistant",
                       params.sessionId,
                       session.toolUseCache,
-                      this.client,
+                      routedNotificationClient,
                       this.logger,
                     )) {
                       await sendUpdate(notification);
@@ -4338,7 +4559,7 @@ export class ClaudeAcpAgent {
                   message.message.role,
                   params.sessionId,
                   session.toolUseCache,
-                  this.client,
+                  routedNotificationClient,
                   this.logger,
                   {
                     clientCapabilities: this.clientCapabilities,
@@ -4485,7 +4706,7 @@ export class ClaudeAcpAgent {
               message.message.role,
               params.sessionId,
               session.toolUseCache,
-              this.client,
+              routedNotificationClient,
               this.logger,
               {
                 clientCapabilities: this.clientCapabilities,
@@ -4579,6 +4800,10 @@ export class ClaudeAcpAgent {
             // and task store are independent of the previous transcript.
             // Clear both the in-memory snapshot and the client's visible plan
             // before any follow-up prompt can republish stale tasks.
+            await finishNativeSubagents("failed");
+            nativeSubagents.clear();
+            nativeSubagentTaskByToolUse.clear();
+            nativeSubagentParentByToolUse.clear();
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
             // A reset mounts a fresh transcript (`new_conversation_id`), so our
@@ -4615,6 +4840,7 @@ export class ClaudeAcpAgent {
           message.includes("process exited with") ||
           message.includes("process terminated by signal") ||
           message.includes("Failed to write to process stdin"));
+      await finishNativeSubagents(session.cancelled ? "cancelled" : "failed");
       if (supportsAirSessionFailures(this.clientCapabilities) && session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
           await failActiveWithSessionFailure(
@@ -4653,6 +4879,47 @@ export class ClaudeAcpAgent {
         );
         this.closeQueryStream(session);
       }
+    }
+  }
+
+  private async announceNativeSubagent(child: NativeSubagent): Promise<void> {
+    if (child.announced) return;
+    await this.client.sessionUpdate({
+      sessionId: child.parentSessionId,
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagentSessionId: child.sessionId,
+        name: child.name,
+        task: child.task,
+        capabilities: {},
+      },
+    });
+    child.announced = true;
+  }
+
+  private async finishNativeSubagent(
+    session: Session,
+    taskId: string,
+    state: SubagentState,
+  ): Promise<void> {
+    const child = session.nativeSubagentsByTaskId?.get(taskId);
+    if (!child || child.terminalState !== undefined) return;
+    await this.announceNativeSubagent(child);
+    child.terminalState = state;
+    await this.client.sessionUpdate({
+      sessionId: child.parentSessionId,
+      update: {
+        sessionUpdate: "subagent_state_update",
+        subagentSessionId: child.sessionId,
+        state,
+      },
+    });
+  }
+
+  private async finishNativeSubagents(session: Session, state: SubagentState): Promise<void> {
+    const taskIds = [...(session.nativeSubagentsByTaskId?.keys() ?? [])].reverse();
+    for (const taskId of taskIds) {
+      await this.finishNativeSubagent(session, taskId, state);
     }
   }
 
@@ -4700,6 +4967,7 @@ export class ClaudeAcpAgent {
     if (session.queryClosed) {
       return;
     }
+    await this.finishNativeSubagents(session, "cancelled");
     // A priority steer may still be queued in the SDK when cancellation
     // settles its owning turn. Its later echo matches no live turn, and its
     // result must be skipped rather than promoted onto the next prompt.
@@ -5309,6 +5577,7 @@ export class ClaudeAcpAgent {
     toolName: string,
     signal: AbortSignal,
     parentToolUseId?: string,
+    ownerSessionId: string = params.sessionId,
   ): Promise<RequestPermissionResponse> {
     if (signal.aborted) throw new Error("Tool use aborted");
     // The SDK may invoke `canUseTool` (and therefore this permission request)
@@ -5318,12 +5587,13 @@ export class ClaudeAcpAgent {
     // later refines it with a `tool_call_update` rather than emitting a
     // duplicate (see `emittedToolCalls` in `toAcpNotifications`).
     await this.ensureToolCallEmitted(
-      params.sessionId,
+      ownerSessionId,
       toolName,
       params.toolCall.toolCallId,
       params.toolCall.rawInput,
       parentToolUseId,
       signal,
+      params.sessionId,
     );
     if (signal.aborted) throw new Error("Tool use aborted");
 
@@ -5361,6 +5631,7 @@ export class ClaudeAcpAgent {
     toolInput: unknown,
     parentToolUseId?: string,
     signal?: AbortSignal,
+    notificationSessionId: string = sessionId,
   ): Promise<void> {
     const session = this.sessions[sessionId];
     if (!session) {
@@ -5387,7 +5658,7 @@ export class ClaudeAcpAgent {
       };
     }
     try {
-      const emission = this.client.sessionUpdate({ sessionId, update });
+      const emission = this.client.sessionUpdate({ sessionId: notificationSessionId, update });
       await (signal ? raceWithAbort(emission, signal) : emission);
     } catch (error) {
       // The set is also the de-duplication guard for the later streamed
@@ -5452,6 +5723,18 @@ export class ClaudeAcpAgent {
       const parentToolUseId = agentID
         ? session.liveBackgroundTasks.get(agentID)?.parentToolUseId
         : undefined;
+      const permissionSessionId =
+        clientSupportsSubagents(this.clientCapabilities) && agentID
+          ? (() => {
+              const child = session.nativeSubagentsByTaskId?.get(agentID);
+              // A request must never target a child session before its
+              // subagent_spawned notification. In the rare SDK ordering where
+              // canUseTool beats the spawning Agent/Task frame, keep the
+              // permission on the root session; the later frame will announce
+              // the child with correct nested lineage.
+              return child?.announced ? child.sessionId : sessionId;
+            })()
+          : sessionId;
       if (agentID && !parentToolUseId) {
         // The attribution rests on an undocumented SDK invariant
         // (task_started.task_id === canUseTool's agentID for subagent tasks;
@@ -5537,11 +5820,12 @@ export class ClaudeAcpAgent {
         {
           ...presentation,
           options: permissionOptions,
-          sessionId,
+          sessionId: permissionSessionId,
         },
         toolName,
         signal,
         parentToolUseId,
+        sessionId,
       );
       if (signal.aborted) throw new Error("Tool use aborted");
       const decodedPermission = decodeClaudePermissionResponse(
@@ -6611,6 +6895,9 @@ export class ClaudeAcpAgent {
       toolUseCache: {},
       emittedToolCalls: new Set(),
       liveBackgroundTasks: new Map(),
+      nativeSubagentsByTaskId: new Map(),
+      nativeSubagentTaskIdByToolUseId: new Map(),
+      nativeSubagentParentByToolUseId: new Map(),
       emittedAssistantText: false,
       owedTrailingIdles: 0,
       messageIdToUuid: new Map(),

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1041,9 +1041,26 @@ export type ToolUpdateMeta = {
   };
 };
 
+const SUBAGENT_TRANSCRIPT_CAPABILITY = "subagent-transcript";
+
+function supportsSubagentTranscript(capabilities?: ClientCapabilities | null): boolean {
+  return capabilities?._meta?.[SUBAGENT_TRANSCRIPT_CAPABILITY] === true;
+}
+
 function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | null {
   if (!("parent_tool_use_id" in message)) return null;
   return typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : null;
+}
+
+function stripSubagentTextAndThinking(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  return content.filter(
+    (item) =>
+      !item ||
+      typeof item !== "object" ||
+      !("type" in item) ||
+      (item.type !== "text" && item.type !== "thinking"),
+  );
 }
 
 export type ToolUseCache = {
@@ -3322,7 +3339,11 @@ export class ClaudeAcpAgent {
                 const parentToolUseId = message.agent_id
                   ? session.liveBackgroundTasks.get(message.agent_id)?.parentToolUseId
                   : undefined;
-                if (message.agent_id && !parentToolUseId) {
+                if (
+                  message.agent_id &&
+                  !parentToolUseId &&
+                  clientSupportsSubagents(this.clientCapabilities)
+                ) {
                   // An agent-scoped denial with missing lineage cannot safely
                   // be presented in the root transcript. The matching hidden
                   // child tool call was not announced there.
@@ -4554,10 +4575,11 @@ export class ClaudeAcpAgent {
               streamedBlocks.length = 0;
             } else if (
               message.type === "assistant" &&
-              !clientSupportsSubagents(this.clientCapabilities)
+              !(session.forwardSubagentText || supportsSubagentTranscript(this.clientCapabilities))
             ) {
-              // Child content has no visible fallback. Only bilaterally
-              // negotiated native sessions can receive it.
+              // Legacy clients keep the flattened tool-call representation,
+              // but nested text/thinking stays internal unless explicitly
+              // requested through the historical transcript extension.
               content = message.message.content.filter(
                 (item) => item.type !== "text" && item.type !== "thinking",
               );
@@ -5229,6 +5251,8 @@ export class ClaudeAcpAgent {
     const toolUseCache: ToolUseCache = {};
     const messages = await getSessionMessages(sessionId);
     const session = this.sessions[sessionId];
+    const forwardSubagentText =
+      session?.forwardSubagentText ?? supportsSubagentTranscript(this.clientCapabilities);
     const supportsTypedFailures = supportsAirSessionFailures(this.clientCapabilities);
     const activeUsageLimit = supportsTypedFailures ? activeUsageLimitMessage(messages) : undefined;
     const sessionFailures =
@@ -5303,7 +5327,7 @@ export class ClaudeAcpAgent {
       // @ts-expect-error - untyped in SDK but we handle all of these
       let content: unknown = message.message.content;
       const parentToolUseId = parentToolUseIdOf(message);
-      if (parentToolUseId) {
+      if (parentToolUseId && clientSupportsSubagents(this.clientCapabilities)) {
         // Persisted SDK sidechains do not contain the authoritative
         // task_started/task_updated lifecycle needed to reconstruct a native
         // child session. Never replay them into the root transcript: an
@@ -5311,6 +5335,9 @@ export class ClaudeAcpAgent {
         // a capable client must not receive child output without a preceding
         // subagent_spawned event.
         continue;
+      }
+      if (message.type === "assistant" && parentToolUseId && !forwardSubagentText) {
+        content = stripSubagentTextAndThinking(content);
       }
       // @ts-expect-error - untyped in SDK but we handle all of these
       if (message.message.role === "user") {
@@ -5438,7 +5465,6 @@ export class ClaudeAcpAgent {
     signal: AbortSignal,
     parentToolUseId?: string,
     ownerSessionId: string = params.sessionId,
-    originatesFromSubagent: boolean = false,
   ): Promise<RequestPermissionResponse> {
     if (signal.aborted) throw new Error("Tool use aborted");
     // The SDK may invoke `canUseTool` (and therefore this permission request)
@@ -5447,20 +5473,15 @@ export class ClaudeAcpAgent {
     // so emit it now if it hasn't been sent yet. The streamed tool_use chunk
     // later refines it with a `tool_call_update` rather than emitting a
     // duplicate (see `emittedToolCalls` in `toAcpNotifications`).
-    if (
-      (!originatesFromSubagent && !parentToolUseId) ||
-      clientSupportsSubagents(this.clientCapabilities)
-    ) {
-      await this.ensureToolCallEmitted(
-        ownerSessionId,
-        toolName,
-        params.toolCall.toolCallId,
-        params.toolCall.rawInput,
-        parentToolUseId,
-        signal,
-        params.sessionId,
-      );
-    }
+    await this.ensureToolCallEmitted(
+      ownerSessionId,
+      toolName,
+      params.toolCall.toolCallId,
+      params.toolCall.rawInput,
+      parentToolUseId,
+      signal,
+      params.sessionId,
+    );
     if (signal.aborted) throw new Error("Tool use aborted");
 
     // Do not rely on every ACP client settling requestPermission after the
@@ -5692,7 +5713,6 @@ export class ClaudeAcpAgent {
         signal,
         parentToolUseId,
         sessionId,
-        agentID !== undefined,
       );
       if (signal.aborted) throw new Error("Tool use aborted");
       const decodedPermission = decodeClaudePermissionResponse(
@@ -6300,7 +6320,10 @@ export class ClaudeAcpAgent {
     // Extract options from _meta if provided
     const sessionMeta = params._meta as NewSessionMeta | undefined;
     const userProvidedOptions = sessionMeta?.claudeCode?.options;
-    const forwardSubagentText = clientSupportsSubagents(this.clientCapabilities);
+    const forwardSubagentText =
+      clientSupportsSubagents(this.clientCapabilities) ||
+      supportsSubagentTranscript(this.clientCapabilities) ||
+      userProvidedOptions?.forwardSubagentText === true;
 
     // Configure thinking behavior from environment variable
     const thinking = resolveThinkingConfig(process.env.MAX_THINKING_TOKENS, this.logger);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -984,25 +984,12 @@ type ProviderConfig = {
   };
 };
 
-/**
- * Extra metadata that the agent provides for each tool_call / tool_update update.
- */
-export type ToolTag = {
-  /** Short, user-visible category name. */
-  label: string;
-  /** CSS-compatible color suggested to clients that render the tag. */
-  color: string;
-};
-
 export type ToolUpdateMeta = {
   claudeCode?: {
     /* The name of the tool that was used in Claude Code. */
     toolName: string;
     /* A human-readable title supplied by Claude Code for the tool call. */
     title?: string;
-    /* Presentation hints for compact, color-coded tool categories. Clients may
-       ignore these without affecting the standard ACP tool-call rendering. */
-    tags?: ToolTag[];
     /* The structured output provided by Claude Code. */
     toolResponse?: unknown;
     /* For a tool call made inside a subagent: the tool_use id of the
@@ -8074,29 +8061,6 @@ function shouldEmitToolCall(toolName: string): boolean {
   return toolName !== "TodoWrite" && !isTaskTool(toolName) && !isFileChangeAuditTool(toolName);
 }
 
-const TOOL_TAGS = {
-  execute: { label: "Execute", color: "#D97706" },
-  edit: { label: "Edit", color: "#2563EB" },
-  search: { label: "Search", color: "#7C3AED" },
-  delegate: { label: "Delegate", color: "#059669" },
-  plan: { label: "Plan", color: "#0891B2" },
-  skill: { label: "Skill", color: "#DB2777" },
-  other: { label: "Tool", color: "#6B7280" },
-} as const satisfies Record<string, ToolTag>;
-
-/** Return the stable presentation tag for a Claude Code tool. */
-function toolTagForToolName(toolName: string): ToolTag {
-  if (toolName === "Bash") return TOOL_TAGS.execute;
-  if (["Edit", "MultiEdit", "NotebookEdit", "Write"].includes(toolName)) return TOOL_TAGS.edit;
-  if (["Glob", "Grep", "Read", "WebFetch", "WebSearch"].includes(toolName)) {
-    return TOOL_TAGS.search;
-  }
-  if (toolName === "Agent" || toolName === "Task") return TOOL_TAGS.delegate;
-  if (toolName === "TodoWrite" || isTaskTool(toolName)) return TOOL_TAGS.plan;
-  if (toolName === "Skill") return TOOL_TAGS.skill;
-  return TOOL_TAGS.other;
-}
-
 /** Build the Claude Code-specific metadata for a tool call. Bash descriptions
  *  are kept out of ACP's standard `title`, which clients may use as the shell
  *  command preview, while still giving clients access to Claude's concise
@@ -8123,7 +8087,6 @@ function claudeCodeMetaFromToolUse(
   const skillPath = skillName ? resolveSkillPath(skillName, cwd) : undefined;
   return {
     toolName: toolUse.name,
-    tags: [toolTagForToolName(toolUse.name)],
     ...(description ? { title: description } : {}),
     ...((toolUse.name === "Agent" || toolUse.name === "Task") && { subagent: true as const }),
     ...(skillName ? { skill: skillName } : {}),

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -96,6 +96,7 @@ import {
 } from "./goal-extension.js";
 import { sanitizeTitle, SessionTitles } from "./session-titles.js";
 import {
+  AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
   AcpSessionNotification,
   asSdkSessionNotification,
   clientSupportsSubagents,
@@ -1629,7 +1630,10 @@ export class ClaudeAcpAgent {
       // steering extension contract: advertises the `_session/steering` request
       // so clients know they may inject a follow-up into a running turn.
       _meta: {
-        ...airSessionFailureCapabilityMeta(AGENT_FILE_CHANGE_REPORT_CAPABILITY),
+        ...airSessionFailureCapabilityMeta(
+          AGENT_FILE_CHANGE_REPORT_CAPABILITY,
+          AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
+        ),
         steering: {
           supported: true,
         },
@@ -3401,6 +3405,7 @@ export class ClaudeAcpAgent {
                     toolUseId: message.tool_use_id,
                     subagentType: message.subagent_type,
                     description: message.description,
+                    prompt: message.prompt,
                   },
                   sendUpdate,
                 );

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -107,6 +107,8 @@ import {
   NativeSubagent,
   NativeSubagentRuntime,
 } from "./native-subagents.js";
+import { AIR_ASYNC_TASKS_CAPABILITY } from "./air-extension.js";
+import { AsyncTaskRuntime, clientSupportsAsyncTasks } from "./async-tasks.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import { execFile } from "node:child_process";
@@ -1633,6 +1635,7 @@ export class ClaudeAcpAgent {
         ...airSessionFailureCapabilityMeta(
           AGENT_FILE_CHANGE_REPORT_CAPABILITY,
           AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
+          AIR_ASYNC_TASKS_CAPABILITY,
         ),
         steering: {
           supported: true,
@@ -2222,6 +2225,11 @@ export class ClaudeAcpAgent {
       session,
       async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
       this.logger,
+    );
+    const asyncTasks = new AsyncTaskRuntime(
+      clientSupportsAsyncTasks(this.clientCapabilities),
+      params.sessionId,
+      async (notification) => this.client.sessionUpdate(asSdkSessionNotification(notification)),
     );
 
     const sendUpdate = async (notification: AcpSessionNotification) => {
@@ -2828,6 +2836,7 @@ export class ClaudeAcpAgent {
           const inFlight = session.activeTurn;
           try {
             await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+            await asyncTasks.finishAll(session.cancelled ? "stopped" : "failed");
           } catch (error) {
             this.logger.error(
               `Session ${params.sessionId}: failed to publish terminal subagent state`,
@@ -3374,7 +3383,15 @@ export class ClaudeAcpAgent {
               case "hook_progress":
               case "hook_response":
               case "files_persisted":
+                break;
               case "task_progress":
+                await asyncTasks.taskProgress({
+                  taskId: message.task_id,
+                  description: message.description,
+                  summary: message.summary,
+                  lastToolName: message.last_tool_name,
+                  usage: message.usage,
+                });
                 break;
               case "task_started":
                 // For subagent tasks `task_id` is the subagent's agent id (the
@@ -3409,6 +3426,14 @@ export class ClaudeAcpAgent {
                   },
                   sendUpdate,
                 );
+                await asyncTasks.taskStarted({
+                  taskId: message.task_id,
+                  taskType: message.task_type,
+                  description: message.description,
+                  subagentType: message.subagent_type,
+                  workflowName: message.workflow_name,
+                  skipTranscript: message.skip_transcript,
+                });
                 if (message.subagent_type && session.activeTurn && !session.activeTurn.settled) {
                   (session.activeTurn.spawnedTaskIds ??= new Set()).add(message.task_id);
                 }
@@ -3417,10 +3442,12 @@ export class ClaudeAcpAgent {
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
                 await subagents.finishTask(message.task_id, message.status, sendUpdate);
+                await asyncTasks.taskNotification(message.task_id, message.status, message.summary);
                 if (message.tool_use_id) subagents.discardPending(message.tool_use_id);
                 session.liveBackgroundTasks.delete(message.task_id);
                 break;
               case "task_updated":
+                await asyncTasks.taskUpdated(message.task_id, message.patch);
                 // terminal-status task_updated patch and a (deduplicated)
                 // task_notification when a task settles, but only the patch is
                 // guaranteed per transition — prune on it too so the registry
@@ -4651,6 +4678,7 @@ export class ClaudeAcpAgent {
             // before any follow-up prompt can republish stale tasks.
             try {
               await subagents.finishAll("failed", sendUpdate);
+              await asyncTasks.finishAll("failed");
             } catch (error) {
               this.logger.error(
                 `Session ${params.sessionId}: failed to publish reset subagent state`,
@@ -4658,6 +4686,7 @@ export class ClaudeAcpAgent {
               );
             }
             subagents.clear();
+            asyncTasks.clear();
             session.taskState.clear();
             await this.publishTaskPlan(params.sessionId, session.taskState);
             // A reset mounts a fresh transcript (`new_conversation_id`), so our
@@ -4696,6 +4725,7 @@ export class ClaudeAcpAgent {
           message.includes("Failed to write to process stdin"));
       try {
         await subagents.finishAll(session.cancelled ? "cancelled" : "failed", sendUpdate);
+        await asyncTasks.finishAll(session.cancelled ? "stopped" : "failed");
       } catch (finishError) {
         this.logger.error(
           `Session ${params.sessionId}: failed to publish terminal subagent state after stream error`,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1070,17 +1070,6 @@ function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | 
   return typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : null;
 }
 
-function stripSubagentTextAndThinking(content: unknown): unknown {
-  if (!Array.isArray(content)) return content;
-  return content.filter(
-    (item) =>
-      !item ||
-      typeof item !== "object" ||
-      !("type" in item) ||
-      (item.type !== "text" && item.type !== "thinking"),
-  );
-}
-
 export type ToolUseCache = {
   [key: string]: {
     type: "tool_use" | "server_tool_use" | "mcp_tool_use";
@@ -3450,6 +3439,12 @@ export class ClaudeAcpAgent {
                 const parentToolUseId = message.agent_id
                   ? session.liveBackgroundTasks.get(message.agent_id)?.parentToolUseId
                   : undefined;
+                if (message.agent_id && !parentToolUseId) {
+                  // An agent-scoped denial with missing lineage cannot safely
+                  // be presented in the root transcript. The matching hidden
+                  // child tool call was not announced there.
+                  break;
+                }
                 const reason = message.decision_reason ?? message.message;
                 await sendUpdate({
                   sessionId: message.session_id,
@@ -4749,6 +4744,13 @@ export class ClaudeAcpAgent {
             if (toolCallId === null || !session.emittedToolCalls.has(toolCallId)) {
               break;
             }
+            const subagentParentToolUseId = message.parent_tool_use_id
+              ? [...session.liveBackgroundTasks.values()].some(
+                  (task) => task.isSubagent && task.parentToolUseId === message.parent_tool_use_id,
+                )
+                ? message.parent_tool_use_id
+                : undefined
+              : undefined;
             await sendUpdate({
               sessionId: message.session_id,
               update: {
@@ -4758,6 +4760,9 @@ export class ClaudeAcpAgent {
                 _meta: {
                   claudeCode: {
                     toolName: message.tool_name,
+                    ...(subagentParentToolUseId
+                      ? { parentToolUseId: subagentParentToolUseId }
+                      : {}),
                     toolResponse: {
                       elapsedTimeSeconds: message.elapsed_time_seconds,
                       // For Agent/Task calls: the subagent's type, and — when
@@ -5370,7 +5375,6 @@ export class ClaudeAcpAgent {
     const toolUseCache: ToolUseCache = {};
     const messages = await getSessionMessages(sessionId);
     const session = this.sessions[sessionId];
-    const forwardSubagentText = clientSupportsSubagents(this.clientCapabilities);
     const supportsTypedFailures = supportsAirSessionFailures(this.clientCapabilities);
     const activeUsageLimit = supportsTypedFailures ? activeUsageLimitMessage(messages) : undefined;
     const sessionFailures =
@@ -5445,8 +5449,14 @@ export class ClaudeAcpAgent {
       // @ts-expect-error - untyped in SDK but we handle all of these
       let content: unknown = message.message.content;
       const parentToolUseId = parentToolUseIdOf(message);
-      if (message.type === "assistant" && parentToolUseId && !forwardSubagentText) {
-        content = stripSubagentTextAndThinking(content);
+      if (parentToolUseId) {
+        // Persisted SDK sidechains do not contain the authoritative
+        // task_started/task_updated lifecycle needed to reconstruct a native
+        // child session. Never replay them into the root transcript: an
+        // unsupported client must not see a legacy child representation, and
+        // a capable client must not receive child output without a preceding
+        // subagent_spawned event.
+        continue;
       }
       // @ts-expect-error - untyped in SDK but we handle all of these
       if (message.message.role === "user") {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -4591,15 +4591,15 @@ export class ClaudeAcpAgent {
               content = message.message.content;
             }
 
-      const acceptedPlanToolUseId = observeExitPlanToolResults(message, content, session);
-      if (message.type === "user") {
-        const backgroundBashTask = backgroundBashTaskFromToolResult(
-          content,
-          message.tool_use_result,
-          session.toolUseCache,
-        );
-        if (backgroundBashTask) await asyncTasks.taskStarted(backgroundBashTask);
-      }
+            const acceptedPlanToolUseId = observeExitPlanToolResults(message, content, session);
+            if (message.type === "user") {
+              const backgroundBashTask = backgroundBashTaskFromToolResult(
+                content,
+                message.tool_use_result,
+                session.toolUseCache,
+              );
+              if (backgroundBashTask) await asyncTasks.taskBackgrounded(backgroundBashTask);
+            }
 
             for (const notification of toAcpNotifications(
               content,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -980,12 +980,22 @@ type ProviderConfig = {
 /**
  * Extra metadata that the agent provides for each tool_call / tool_update update.
  */
+export type ToolTag = {
+  /** Short, user-visible category name. */
+  label: string;
+  /** CSS-compatible color suggested to clients that render the tag. */
+  color: string;
+};
+
 export type ToolUpdateMeta = {
   claudeCode?: {
     /* The name of the tool that was used in Claude Code. */
     toolName: string;
     /* A human-readable title supplied by Claude Code for the tool call. */
     title?: string;
+    /* Presentation hints for compact, color-coded tool categories. Clients may
+       ignore these without affecting the standard ACP tool-call rendering. */
+    tags?: ToolTag[];
     /* The structured output provided by Claude Code. */
     toolResponse?: unknown;
     /* For a tool call made inside a subagent: the tool_use id of the
@@ -7993,6 +8003,29 @@ function shouldEmitToolCall(toolName: string): boolean {
   return toolName !== "TodoWrite" && !isTaskTool(toolName) && !isFileChangeAuditTool(toolName);
 }
 
+const TOOL_TAGS = {
+  execute: { label: "Execute", color: "#D97706" },
+  edit: { label: "Edit", color: "#2563EB" },
+  search: { label: "Search", color: "#7C3AED" },
+  delegate: { label: "Delegate", color: "#059669" },
+  plan: { label: "Plan", color: "#0891B2" },
+  skill: { label: "Skill", color: "#DB2777" },
+  other: { label: "Tool", color: "#6B7280" },
+} as const satisfies Record<string, ToolTag>;
+
+/** Return the stable presentation tag for a Claude Code tool. */
+function toolTagForToolName(toolName: string): ToolTag {
+  if (toolName === "Bash") return TOOL_TAGS.execute;
+  if (["Edit", "MultiEdit", "NotebookEdit", "Write"].includes(toolName)) return TOOL_TAGS.edit;
+  if (["Glob", "Grep", "Read", "WebFetch", "WebSearch"].includes(toolName)) {
+    return TOOL_TAGS.search;
+  }
+  if (toolName === "Agent" || toolName === "Task") return TOOL_TAGS.delegate;
+  if (toolName === "TodoWrite" || isTaskTool(toolName)) return TOOL_TAGS.plan;
+  if (toolName === "Skill") return TOOL_TAGS.skill;
+  return TOOL_TAGS.other;
+}
+
 /** Build the Claude Code-specific metadata for a tool call. Bash descriptions
  *  are kept out of ACP's standard `title`, which clients may use as the shell
  *  command preview, while still giving clients access to Claude's concise
@@ -8019,6 +8052,7 @@ function claudeCodeMetaFromToolUse(
   const skillPath = skillName ? resolveSkillPath(skillName, cwd) : undefined;
   return {
     toolName: toolUse.name,
+    tags: [toolTagForToolName(toolUse.name)],
     ...(description ? { title: description } : {}),
     ...((toolUse.name === "Agent" || toolUse.name === "Task") && { subagent: true as const }),
     ...(skillName ? { skill: skillName } : {}),

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -3,6 +3,12 @@ import type {
   SessionCapabilities,
   SessionNotification,
 } from "@agentclientprotocol/sdk";
+import {
+  AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
+  clientSupportsAirCapability,
+} from "./air-extension.js";
+
+export { AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY } from "./air-extension.js";
 
 /**
  * Temporary typed surface for agentclientprotocol/agent-client-protocol#1992.
@@ -51,7 +57,11 @@ export function clientSupportsSubagents(capabilities?: ClientCapabilities | null
   const subagents = (
     capabilities as (ClientCapabilities & { subagents?: unknown }) | null | undefined
   )?.subagents;
-  return typeof subagents === "object" && subagents !== null && !Array.isArray(subagents);
+  if (typeof subagents === "object" && subagents !== null && !Array.isArray(subagents)) {
+    return true;
+  }
+
+  return clientSupportsAirCapability(capabilities, AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY);
 }
 
 /** The only cast needed until the TypeScript SDK publishes PR #1992. */

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -63,6 +63,10 @@ export type AsyncTaskProgressUpdate = {
   summary?: string;
   lastToolName?: string;
   usage?: { totalTokens: number; toolUses: number; durationMs: number };
+  /** Latest durable task log path. May arrive after spawn. */
+  outputFilePath?: string;
+  /** Originating tool call, when correlation becomes known after spawn. */
+  toolCallId?: string;
   _meta?: Record<string, unknown> | null;
 };
 
@@ -71,6 +75,10 @@ export type AsyncTaskStateUpdate = {
   asyncTaskId: string;
   state: AsyncTaskState;
   summary?: string;
+  /** Latest durable task log path, including terminal-only SDK reports. */
+  outputFilePath?: string;
+  /** Originating tool call, including terminal-only late correlation. */
+  toolCallId?: string;
   _meta?: Record<string, unknown> | null;
 };
 

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -1,0 +1,62 @@
+import type {
+  ClientCapabilities,
+  SessionCapabilities,
+  SessionNotification,
+} from "@agentclientprotocol/sdk";
+
+/**
+ * Temporary typed surface for agentclientprotocol/agent-client-protocol#1992.
+ *
+ * The wire contract is already defined by the ACP draft, but the published
+ * TypeScript SDK does not contain it yet. Keep the compatibility boundary in
+ * this file so it can be replaced by SDK exports without changing lifecycle
+ * code when the draft ships.
+ */
+export type SubagentSessionCapabilities = {
+  cancel?: boolean;
+  close?: boolean;
+  _meta?: Record<string, unknown> | null;
+};
+
+export type SubagentSpawnedUpdate = {
+  sessionUpdate: "subagent_spawned";
+  subagentSessionId: string;
+  name: string;
+  task: string;
+  capabilities: SubagentSessionCapabilities;
+  _meta?: Record<string, unknown> | null;
+};
+
+export type SubagentState = "completed" | "failed" | "cancelled";
+
+export type SubagentStateUpdate = {
+  sessionUpdate: "subagent_state_update";
+  subagentSessionId: string;
+  state: SubagentState;
+  _meta?: Record<string, unknown> | null;
+};
+
+export type AcpSessionUpdate =
+  SessionNotification["update"] | SubagentSpawnedUpdate | SubagentStateUpdate;
+
+export type AcpSessionNotification = Omit<SessionNotification, "update"> & {
+  update: AcpSessionUpdate;
+};
+
+export type SubagentAwareSessionCapabilities = SessionCapabilities & {
+  subagents?: Record<string, never>;
+};
+
+export function clientSupportsSubagents(capabilities?: ClientCapabilities | null): boolean {
+  const subagents = (
+    capabilities as (ClientCapabilities & { subagents?: unknown }) | null | undefined
+  )?.subagents;
+  return typeof subagents === "object" && subagents !== null && !Array.isArray(subagents);
+}
+
+/** The only cast needed until the TypeScript SDK publishes PR #1992. */
+export function asSdkSessionNotification(
+  notification: AcpSessionNotification,
+): SessionNotification {
+  return notification as SessionNotification;
+}

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -28,12 +28,12 @@ export type SubagentSpawnedUpdate = {
   sessionUpdate: "subagent_spawned";
   subagentSessionId: string;
   name: string;
-  description: string;
+  task: string;
   capabilities: SubagentSessionCapabilities;
   _meta?: Record<string, unknown> | null;
 };
 
-export type SubagentState = "completed" | "failed" | "cancelled";
+export type SubagentState = "completed" | "failed" | "cancelled" | "disconnected";
 
 export type SubagentStateUpdate = {
   sessionUpdate: "subagent_state_update";

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -28,7 +28,7 @@ export type SubagentSpawnedUpdate = {
   sessionUpdate: "subagent_spawned";
   subagentSessionId: string;
   name: string;
-  task: string;
+  description: string;
   capabilities: SubagentSessionCapabilities;
   _meta?: Record<string, unknown> | null;
 };

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -51,6 +51,7 @@ export type AsyncTaskSpawnedUpdate = {
   taskType: string;
   description: string;
   showInTranscript: boolean;
+  outputFilePath?: string;
   _meta?: Record<string, unknown> | null;
 };
 

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -51,6 +51,7 @@ export type AsyncTaskSpawnedUpdate = {
   taskType: string;
   description: string;
   showInTranscript: boolean;
+  canStop: boolean;
   outputFilePath?: string;
   toolCallId?: string;
   _meta?: Record<string, unknown> | null;

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -42,8 +42,43 @@ export type SubagentStateUpdate = {
   _meta?: Record<string, unknown> | null;
 };
 
+export type AsyncTaskState = "running" | "paused" | "completed" | "failed" | "stopped";
+
+export type AsyncTaskSpawnedUpdate = {
+  sessionUpdate: "async_task_spawned";
+  asyncTaskId: string;
+  name: string;
+  taskType: string;
+  description: string;
+  showInTranscript: boolean;
+  _meta?: Record<string, unknown> | null;
+};
+
+export type AsyncTaskProgressUpdate = {
+  sessionUpdate: "async_task_progress";
+  asyncTaskId: string;
+  description?: string;
+  summary?: string;
+  lastToolName?: string;
+  usage?: { totalTokens: number; toolUses: number; durationMs: number };
+  _meta?: Record<string, unknown> | null;
+};
+
+export type AsyncTaskStateUpdate = {
+  sessionUpdate: "async_task_state_update";
+  asyncTaskId: string;
+  state: AsyncTaskState;
+  summary?: string;
+  _meta?: Record<string, unknown> | null;
+};
+
 export type AcpSessionUpdate =
-  SessionNotification["update"] | SubagentSpawnedUpdate | SubagentStateUpdate;
+  | SessionNotification["update"]
+  | SubagentSpawnedUpdate
+  | SubagentStateUpdate
+  | AsyncTaskSpawnedUpdate
+  | AsyncTaskProgressUpdate
+  | AsyncTaskStateUpdate;
 
 export type AcpSessionNotification = Omit<SessionNotification, "update"> & {
   update: AcpSessionUpdate;

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -52,6 +52,7 @@ export type AsyncTaskSpawnedUpdate = {
   description: string;
   showInTranscript: boolean;
   outputFilePath?: string;
+  toolCallId?: string;
   _meta?: Record<string, unknown> | null;
 };
 

--- a/src/air-extension.ts
+++ b/src/air-extension.ts
@@ -1,0 +1,40 @@
+import type { ClientCapabilities } from "@agentclientprotocol/sdk";
+
+export const AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY = "nativeSubagentSessions";
+export const AIR_SESSION_FAILURE_CAPABILITY = "sessionFailure";
+
+export const JETBRAINS_META_KEY = "jetbrains";
+export const AIR_META_KEY = "air";
+export const AIR_EXTENSION_VERSION_KEY = "version";
+const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
+export const AIR_EXTENSION_VERSION = 1;
+
+export function airCapabilityMeta(...capabilities: string[]) {
+  return {
+    [JETBRAINS_META_KEY]: {
+      [AIR_META_KEY]: {
+        [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
+        [AIR_EXTENSION_CAPABILITIES_KEY]: capabilities,
+      },
+    },
+  };
+}
+
+export function clientSupportsAirCapability(
+  capabilities: ClientCapabilities | null | undefined,
+  capability: string,
+): boolean {
+  const jetbrains = capabilities?._meta?.[JETBRAINS_META_KEY] as
+    Record<string, unknown> | undefined;
+  const air = jetbrains?.[AIR_META_KEY] as Record<string, unknown> | undefined;
+  const version = air?.[AIR_EXTENSION_VERSION_KEY];
+  const advertised = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
+  return (
+    typeof version === "number" &&
+    Number.isFinite(version) &&
+    Number.isInteger(version) &&
+    version >= AIR_EXTENSION_VERSION &&
+    Array.isArray(advertised) &&
+    advertised.includes(capability)
+  );
+}

--- a/src/air-extension.ts
+++ b/src/air-extension.ts
@@ -1,6 +1,7 @@
 import type { ClientCapabilities } from "@agentclientprotocol/sdk";
 
 export const AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY = "nativeSubagentSessions";
+export const AIR_ASYNC_TASKS_CAPABILITY = "asyncTasks";
 export const AIR_SESSION_FAILURE_CAPABILITY = "sessionFailure";
 
 export const JETBRAINS_META_KEY = "jetbrains";

--- a/src/air-extension.ts
+++ b/src/air-extension.ts
@@ -1,33 +1,61 @@
-import type { ClientCapabilities } from "@agentclientprotocol/sdk";
-
 export const AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY = "nativeSubagentSessions";
 export const AIR_ASYNC_TASKS_CAPABILITY = "asyncTasks";
 export const AIR_SESSION_FAILURE_CAPABILITY = "sessionFailure";
 
-export const JETBRAINS_META_KEY = "jetbrains";
-export const AIR_META_KEY = "air";
-export const AIR_EXTENSION_VERSION_KEY = "version";
+const JETBRAINS_META_KEY = "jetbrains";
+const AIR_META_KEY = "air";
+const AIR_EXTENSION_VERSION_KEY = "version";
 const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
-export const AIR_EXTENSION_VERSION = 1;
+const AIR_EXTENSION_VERSION = 1;
 
+/** The capability list this side advertises, as its own `_meta` object. */
 export function airCapabilityMeta(...capabilities: string[]) {
+  return withAirMeta(undefined, AIR_EXTENSION_CAPABILITIES_KEY, capabilities);
+}
+
+/**
+ * Merges one AIR extension payload into an existing `_meta`.
+ *
+ * Every other namespace is preserved: an update can carry both agent-native
+ * `claudeCode` metadata and an AIR payload, and two AIR payloads can share the
+ * same `air` object. Pass `undefined` to build a fresh `_meta`.
+ */
+export function withAirMeta(
+  meta: Record<string, unknown> | null | undefined,
+  capability: string,
+  payload: unknown,
+): Record<string, unknown> {
+  const jetbrains = asRecord(meta?.[JETBRAINS_META_KEY]);
+  const air = asRecord(jetbrains[AIR_META_KEY]);
   return {
+    ...meta,
     [JETBRAINS_META_KEY]: {
+      ...jetbrains,
       [AIR_META_KEY]: {
+        ...air,
         [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
-        [AIR_EXTENSION_CAPABILITIES_KEY]: capabilities,
+        [capability]: payload,
       },
     },
   };
 }
 
-export function clientSupportsAirCapability(
-  capabilities: ClientCapabilities | null | undefined,
-  capability: string,
-): boolean {
-  const jetbrains = capabilities?._meta?.[JETBRAINS_META_KEY] as
-    Record<string, unknown> | undefined;
-  const air = jetbrains?.[AIR_META_KEY] as Record<string, unknown> | undefined;
+/** The `air` object inside a `_meta`, or undefined when the peer sent no AIR extension. */
+export function airExtensionMeta(meta: unknown): Record<string, unknown> | undefined {
+  const air = asRecord(asRecord(meta)[JETBRAINS_META_KEY])[AIR_META_KEY];
+  return air && typeof air === "object" && !Array.isArray(air)
+    ? (air as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Whether the peer advertised `capability`.
+ *
+ * Takes `unknown` because every caller is reading wire data: an ACP
+ * `ClientCapabilities`, or a bag whose `_meta` was never validated.
+ */
+export function clientSupportsAirCapability(capabilities: unknown, capability: string): boolean {
+  const air = airExtensionMeta(asRecord(capabilities)._meta);
   const version = air?.[AIR_EXTENSION_VERSION_KEY];
   const advertised = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
   return (
@@ -38,4 +66,10 @@ export function clientSupportsAirCapability(
     Array.isArray(advertised) &&
     advertised.includes(capability)
   );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -3,6 +3,7 @@ import type { AcpSessionNotification, AsyncTaskState } from "./acp-subagents.js"
 import { AIR_ASYNC_TASKS_CAPABILITY, clientSupportsAirCapability } from "./air-extension.js";
 
 type Publish = (notification: AcpSessionNotification) => Promise<void>;
+type TerminalSource = "event" | "level" | "shutdown";
 
 type AsyncTask = {
   id: string;
@@ -13,27 +14,67 @@ type AsyncTask = {
   outputFilePath?: string;
   toolCallId?: string;
   announced: boolean;
+  ignored: boolean;
+  startedObserved: boolean;
+  panelOnlyRecovery: boolean;
   state: AsyncTaskState;
+  terminalSummary?: string;
+  terminalSource?: TerminalSource;
 };
 
-export type AsyncTaskStarted = {
-  taskId: string;
+type TaskIdentity = { taskId?: unknown; task_id?: unknown };
+
+export type AsyncTaskStarted = TaskIdentity & {
   taskType?: unknown;
+  task_type?: unknown;
   description?: unknown;
   subagentType?: unknown;
+  subagent_type?: unknown;
   isBackgrounded?: unknown;
+  is_backgrounded?: unknown;
   workflowName?: unknown;
+  workflow_name?: unknown;
   skipTranscript?: unknown;
+  skip_transcript?: unknown;
   outputFilePath?: unknown;
+  output_file?: unknown;
   toolCallId?: unknown;
+  tool_use_id?: unknown;
 };
 
-type TaskProgress = {
-  taskId: string;
+export type AsyncTaskUpdated = TaskIdentity & { patch?: TaskPatch };
+
+type TaskPatch = {
+  status?: unknown;
+  description?: unknown;
+  isBackgrounded?: unknown;
+  is_backgrounded?: unknown;
+  error?: unknown;
+  outputFilePath?: unknown;
+  output_file?: unknown;
+};
+
+export type AsyncTaskNotification = TaskIdentity & {
+  status?: unknown;
+  summary?: unknown;
+  outputFilePath?: unknown;
+  output_file?: unknown;
+};
+
+type TaskProgress = TaskIdentity & {
   description?: unknown;
   summary?: unknown;
   lastToolName?: unknown;
+  last_tool_name?: unknown;
   usage?: unknown;
+  outputFilePath?: unknown;
+  output_file?: unknown;
+};
+
+type BackgroundTaskLevel = TaskIdentity & {
+  taskType?: unknown;
+  task_type?: unknown;
+  description?: unknown;
 };
 
 export function clientSupportsAsyncTasks(capabilities?: ClientCapabilities | null): boolean {
@@ -42,6 +83,11 @@ export function clientSupportsAsyncTasks(capabilities?: ClientCapabilities | nul
 
 /** Publishes Claude's non-agent background work as a separate AIR task lifecycle. */
 export class AsyncTaskRuntime {
+  /**
+   * One registry owns both active tasks and terminal tombstones. Keeping an
+   * unannounced terminal record is intentional: the Bash result proving that
+   * a command was backgrounded can arrive after its terminal SDK edge.
+   */
   private readonly tasks = new Map<string, AsyncTask>();
 
   constructor(
@@ -51,98 +97,228 @@ export class AsyncTaskRuntime {
   ) {}
 
   async taskStarted(message: AsyncTaskStarted): Promise<void> {
-    if (!this.enabled || message.subagentType || this.tasks.has(message.taskId)) return;
-    const taskType = friendlyTaskType(message.taskType);
-    const description = nonBlankString(message.description) ?? defaultDescription(taskType);
-    const task: AsyncTask = {
-      id: message.taskId,
-      name: nonBlankString(message.workflowName) ?? description,
-      taskType,
-      description,
-      showInTranscript: message.skipTranscript !== true,
-      outputFilePath: nonBlankString(message.outputFilePath),
-      toolCallId: nonBlankString(message.toolCallId),
-      announced: false,
-      state: "running",
-    };
-    this.tasks.set(task.id, task);
-    if (isBackgroundTask(message.isBackgrounded, message.taskType)) await this.announce(task);
+    if (!this.enabled) return;
+    const taskId = taskIdOf(message);
+    if (!taskId) return;
+    const task = this.task(taskId);
+    if (isSubagentTask(message)) {
+      task.ignored = true;
+      return;
+    }
+
+    const previousOutputFilePath = task.outputFilePath;
+    const previousToolCallId = task.toolCallId;
+    const wasAnnounced = task.announced;
+    this.mergeStarted(task, message);
+    if (
+      isBackgroundTask(
+        field(message, "isBackgrounded", "is_backgrounded"),
+        field(message, "taskType", "task_type"),
+      )
+    ) {
+      await this.announce(task);
+    }
+    if (
+      wasAnnounced &&
+      (task.outputFilePath !== previousOutputFilePath || task.toolCallId !== previousToolCallId)
+    ) {
+      await this.publishMetadata(task);
+    }
   }
 
   async taskBackgrounded(message: AsyncTaskStarted): Promise<void> {
-    if (!this.enabled || message.subagentType) return;
-    const existing = this.tasks.get(message.taskId);
-    if (!existing) {
-      await this.taskStarted({ ...message, isBackgrounded: true });
+    if (!this.enabled) return;
+    const taskId = taskIdOf(message);
+    if (!taskId) return;
+    const task = this.task(taskId);
+    if (isSubagentTask(message)) {
+      task.ignored = true;
       return;
     }
-    const description = nonBlankString(message.description);
-    if (description) {
-      existing.description = description;
-      existing.name = nonBlankString(message.workflowName) ?? description;
+
+    const previousOutputFilePath = task.outputFilePath;
+    const previousToolCallId = task.toolCallId;
+    const wasAnnounced = task.announced;
+    this.mergeStarted(task, message);
+    await this.announce(task);
+    if (
+      wasAnnounced &&
+      (task.outputFilePath !== previousOutputFilePath || task.toolCallId !== previousToolCallId)
+    ) {
+      await this.publishMetadata(task);
     }
-    const outputFilePath = nonBlankString(message.outputFilePath);
-    if (outputFilePath) existing.outputFilePath = outputFilePath;
-    const toolCallId = nonBlankString(message.toolCallId);
-    if (toolCallId) existing.toolCallId = toolCallId;
-    await this.announce(existing);
   }
 
-  async taskUpdated(
-    taskId: string,
-    patch: { status?: unknown; description?: unknown; isBackgrounded?: unknown; error?: unknown },
-  ): Promise<void> {
-    const task = this.tasks.get(taskId);
-    if (!this.enabled || !task) return;
-    const description = nonBlankString(patch.description);
-    if (description) {
-      task.description = description;
-      task.name = description;
+  async taskUpdated(message: AsyncTaskUpdated): Promise<void>;
+  async taskUpdated(taskId: string, patch: TaskPatch): Promise<void>;
+  async taskUpdated(taskOrId: string | AsyncTaskUpdated, legacyPatch?: TaskPatch): Promise<void> {
+    if (!this.enabled) return;
+    const taskId = typeof taskOrId === "string" ? nonBlankString(taskOrId) : taskIdOf(taskOrId);
+    const patch = typeof taskOrId === "string" ? legacyPatch : taskOrId.patch;
+    if (!taskId || !patch) return;
+
+    const task = this.task(taskId);
+    const previousOutputFilePath = task.outputFilePath;
+    this.mergePatch(task, patch);
+    if (field(patch, "isBackgrounded", "is_backgrounded") === true) {
+      await this.announce(task);
     }
-    if (patch.isBackgrounded === true) await this.announce(task);
+
     const state = taskState(patch.status);
-    if (!state) return;
-    if (state === "running" || state === "paused") {
-      if (!task.announced || task.state === state) return;
-      task.state = state;
-      await this.publishState(task, state, nonBlankString(patch.error));
+    if (!state) {
+      if (task.announced && task.outputFilePath !== previousOutputFilePath) {
+        await this.publishMetadata(task);
+      }
       return;
     }
-    await this.finish(task, state, nonBlankString(patch.error));
+
+    if (state === "running" || state === "paused") {
+      if (isTerminal(task.state)) {
+        if (task.announced && task.outputFilePath !== previousOutputFilePath) {
+          await this.publishMetadata(task);
+        }
+        return;
+      }
+      if (task.state !== state) {
+        task.state = state;
+        if (task.announced) await this.publishState(task, state, nonBlankString(patch.error));
+      } else if (task.announced && task.outputFilePath !== previousOutputFilePath) {
+        await this.publishMetadata(task);
+      }
+      return;
+    }
+
+    await this.finish(task, state, nonBlankString(patch.error), "event");
   }
 
   async taskProgress(message: TaskProgress): Promise<void> {
-    const task = this.tasks.get(message.taskId);
-    if (!this.enabled || !task || !task.announced || isTerminal(task.state)) return;
+    if (!this.enabled) return;
+    const taskId = taskIdOf(message);
+    if (!taskId) return;
+    const task = this.tasks.get(taskId);
+    if (!task || !task.announced || task.ignored) return;
+
+    const previousOutputFilePath = task.outputFilePath;
+    this.mergeOutputFilePath(task, message);
+    const outputChanged = task.outputFilePath !== previousOutputFilePath;
+    if (isTerminal(task.state)) {
+      if (outputChanged) await this.publishMetadata(task);
+      return;
+    }
+
     const usage = taskUsage(message.usage);
-    await this.publish({
-      sessionId: this.sessionId,
-      update: {
-        sessionUpdate: "async_task_progress",
-        asyncTaskId: task.id,
-        ...(nonBlankString(message.description)
-          ? { description: nonBlankString(message.description) }
-          : {}),
-        ...(nonBlankString(message.summary) ? { summary: nonBlankString(message.summary) } : {}),
-        ...(nonBlankString(message.lastToolName)
-          ? { lastToolName: nonBlankString(message.lastToolName) }
-          : {}),
-        ...(usage ? { usage } : {}),
-      },
+    const description = nonBlankString(message.description);
+    const summary = nonBlankString(message.summary);
+    const lastToolName = nonBlankString(field(message, "lastToolName", "last_tool_name"));
+    await this.publishProgress(task, {
+      ...(description ? { description } : {}),
+      ...(summary ? { summary } : {}),
+      ...(lastToolName ? { lastToolName } : {}),
+      ...(usage ? { usage } : {}),
+      ...(outputChanged && task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
     });
   }
 
-  async taskNotification(taskId: string, status: unknown, summary?: unknown): Promise<void> {
-    const task = this.tasks.get(taskId);
-    if (!this.enabled || !task) return;
-    const state = taskState(status);
-    if (!state || state === "running" || state === "paused") return;
-    await this.finish(task, state, nonBlankString(summary));
+  async taskNotification(message: AsyncTaskNotification): Promise<void>;
+  async taskNotification(
+    taskId: string,
+    status: unknown,
+    summary?: unknown,
+    outputFilePath?: unknown,
+  ): Promise<void>;
+  async taskNotification(
+    taskOrId: string | AsyncTaskNotification,
+    legacyStatus?: unknown,
+    legacySummary?: unknown,
+    legacyOutputFilePath?: unknown,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    const message: AsyncTaskNotification =
+      typeof taskOrId === "string"
+        ? {
+            taskId: taskOrId,
+            status: legacyStatus,
+            summary: legacySummary,
+            outputFilePath: legacyOutputFilePath,
+          }
+        : taskOrId;
+    const taskId = taskIdOf(message);
+    const state = taskState(message.status);
+    if (!taskId || !state || state === "running" || state === "paused") return;
+
+    const task = this.task(taskId);
+    const wasTerminal = isTerminal(task.state);
+    const correctsLevelState = wasTerminal && task.terminalSource === "level";
+    const previousOutputFilePath = task.outputFilePath;
+    this.mergeOutputFilePath(task, message);
+    await this.finish(task, state, nonBlankString(message.summary), "event");
+    if (
+      wasTerminal &&
+      !correctsLevelState &&
+      task.announced &&
+      task.outputFilePath !== previousOutputFilePath
+    ) {
+      await this.publishMetadata(task);
+    }
+  }
+
+  /**
+   * Reconciles the SDK's replace-semantics background task level. It does not
+   * create unknown tasks because this level normally precedes task_started and
+   * carries no tool-call attribution. It can, however, promote a known
+   * foreground task and terminate an announced task whose edge was lost.
+   */
+  async backgroundTasksChanged(
+    tasksOrMessage: readonly BackgroundTaskLevel[] | { tasks?: unknown },
+  ): Promise<void> {
+    if (!this.enabled) return;
+    const value = Array.isArray(tasksOrMessage)
+      ? tasksOrMessage
+      : isRecord(tasksOrMessage)
+        ? tasksOrMessage.tasks
+        : undefined;
+    if (!Array.isArray(value)) return;
+
+    const live = new Set<string>();
+    for (const item of value) {
+      if (!isRecord(item)) continue;
+      const taskId = taskIdOf(item);
+      if (!taskId) continue;
+      live.add(taskId);
+      const task = this.task(taskId);
+      if (task.ignored || isTerminal(task.state)) continue;
+      if (field(item, "taskType", "task_type") === "local_agent") {
+        task.ignored = true;
+        continue;
+      }
+      if (!task.startedObserved) {
+        // The replace-level proves liveness but carries neither transcript
+        // policy nor full identity. Recover it for the Async Tasks panel only;
+        // creating a transcript card here would be irreversible if a late
+        // task_started says skip_transcript=true.
+        task.panelOnlyRecovery = true;
+        task.showInTranscript = false;
+      }
+      this.mergeLevel(task, item);
+      await this.announce(task);
+    }
+
+    for (const task of this.tasks.values()) {
+      if (task.announced && !task.ignored && !isTerminal(task.state) && !live.has(task.id)) {
+        // This replace-semantics level is itself the authoritative liveness
+        // boundary. Close immediately so a lost terminal edge cannot leave a
+        // permanent running card; a following task_notification may correct
+        // the best-effort stopped state to completed/failed.
+        await this.finish(task, "stopped", undefined, "level");
+      }
+    }
   }
 
   async finishAll(state: Extract<AsyncTaskState, "failed" | "stopped">): Promise<void> {
     for (const task of this.tasks.values()) {
-      if (task.announced && !isTerminal(task.state)) await this.finish(task, state);
+      if (task.announced && !task.ignored && !isTerminal(task.state)) {
+        await this.finish(task, state, undefined, "shutdown");
+      }
     }
   }
 
@@ -150,8 +326,77 @@ export class AsyncTaskRuntime {
     this.tasks.clear();
   }
 
+  private task(taskId: string): AsyncTask {
+    let task = this.tasks.get(taskId);
+    if (task) return task;
+    task = {
+      id: taskId,
+      name: "Background task",
+      taskType: "task",
+      description: "Background task",
+      showInTranscript: true,
+      announced: false,
+      ignored: false,
+      startedObserved: false,
+      panelOnlyRecovery: false,
+      state: "running",
+    };
+    this.tasks.set(taskId, task);
+    return task;
+  }
+
+  private mergeStarted(task: AsyncTask, message: AsyncTaskStarted): void {
+    task.startedObserved = true;
+    const rawTaskType = field(message, "taskType", "task_type");
+    if (rawTaskType !== undefined) task.taskType = friendlyTaskType(rawTaskType);
+    const description = nonBlankString(message.description);
+    if (description) task.description = description;
+    else if (task.description === "Background task")
+      task.description = defaultDescription(task.taskType);
+    task.name = nonBlankString(field(message, "workflowName", "workflow_name")) ?? task.description;
+    const skipTranscript = field(message, "skipTranscript", "skip_transcript");
+    if (task.panelOnlyRecovery) {
+      // A level-only recovery was already announced without a transcript
+      // entry. Keep that decision monotonic: a late task_started can enrich
+      // the panel, but cannot retroactively create or mutate transcript UI.
+      task.showInTranscript = false;
+    } else if (skipTranscript !== undefined) {
+      task.showInTranscript = skipTranscript !== true;
+    }
+    this.mergeOutputFilePath(task, message);
+    const toolCallId = nonBlankString(field(message, "toolCallId", "tool_use_id"));
+    if (toolCallId) task.toolCallId = toolCallId;
+  }
+
+  private mergePatch(task: AsyncTask, patch: TaskPatch): void {
+    const description = nonBlankString(patch.description);
+    if (description) {
+      task.description = description;
+      task.name = description;
+    }
+    this.mergeOutputFilePath(task, patch);
+  }
+
+  private mergeLevel(task: AsyncTask, level: BackgroundTaskLevel): void {
+    const rawTaskType = field(level, "taskType", "task_type");
+    if (rawTaskType !== undefined) task.taskType = friendlyTaskType(rawTaskType);
+    const description = nonBlankString(level.description);
+    if (description) {
+      task.description = description;
+      task.name = description;
+    }
+  }
+
+  private mergeOutputFilePath(
+    task: AsyncTask,
+    value: { outputFilePath?: unknown; output_file?: unknown },
+  ): void {
+    const outputFilePath = nonBlankString(field(value, "outputFilePath", "output_file"));
+    if (outputFilePath) task.outputFilePath = outputFilePath;
+  }
+
   private async announce(task: AsyncTask): Promise<void> {
-    if (task.announced) return;
+    if (task.announced || task.ignored) return;
     await this.publish({
       sessionId: this.sessionId,
       update: {
@@ -166,16 +411,61 @@ export class AsyncTaskRuntime {
       },
     });
     task.announced = true;
+    if (isTerminal(task.state)) {
+      await this.publishState(task, task.state, task.terminalSummary);
+    }
   }
 
-  private async finish(task: AsyncTask, state: AsyncTaskState, summary?: string): Promise<void> {
-    if (isTerminal(task.state)) return;
-    if (!task.announced) {
-      this.tasks.delete(task.id);
-      return;
+  private async finish(
+    task: AsyncTask,
+    state: Extract<AsyncTaskState, "completed" | "failed" | "stopped">,
+    summary: string | undefined,
+    source: TerminalSource,
+  ): Promise<void> {
+    if (task.ignored) return;
+    if (isTerminal(task.state)) {
+      // A level event may precede the authoritative terminal edge. Correct its
+      // best-effort stopped state if that edge later arrives.
+      if (task.terminalSource !== "level" || source !== "event") return;
     }
     task.state = state;
-    await this.publishState(task, state, summary);
+    task.terminalSummary = summary;
+    task.terminalSource = source;
+    if (task.announced) await this.publishState(task, state, summary);
+  }
+
+  private async publishMetadata(task: AsyncTask): Promise<void> {
+    if (task.outputFilePath || task.toolCallId) {
+      if (isTerminal(task.state)) {
+        await this.publishState(task, task.state, task.terminalSummary);
+      } else {
+        await this.publishProgress(task, {
+          ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
+          ...(task.toolCallId ? { toolCallId: task.toolCallId } : {}),
+        });
+      }
+    }
+  }
+
+  private async publishProgress(
+    task: AsyncTask,
+    update: {
+      description?: string;
+      summary?: string;
+      lastToolName?: string;
+      usage?: { totalTokens: number; toolUses: number; durationMs: number };
+      outputFilePath?: string;
+      toolCallId?: string;
+    },
+  ): Promise<void> {
+    await this.publish({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "async_task_progress",
+        asyncTaskId: task.id,
+        ...update,
+      },
+    });
   }
 
   private async publishState(
@@ -190,64 +480,120 @@ export class AsyncTaskRuntime {
         asyncTaskId: task.id,
         state,
         ...(summary ? { summary } : {}),
+        ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
+        ...(task.toolCallId ? { toolCallId: task.toolCallId } : {}),
       },
     });
   }
 }
 
-/**
- * Recovers the lifecycle edge that current Claude CLI versions expose only on
- * the Bash tool result. Background Bash does not consistently emit the SDK's
- * task_started/task_updated system messages, but its structured result carries
- * the stable task id after the process has actually been backgrounded.
- */
+/** Recovers background Bash lifecycle data exposed only on its tool result. */
 export function backgroundBashTaskFromToolResult(
   content: unknown,
   toolUseResult: unknown,
   toolUses: Record<string, { name: string; input: unknown }>,
 ): AsyncTaskStarted | undefined {
-  if (!Array.isArray(content) || !isRecord(toolUseResult)) return undefined;
-  const taskId = nonBlankString(toolUseResult.backgroundTaskId);
+  if (!Array.isArray(content)) return undefined;
+  const backgroundResults = structuredBackgroundResults(toolUseResult, toolUses);
+  const distinctTaskIds = new Set(backgroundResults.map((result) => result.taskId));
+  if (distinctTaskIds.size !== 1) return undefined;
+  const taskId = [...distinctTaskIds][0];
   if (!taskId) return undefined;
 
-  const toolResults = content.filter(
-    (item): item is { type: "tool_result"; tool_use_id: string; content?: unknown } =>
-      isRecord(item) &&
-      item.type === "tool_result" &&
-      typeof item.tool_use_id === "string" &&
-      item.tool_use_id.length > 0,
-  );
-  if (toolResults.length !== 1) return undefined;
+  const toolResults = content.flatMap(toolResultBlock);
+  const bashResults = toolResults.filter((result) => toolUses[result.toolUseId]?.name === "Bash");
+  if (bashResults.length === 0) return undefined;
 
-  const toolUse = toolUses[toolResults[0].tool_use_id];
-  if (toolUse?.name !== "Bash") return undefined;
-  const input = isRecord(toolUse.input) ? toolUse.input : undefined;
-  const description = nonBlankString(input?.command);
-  const outputFilePath = asyncTaskOutputFilePath(toolResults[0].content, taskId);
+  const hintedToolUseIds = new Set(
+    backgroundResults
+      .filter((result) => result.taskId === taskId && result.toolUseId)
+      .map((result) => result.toolUseId!),
+  );
+  let matches: typeof bashResults;
+  if (hintedToolUseIds.size > 0) {
+    matches = bashResults.filter((result) => hintedToolUseIds.has(result.toolUseId));
+  } else {
+    const pathMatches = bashResults.filter(
+      (result) => asyncTaskOutputFilePath(result.content, taskId) !== undefined,
+    );
+    matches = pathMatches.length > 0 ? pathMatches : bashResults.length === 1 ? bashResults : [];
+  }
+  if (matches.length !== 1) return undefined;
+
+  const match = matches[0];
+  const toolUse = toolUses[match.toolUseId];
+  const input = isRecord(toolUse?.input) ? toolUse.input : undefined;
   return {
     taskId,
     taskType: "local_bash",
-    description,
+    description: nonBlankString(input?.command),
     isBackgrounded: true,
-    outputFilePath,
-    toolCallId: toolResults[0].tool_use_id,
+    outputFilePath: asyncTaskOutputFilePath(match.content, taskId),
+    toolCallId: match.toolUseId,
   };
 }
 
+function structuredBackgroundResults(
+  value: unknown,
+  toolUses: Record<string, { name: string; input: unknown }>,
+  hintedToolUseId?: string,
+  seen = new Set<unknown>(),
+): { taskId: string; toolUseId?: string }[] {
+  if (typeof value !== "object" || value === null || seen.has(value)) return [];
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.flatMap((item) =>
+      structuredBackgroundResults(item, toolUses, hintedToolUseId, seen),
+    );
+  }
+
+  const directTaskId = nonBlankString(field(value, "backgroundTaskId", "background_task_id"));
+  const directToolUseId =
+    nonBlankString(field(value, "toolUseId", "tool_use_id")) ?? hintedToolUseId;
+  const results: { taskId: string; toolUseId?: string }[] = directTaskId
+    ? [{ taskId: directTaskId, toolUseId: directToolUseId }]
+    : [];
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "backgroundTaskId" || key === "background_task_id") continue;
+    results.push(
+      ...structuredBackgroundResults(child, toolUses, toolUses[key] ? key : directToolUseId, seen),
+    );
+  }
+  return results;
+}
+
+function toolResultBlock(value: unknown): { toolUseId: string; content?: unknown }[] {
+  if (!isRecord(value) || value.type !== "tool_result") return [];
+  const toolUseId = nonBlankString(field(value, "toolUseId", "tool_use_id"));
+  return toolUseId ? [{ toolUseId, content: value.content }] : [];
+}
+
 function asyncTaskOutputFilePath(content: unknown, taskId: string): string | undefined {
-  if (typeof content !== "string") return undefined;
+  const text = textContent(content);
+  if (!text) return undefined;
   const marker = "Output is being written to: ";
-  const start = content.indexOf(marker);
+  const start = text.indexOf(marker);
   if (start < 0) return undefined;
   const valueStart = start + marker.length;
-  const valueEnd = content.indexOf(". You will be notified", valueStart);
+  const valueEnd = text.indexOf(". You will be notified", valueStart);
   if (valueEnd < 0) return undefined;
-  const path = content.slice(valueStart, valueEnd).trim();
+  const path = text.slice(valueStart, valueEnd).trim();
   const expectedPosixSuffix = `/tasks/${taskId}.output`;
   const expectedWindowsSuffix = `\\tasks\\${taskId}.output`;
   return path.endsWith(expectedPosixSuffix) || path.endsWith(expectedWindowsSuffix)
     ? path
     : undefined;
+}
+
+function textContent(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const parts = value.map(textContent).filter((part): part is string => part !== undefined);
+    return parts.length > 0 ? parts.join("") : undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  if (typeof value.text === "string") return value.text;
+  return value.content === value ? undefined : textContent(value.content);
 }
 
 function friendlyTaskType(value: unknown): string {
@@ -267,6 +613,13 @@ function isBackgroundTask(isBackgrounded: unknown, taskType: unknown): boolean {
   return taskType !== "local_bash" && taskType !== "local_agent";
 }
 
+function isSubagentTask(message: AsyncTaskStarted): boolean {
+  return (
+    field(message, "subagentType", "subagent_type") !== undefined ||
+    field(message, "taskType", "task_type") === "local_agent"
+  );
+}
+
 function taskState(value: unknown): AsyncTaskState | undefined {
   if (value === "pending" || value === "running") return "running";
   if (value === "paused") return "paused";
@@ -276,26 +629,38 @@ function taskState(value: unknown): AsyncTaskState | undefined {
   return undefined;
 }
 
-function isTerminal(state: AsyncTaskState): boolean {
+function isTerminal(state: AsyncTaskState): state is "completed" | "failed" | "stopped" {
   return state === "completed" || state === "failed" || state === "stopped";
 }
 
 function taskUsage(
   value: unknown,
 ): { totalTokens: number; toolUses: number; durationMs: number } | undefined {
-  if (typeof value !== "object" || value === null) return undefined;
-  const usage = value as Record<string, unknown>;
-  if (
-    typeof usage.total_tokens !== "number" ||
-    typeof usage.tool_uses !== "number" ||
-    typeof usage.duration_ms !== "number"
-  )
+  if (!isRecord(value)) return undefined;
+  const totalTokens = numberField(value, "totalTokens", "total_tokens");
+  const toolUses = numberField(value, "toolUses", "tool_uses");
+  const durationMs = numberField(value, "durationMs", "duration_ms");
+  if (totalTokens === undefined || toolUses === undefined || durationMs === undefined)
     return undefined;
-  return {
-    totalTokens: usage.total_tokens,
-    toolUses: usage.tool_uses,
-    durationMs: usage.duration_ms,
-  };
+  return { totalTokens, toolUses, durationMs };
+}
+
+function taskIdOf(value: TaskIdentity): string | undefined {
+  return nonBlankString(field(value, "taskId", "task_id"));
+}
+
+function field(value: object, camelCase: string, snakeCase: string): unknown {
+  const record = value as Record<string, unknown>;
+  return record[camelCase] !== undefined ? record[camelCase] : record[snakeCase];
+}
+
+function numberField(
+  value: Record<string, unknown>,
+  camelCase: string,
+  snakeCase: string,
+): number | undefined {
+  const result = field(value, camelCase, snakeCase);
+  return typeof result === "number" ? result : undefined;
 }
 
 function nonBlankString(value: unknown): string | undefined {

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -17,6 +17,7 @@ type AsyncTask = {
   ignored: boolean;
   startedObserved: boolean;
   panelOnlyRecovery: boolean;
+  stopping: boolean;
   state: AsyncTaskState;
   terminalSummary?: string;
   terminalSource?: TerminalSource;
@@ -329,6 +330,28 @@ export class AsyncTaskRuntime {
     if (errors.length > 1) throw new AggregateError(errors, "Failed to finish async tasks");
   }
 
+  canStop(taskId: string): boolean {
+    const task = this.tasks.get(taskId);
+    return task?.announced === true && !task.ignored && !task.stopping && !isTerminal(task.state);
+  }
+
+  claimStop(taskId: string): boolean {
+    if (!this.canStop(taskId)) return false;
+    this.tasks.get(taskId)!.stopping = true;
+    return true;
+  }
+
+  releaseStop(taskId: string): void {
+    const task = this.tasks.get(taskId);
+    if (task && !isTerminal(task.state)) task.stopping = false;
+  }
+
+  async taskStopped(taskId: string): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!task || !task.announced || task.ignored) return;
+    await this.finish(task, "stopped", undefined, "event");
+  }
+
   clear(): void {
     this.tasks.clear();
   }
@@ -346,6 +369,7 @@ export class AsyncTaskRuntime {
       ignored: false,
       startedObserved: false,
       panelOnlyRecovery: false,
+      stopping: false,
       state: "running",
     };
     this.tasks.set(taskId, task);
@@ -413,6 +437,7 @@ export class AsyncTaskRuntime {
         taskType: task.taskType,
         description: task.description,
         showInTranscript: task.showInTranscript,
+        canStop: true,
         ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
         ...(task.toolCallId ? { toolCallId: task.toolCallId } : {}),
       },

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -1,0 +1,221 @@
+import type { ClientCapabilities } from "@agentclientprotocol/sdk";
+import type { AcpSessionNotification, AsyncTaskState } from "./acp-subagents.js";
+import { AIR_ASYNC_TASKS_CAPABILITY, clientSupportsAirCapability } from "./air-extension.js";
+
+type Publish = (notification: AcpSessionNotification) => Promise<void>;
+
+type AsyncTask = {
+  id: string;
+  name: string;
+  taskType: string;
+  description: string;
+  showInTranscript: boolean;
+  announced: boolean;
+  state: AsyncTaskState;
+};
+
+type TaskStarted = {
+  taskId: string;
+  taskType?: unknown;
+  description?: unknown;
+  subagentType?: unknown;
+  isBackgrounded?: unknown;
+  workflowName?: unknown;
+  skipTranscript?: unknown;
+};
+
+type TaskProgress = {
+  taskId: string;
+  description?: unknown;
+  summary?: unknown;
+  lastToolName?: unknown;
+  usage?: unknown;
+};
+
+export function clientSupportsAsyncTasks(capabilities?: ClientCapabilities | null): boolean {
+  return clientSupportsAirCapability(capabilities, AIR_ASYNC_TASKS_CAPABILITY);
+}
+
+/** Publishes Claude's non-agent background work as a separate AIR task lifecycle. */
+export class AsyncTaskRuntime {
+  private readonly tasks = new Map<string, AsyncTask>();
+
+  constructor(
+    readonly enabled: boolean,
+    private readonly sessionId: string,
+    private readonly publish: Publish,
+  ) {}
+
+  async taskStarted(message: TaskStarted): Promise<void> {
+    if (!this.enabled || message.subagentType || this.tasks.has(message.taskId)) return;
+    const taskType = friendlyTaskType(message.taskType);
+    const description = nonBlankString(message.description) ?? defaultDescription(taskType);
+    const task: AsyncTask = {
+      id: message.taskId,
+      name: nonBlankString(message.workflowName) ?? description,
+      taskType,
+      description,
+      showInTranscript: message.skipTranscript !== true,
+      announced: false,
+      state: "running",
+    };
+    this.tasks.set(task.id, task);
+    if (isBackgroundTask(message.isBackgrounded, message.taskType)) await this.announce(task);
+  }
+
+  async taskUpdated(
+    taskId: string,
+    patch: { status?: unknown; description?: unknown; isBackgrounded?: unknown; error?: unknown },
+  ): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!this.enabled || !task) return;
+    const description = nonBlankString(patch.description);
+    if (description) {
+      task.description = description;
+      task.name = description;
+    }
+    if (patch.isBackgrounded === true) await this.announce(task);
+    const state = taskState(patch.status);
+    if (!state) return;
+    if (state === "running" || state === "paused") {
+      if (!task.announced || task.state === state) return;
+      task.state = state;
+      await this.publishState(task, state, nonBlankString(patch.error));
+      return;
+    }
+    await this.finish(task, state, nonBlankString(patch.error));
+  }
+
+  async taskProgress(message: TaskProgress): Promise<void> {
+    const task = this.tasks.get(message.taskId);
+    if (!this.enabled || !task || !task.announced || isTerminal(task.state)) return;
+    const usage = taskUsage(message.usage);
+    await this.publish({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "async_task_progress",
+        asyncTaskId: task.id,
+        ...(nonBlankString(message.description)
+          ? { description: nonBlankString(message.description) }
+          : {}),
+        ...(nonBlankString(message.summary) ? { summary: nonBlankString(message.summary) } : {}),
+        ...(nonBlankString(message.lastToolName)
+          ? { lastToolName: nonBlankString(message.lastToolName) }
+          : {}),
+        ...(usage ? { usage } : {}),
+      },
+    });
+  }
+
+  async taskNotification(taskId: string, status: unknown, summary?: unknown): Promise<void> {
+    const task = this.tasks.get(taskId);
+    if (!this.enabled || !task) return;
+    const state = taskState(status);
+    if (!state || state === "running" || state === "paused") return;
+    await this.finish(task, state, nonBlankString(summary));
+  }
+
+  async finishAll(state: Extract<AsyncTaskState, "failed" | "stopped">): Promise<void> {
+    for (const task of this.tasks.values()) {
+      if (task.announced && !isTerminal(task.state)) await this.finish(task, state);
+    }
+  }
+
+  clear(): void {
+    this.tasks.clear();
+  }
+
+  private async announce(task: AsyncTask): Promise<void> {
+    if (task.announced) return;
+    await this.publish({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "async_task_spawned",
+        asyncTaskId: task.id,
+        name: task.name,
+        taskType: task.taskType,
+        description: task.description,
+        showInTranscript: task.showInTranscript,
+      },
+    });
+    task.announced = true;
+  }
+
+  private async finish(task: AsyncTask, state: AsyncTaskState, summary?: string): Promise<void> {
+    if (isTerminal(task.state)) return;
+    if (!task.announced) {
+      this.tasks.delete(task.id);
+      return;
+    }
+    task.state = state;
+    await this.publishState(task, state, summary);
+  }
+
+  private async publishState(
+    task: AsyncTask,
+    state: AsyncTaskState,
+    summary?: string,
+  ): Promise<void> {
+    await this.publish({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "async_task_state_update",
+        asyncTaskId: task.id,
+        state,
+        ...(summary ? { summary } : {}),
+      },
+    });
+  }
+}
+
+function friendlyTaskType(value: unknown): string {
+  if (value === "local_bash") return "shell";
+  if (value === "local_workflow") return "workflow";
+  if (value === "local_monitor" || value === "mcp") return "monitor";
+  return nonBlankString(value) ?? "task";
+}
+
+function defaultDescription(taskType: string): string {
+  return taskType === "task" ? "Background task" : taskType[0].toUpperCase() + taskType.slice(1);
+}
+
+function isBackgroundTask(isBackgrounded: unknown, taskType: unknown): boolean {
+  if (isBackgrounded === true) return true;
+  if (isBackgrounded === false) return false;
+  return taskType !== "local_bash" && taskType !== "local_agent";
+}
+
+function taskState(value: unknown): AsyncTaskState | undefined {
+  if (value === "pending" || value === "running") return "running";
+  if (value === "paused") return "paused";
+  if (value === "completed") return "completed";
+  if (value === "failed") return "failed";
+  if (value === "killed" || value === "cancelled" || value === "stopped") return "stopped";
+  return undefined;
+}
+
+function isTerminal(state: AsyncTaskState): boolean {
+  return state === "completed" || state === "failed" || state === "stopped";
+}
+
+function taskUsage(
+  value: unknown,
+): { totalTokens: number; toolUses: number; durationMs: number } | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const usage = value as Record<string, unknown>;
+  if (
+    typeof usage.total_tokens !== "number" ||
+    typeof usage.tool_uses !== "number" ||
+    typeof usage.duration_ms !== "number"
+  )
+    return undefined;
+  return {
+    totalTokens: usage.total_tokens,
+    toolUses: usage.tool_uses,
+    durationMs: usage.duration_ms,
+  };
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -315,11 +315,18 @@ export class AsyncTaskRuntime {
   }
 
   async finishAll(state: Extract<AsyncTaskState, "failed" | "stopped">): Promise<void> {
+    const errors: unknown[] = [];
     for (const task of this.tasks.values()) {
       if (task.announced && !task.ignored && !isTerminal(task.state)) {
-        await this.finish(task, state, undefined, "shutdown");
+        try {
+          await this.finish(task, state, undefined, "shutdown");
+        } catch (error) {
+          errors.push(error);
+        }
       }
     }
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, "Failed to finish async tasks");
   }
 
   clear(): void {
@@ -428,10 +435,22 @@ export class AsyncTaskRuntime {
       // best-effort stopped state if that edge later arrives.
       if (task.terminalSource !== "level" || source !== "event") return;
     }
+    const previous = {
+      state: task.state,
+      terminalSummary: task.terminalSummary,
+      terminalSource: task.terminalSource,
+    };
     task.state = state;
     task.terminalSummary = summary;
     task.terminalSource = source;
-    if (task.announced) await this.publishState(task, state, summary);
+    try {
+      if (task.announced) await this.publishState(task, state, summary);
+    } catch (error) {
+      task.state = previous.state;
+      task.terminalSummary = previous.terminalSummary;
+      task.terminalSource = previous.terminalSource;
+      throw error;
+    }
   }
 
   private async publishMetadata(task: AsyncTask): Promise<void> {

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -14,7 +14,7 @@ type AsyncTask = {
   state: AsyncTaskState;
 };
 
-type TaskStarted = {
+export type AsyncTaskStarted = {
   taskId: string;
   taskType?: unknown;
   description?: unknown;
@@ -46,7 +46,7 @@ export class AsyncTaskRuntime {
     private readonly publish: Publish,
   ) {}
 
-  async taskStarted(message: TaskStarted): Promise<void> {
+  async taskStarted(message: AsyncTaskStarted): Promise<void> {
     if (!this.enabled || message.subagentType || this.tasks.has(message.taskId)) return;
     const taskType = friendlyTaskType(message.taskType);
     const description = nonBlankString(message.description) ?? defaultDescription(taskType);
@@ -168,6 +168,42 @@ export class AsyncTaskRuntime {
   }
 }
 
+/**
+ * Recovers the lifecycle edge that current Claude CLI versions expose only on
+ * the Bash tool result. Background Bash does not consistently emit the SDK's
+ * task_started/task_updated system messages, but its structured result carries
+ * the stable task id after the process has actually been backgrounded.
+ */
+export function backgroundBashTaskFromToolResult(
+  content: unknown,
+  toolUseResult: unknown,
+  toolUses: Record<string, { name: string; input: unknown }>,
+): AsyncTaskStarted | undefined {
+  if (!Array.isArray(content) || !isRecord(toolUseResult)) return undefined;
+  const taskId = nonBlankString(toolUseResult.backgroundTaskId);
+  if (!taskId) return undefined;
+
+  const toolResults = content.filter(
+    (item): item is { type: "tool_result"; tool_use_id: string } =>
+      isRecord(item) &&
+      item.type === "tool_result" &&
+      typeof item.tool_use_id === "string" &&
+      item.tool_use_id.length > 0,
+  );
+  if (toolResults.length !== 1) return undefined;
+
+  const toolUse = toolUses[toolResults[0].tool_use_id];
+  if (toolUse?.name !== "Bash") return undefined;
+  const input = isRecord(toolUse.input) ? toolUse.input : undefined;
+  const description = nonBlankString(input?.command);
+  return {
+    taskId,
+    taskType: "local_bash",
+    description,
+    isBackgrounded: true,
+  };
+}
+
 function friendlyTaskType(value: unknown): string {
   if (value === "local_bash") return "shell";
   if (value === "local_workflow") return "workflow";
@@ -218,4 +254,8 @@ function taskUsage(
 
 function nonBlankString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -10,6 +10,7 @@ type AsyncTask = {
   taskType: string;
   description: string;
   showInTranscript: boolean;
+  outputFilePath?: string;
   announced: boolean;
   state: AsyncTaskState;
 };
@@ -22,6 +23,7 @@ export type AsyncTaskStarted = {
   isBackgrounded?: unknown;
   workflowName?: unknown;
   skipTranscript?: unknown;
+  outputFilePath?: unknown;
 };
 
 type TaskProgress = {
@@ -56,6 +58,7 @@ export class AsyncTaskRuntime {
       taskType,
       description,
       showInTranscript: message.skipTranscript !== true,
+      outputFilePath: nonBlankString(message.outputFilePath),
       announced: false,
       state: "running",
     };
@@ -75,6 +78,8 @@ export class AsyncTaskRuntime {
       existing.description = description;
       existing.name = nonBlankString(message.workflowName) ?? description;
     }
+    const outputFilePath = nonBlankString(message.outputFilePath);
+    if (outputFilePath) existing.outputFilePath = outputFilePath;
     await this.announce(existing);
   }
 
@@ -151,6 +156,7 @@ export class AsyncTaskRuntime {
         taskType: task.taskType,
         description: task.description,
         showInTranscript: task.showInTranscript,
+        ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
       },
     });
     task.announced = true;
@@ -199,7 +205,7 @@ export function backgroundBashTaskFromToolResult(
   if (!taskId) return undefined;
 
   const toolResults = content.filter(
-    (item): item is { type: "tool_result"; tool_use_id: string } =>
+    (item): item is { type: "tool_result"; tool_use_id: string; content?: unknown } =>
       isRecord(item) &&
       item.type === "tool_result" &&
       typeof item.tool_use_id === "string" &&
@@ -211,12 +217,30 @@ export function backgroundBashTaskFromToolResult(
   if (toolUse?.name !== "Bash") return undefined;
   const input = isRecord(toolUse.input) ? toolUse.input : undefined;
   const description = nonBlankString(input?.command);
+  const outputFilePath = asyncTaskOutputFilePath(toolResults[0].content, taskId);
   return {
     taskId,
     taskType: "local_bash",
     description,
     isBackgrounded: true,
+    outputFilePath,
   };
+}
+
+function asyncTaskOutputFilePath(content: unknown, taskId: string): string | undefined {
+  if (typeof content !== "string") return undefined;
+  const marker = "Output is being written to: ";
+  const start = content.indexOf(marker);
+  if (start < 0) return undefined;
+  const valueStart = start + marker.length;
+  const valueEnd = content.indexOf(". You will be notified", valueStart);
+  if (valueEnd < 0) return undefined;
+  const path = content.slice(valueStart, valueEnd).trim();
+  const expectedPosixSuffix = `/tasks/${taskId}.output`;
+  const expectedWindowsSuffix = `\\tasks\\${taskId}.output`;
+  return path.endsWith(expectedPosixSuffix) || path.endsWith(expectedWindowsSuffix)
+    ? path
+    : undefined;
 }
 
 function friendlyTaskType(value: unknown): string {

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -11,6 +11,7 @@ type AsyncTask = {
   description: string;
   showInTranscript: boolean;
   outputFilePath?: string;
+  toolCallId?: string;
   announced: boolean;
   state: AsyncTaskState;
 };
@@ -24,6 +25,7 @@ export type AsyncTaskStarted = {
   workflowName?: unknown;
   skipTranscript?: unknown;
   outputFilePath?: unknown;
+  toolCallId?: unknown;
 };
 
 type TaskProgress = {
@@ -59,6 +61,7 @@ export class AsyncTaskRuntime {
       description,
       showInTranscript: message.skipTranscript !== true,
       outputFilePath: nonBlankString(message.outputFilePath),
+      toolCallId: nonBlankString(message.toolCallId),
       announced: false,
       state: "running",
     };
@@ -80,6 +83,8 @@ export class AsyncTaskRuntime {
     }
     const outputFilePath = nonBlankString(message.outputFilePath);
     if (outputFilePath) existing.outputFilePath = outputFilePath;
+    const toolCallId = nonBlankString(message.toolCallId);
+    if (toolCallId) existing.toolCallId = toolCallId;
     await this.announce(existing);
   }
 
@@ -157,6 +162,7 @@ export class AsyncTaskRuntime {
         description: task.description,
         showInTranscript: task.showInTranscript,
         ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),
+        ...(task.toolCallId ? { toolCallId: task.toolCallId } : {}),
       },
     });
     task.announced = true;
@@ -224,6 +230,7 @@ export function backgroundBashTaskFromToolResult(
     description,
     isBackgrounded: true,
     outputFilePath,
+    toolCallId: toolResults[0].tool_use_id,
   };
 }
 

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -18,6 +18,7 @@ type AsyncTask = {
   startedObserved: boolean;
   panelOnlyRecovery: boolean;
   stopping: boolean;
+  stopAnnounced: boolean;
   state: AsyncTaskState;
   terminalSummary?: string;
   terminalSource?: TerminalSource;
@@ -348,8 +349,31 @@ export class AsyncTaskRuntime {
 
   async taskStopped(taskId: string): Promise<void> {
     const task = this.tasks.get(taskId);
-    if (!task || !task.announced || task.ignored) return;
+    if (!task || !task.announced || task.ignored || task.stopAnnounced) return;
+    task.stopAnnounced = true;
+    // No terminal summary: a stopped task leaves the Async Tasks panel at once,
+    // so anything said there is said to nobody.
     await this.finish(task, "stopped", undefined, "event");
+    // The transcript is where the acknowledgement has to land, and it is the
+    // only one the user gets -- the SDK injects nothing into the model's
+    // context for a stopped shell task.
+    //
+    // Terminal state deliberately does not gate this. The SDK's own
+    // `task_notification` routinely wins the race against the `stopTask`
+    // response that brought us here, so by now the task is usually already
+    // terminal: gating on that would silence the very stop the user asked for.
+    // `stopAnnounced` is what keeps this to one line per task.
+    //
+    // `showInTranscript` does not gate it either: that flag decides whether the
+    // task owns a transcript *card* (a background Bash task is already drawn as
+    // its tool call), not whether the agent may answer a direct user action.
+    await this.publish({
+      sessionId: this.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: `**Task stopped by user:** ${task.name}.` },
+      },
+    });
   }
 
   clear(): void {
@@ -370,6 +394,7 @@ export class AsyncTaskRuntime {
       startedObserved: false,
       panelOnlyRecovery: false,
       stopping: false,
+      stopAnnounced: false,
       state: "running",
     };
     this.tasks.set(taskId, task);
@@ -538,15 +563,20 @@ export function backgroundBashTaskFromToolResult(
   toolUses: Record<string, { name: string; input: unknown }>,
 ): AsyncTaskStarted | undefined {
   if (!Array.isArray(content)) return undefined;
-  const backgroundResults = structuredBackgroundResults(toolUseResult, toolUses);
-  const distinctTaskIds = new Set(backgroundResults.map((result) => result.taskId));
-  if (distinctTaskIds.size !== 1) return undefined;
-  const taskId = [...distinctTaskIds][0];
-  if (!taskId) return undefined;
-
   const toolResults = content.flatMap(toolResultBlock);
   const bashResults = toolResults.filter((result) => toolUses[result.toolUseId]?.name === "Bash");
   if (bashResults.length === 0) return undefined;
+
+  const backgroundResults = structuredBackgroundResults(toolUseResult, toolUses);
+  const distinctTaskIds = new Set([
+    ...backgroundResults.map((result) => result.taskId),
+    ...bashResults
+      .map((result) => backgroundTaskIdFromText(result.content))
+      .filter((taskId): taskId is string => taskId !== undefined),
+  ]);
+  if (distinctTaskIds.size !== 1) return undefined;
+  const taskId = [...distinctTaskIds][0];
+  if (!taskId) return undefined;
 
   const hintedToolUseIds = new Set(
     backgroundResults
@@ -575,6 +605,17 @@ export function backgroundBashTaskFromToolResult(
     outputFilePath: asyncTaskOutputFilePath(match.content, taskId),
     toolCallId: match.toolUseId,
   };
+}
+
+function backgroundTaskIdFromText(content: unknown): string | undefined {
+  const text = textContent(content);
+  if (!text) return undefined;
+  const marker = "Command running in background with ID: ";
+  const start = text.indexOf(marker);
+  if (start < 0) return undefined;
+  const valueStart = start + marker.length;
+  const valueEnd = text.indexOf(".", valueStart);
+  return valueEnd < 0 ? undefined : nonBlankString(text.slice(valueStart, valueEnd));
 }
 
 function structuredBackgroundResults(

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -63,6 +63,21 @@ export class AsyncTaskRuntime {
     if (isBackgroundTask(message.isBackgrounded, message.taskType)) await this.announce(task);
   }
 
+  async taskBackgrounded(message: AsyncTaskStarted): Promise<void> {
+    if (!this.enabled || message.subagentType) return;
+    const existing = this.tasks.get(message.taskId);
+    if (!existing) {
+      await this.taskStarted({ ...message, isBackgrounded: true });
+      return;
+    }
+    const description = nonBlankString(message.description);
+    if (description) {
+      existing.description = description;
+      existing.name = nonBlankString(message.workflowName) ?? description;
+    }
+    await this.announce(existing);
+  }
+
   async taskUpdated(
     taskId: string,
     patch: { status?: unknown; description?: unknown; isBackgrounded?: unknown; error?: unknown },

--- a/src/file-change-audit.ts
+++ b/src/file-change-audit.ts
@@ -7,6 +7,7 @@ import {
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { z } from "zod";
+import { airExtensionMeta, clientSupportsAirCapability, withAirMeta } from "./air-extension.js";
 
 export const AGENT_FILE_CHANGE_REPORT_CAPABILITY = "agentFileChangeReport";
 export const FILE_CHANGE_AUDIT_SERVER_NAME = "claude_agent_acp";
@@ -55,12 +56,6 @@ export type AgentFileChangeReportResult = {
 export type FileChangeReportUnavailableReason =
   "cancelled" | "timeout" | "invalidOutput" | "notReported" | "providerError";
 
-const JETBRAINS_META_KEY = "jetbrains";
-const AIR_META_KEY = "air";
-const AIR_EXTENSION_VERSION = 1;
-const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
-const AIR_AGENT_FILE_CHANGE_REPORT_KEY = "agentFileChangeReport";
-
 type FileChangeAuditSupportOptions = {
   cwd: string;
   additionalDirectories: string[];
@@ -98,7 +93,7 @@ const reportInputSchema = {
 };
 
 export function agentFileChangeReportRequestId(meta: unknown): string | undefined {
-  const air = airExtension(meta);
+  const air = airExtensionMeta(meta);
   const request = air?.agentFileChangeReportRequest;
   if (!request || typeof request !== "object" || Array.isArray(request)) return undefined;
   const requestRecord = request as Record<string, unknown>;
@@ -117,39 +112,13 @@ export function agentFileChangeReportRequestId(meta: unknown): string | undefine
 }
 
 export function supportsAgentFileChangeReport(capabilities: unknown): boolean {
-  if (!capabilities || typeof capabilities !== "object" || Array.isArray(capabilities)) {
-    return false;
-  }
-  const air = airExtension((capabilities as Record<string, unknown>)._meta);
-  const advertised = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
-  return (
-    air?.version === AIR_EXTENSION_VERSION &&
-    Array.isArray(advertised) &&
-    advertised.includes(AGENT_FILE_CHANGE_REPORT_CAPABILITY)
-  );
+  return clientSupportsAirCapability(capabilities, AGENT_FILE_CHANGE_REPORT_CAPABILITY);
 }
 
 export function agentFileChangeReportMeta(
   result: AgentFileChangeReportResult,
 ): Record<string, unknown> {
-  return {
-    [JETBRAINS_META_KEY]: {
-      [AIR_META_KEY]: {
-        version: AIR_EXTENSION_VERSION,
-        [AIR_AGENT_FILE_CHANGE_REPORT_KEY]: result,
-      },
-    },
-  };
-}
-
-function airExtension(meta: unknown): Record<string, unknown> | undefined {
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return undefined;
-  const jetbrains = (meta as Record<string, unknown>)[JETBRAINS_META_KEY];
-  if (!jetbrains || typeof jetbrains !== "object" || Array.isArray(jetbrains)) return undefined;
-  const air = (jetbrains as Record<string, unknown>)[AIR_META_KEY];
-  return air && typeof air === "object" && !Array.isArray(air)
-    ? (air as Record<string, unknown>)
-    : undefined;
+  return withAirMeta(undefined, AGENT_FILE_CHANGE_REPORT_CAPABILITY, result);
 }
 
 export function createFileChangeAuditTurnState(requestId: string): FileChangeAuditTurnState {

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -49,6 +49,7 @@ export class NativeSubagentRuntime {
   private readonly taskByToolUse: Map<string, string>;
   private readonly parentByToolUse: Map<string, string>;
   private readonly identityByToolUse = new Map<string, SubagentIdentity>();
+  private readonly childTaskByParentToolUse = new Map<string, string>();
   private readonly pending = new Map<string, AcpSessionNotification[]>();
   private pendingCount = 0;
 
@@ -63,11 +64,15 @@ export class NativeSubagentRuntime {
     this.children = session.nativeSubagentsByTaskId ??= new Map();
     this.taskByToolUse = session.nativeSubagentTaskIdByToolUseId ??= new Map();
     this.parentByToolUse = session.nativeSubagentParentByToolUseId ??= new Map();
+    for (const [taskId, child] of this.children) {
+      if (child.parentToolUseId) this.childTaskByParentToolUse.set(child.parentToolUseId, taskId);
+    }
   }
 
   async route(
     notification: AcpSessionNotification,
     deliver: Publish,
+    forcedSessionId?: string,
   ): Promise<AcpSessionNotification | null> {
     const { update } = notification;
     const claudeMeta = update._meta?.claudeCode as
@@ -96,15 +101,22 @@ export class NativeSubagentRuntime {
         : this.rootSessionId;
       this.parentByToolUse.set(update.toolCallId, parentSessionId ?? this.rootSessionId);
 
-      for (const child of this.children.values()) {
-        if (child.parentToolUseId !== update.toolCallId || child.announced) continue;
+      const childTaskId = this.childTaskByParentToolUse.get(update.toolCallId);
+      const child = childTaskId ? this.children.get(childTaskId) : undefined;
+      if (child && !child.announced) {
         child.parentSessionId = parentSessionId ?? this.rootSessionId;
         applySubagentIdentity(child, this.identityByToolUse.get(update.toolCallId));
         await announceNativeSubagent(child, this.publish);
         for (const pending of this.takePending(update.toolCallId)) await deliver(pending);
       }
-      return null;
+      return forcedSessionId ? { ...notification, sessionId: forcedSessionId } : null;
     }
+
+    // A permission request may have had to create the tool call before native
+    // child ownership was known. Keep every later update in that original ACP
+    // session; moving a lifecycle after its initial call creates an orphan in
+    // both transcripts.
+    if (forcedSessionId) return { ...notification, sessionId: forcedSessionId };
 
     if (this.enabled && claudeMeta?.parentToolUseId) {
       const taskId = this.taskByToolUse.get(claudeMeta.parentToolUseId);
@@ -153,7 +165,10 @@ export class NativeSubagentRuntime {
       ),
     };
     this.children.set(task.taskId, child);
-    if (task.toolUseId) this.taskByToolUse.set(task.toolUseId, task.taskId);
+    if (task.toolUseId) {
+      this.taskByToolUse.set(task.toolUseId, task.taskId);
+      this.childTaskByParentToolUse.set(task.toolUseId, task.taskId);
+    }
 
     // A nested child must wait for the spawning Agent/Task frame to establish
     // its immediate parent. Root children without a tool id can be announced.
@@ -176,7 +191,11 @@ export class NativeSubagentRuntime {
       for (const pending of this.takePending(child.parentToolUseId)) await deliver(pending);
     }
     await finishNativeSubagent(this.session, taskId, state, this.publish);
-    if (child.parentToolUseId) this.identityByToolUse.delete(child.parentToolUseId);
+    if (child.parentToolUseId) {
+      this.identityByToolUse.delete(child.parentToolUseId);
+      this.parentByToolUse.delete(child.parentToolUseId);
+      this.childTaskByParentToolUse.delete(child.parentToolUseId);
+    }
   }
 
   async finishAll(state: SubagentState, deliver: Publish): Promise<void> {
@@ -196,6 +215,7 @@ export class NativeSubagentRuntime {
     this.taskByToolUse.clear();
     this.parentByToolUse.clear();
     this.identityByToolUse.clear();
+    this.childTaskByParentToolUse.clear();
     this.pending.clear();
     this.pendingCount = 0;
   }

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -226,7 +226,6 @@ export async function finishNativeSubagent(
   const child = session.nativeSubagentsByTaskId?.get(taskId);
   if (!child || child.terminalState !== undefined) return;
   await announceNativeSubagent(child, publish);
-  child.terminalState = state;
   await publish({
     sessionId: child.parentSessionId,
     update: {
@@ -235,6 +234,7 @@ export async function finishNativeSubagent(
       state,
     },
   });
+  child.terminalState = state;
 }
 
 export async function finishNativeSubagents(

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -78,7 +78,7 @@ export class NativeSubagentRuntime {
         claudeMeta?.toolName === "Agent" ||
         claudeMeta?.toolName === "Task");
 
-    if (!this.enabled && (isControl || claudeMeta?.parentToolUseId)) return null;
+    if (!this.enabled) return notification;
 
     if (this.enabled && isControl) {
       const identity = subagentIdentity(update.rawInput);

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -5,9 +5,13 @@ export type NativeSubagent = {
   parentSessionId: string;
   parentToolUseId?: string;
   name: string;
-  description: string;
+  task: string;
   announced?: boolean;
   terminalState?: SubagentState;
+  /** Connection-local single-flight state; never serialized on the wire. */
+  announcePromise?: Promise<void>;
+  /** Connection-local single-flight state; never serialized on the wire. */
+  terminalPromise?: Promise<void>;
 };
 
 export type NativeSubagentSession = {
@@ -49,7 +53,10 @@ export class NativeSubagentRuntime {
   private readonly taskByToolUse: Map<string, string>;
   private readonly parentByToolUse: Map<string, string>;
   private readonly identityByToolUse = new Map<string, SubagentIdentity>();
-  private readonly childTaskByParentToolUse = new Map<string, string>();
+  private readonly controlByToolUse = new Map<string, AcpSessionNotification>();
+  private readonly childByParentToolUse = new Map<string, NativeSubagent>();
+  private readonly taskFinishPromises = new Map<string, Promise<void>>();
+  private readonly generationByTaskId = new Map<string, number>();
   private readonly pending = new Map<string, AcpSessionNotification[]>();
   private pendingCount = 0;
 
@@ -64,8 +71,10 @@ export class NativeSubagentRuntime {
     this.children = session.nativeSubagentsByTaskId ??= new Map();
     this.taskByToolUse = session.nativeSubagentTaskIdByToolUseId ??= new Map();
     this.parentByToolUse = session.nativeSubagentParentByToolUseId ??= new Map();
-    for (const [taskId, child] of this.children) {
-      if (child.parentToolUseId) this.childTaskByParentToolUse.set(child.parentToolUseId, taskId);
+    for (const child of this.children.values()) {
+      if (child.parentToolUseId) {
+        this.childByParentToolUse.set(child.parentToolUseId, child);
+      }
     }
   }
 
@@ -77,37 +86,42 @@ export class NativeSubagentRuntime {
     const { update } = notification;
     const claudeMeta = update._meta?.claudeCode as
       { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
-    const isControl =
-      (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
-      (claudeMeta?.subagent === true ||
-        claudeMeta?.toolName === "Agent" ||
-        claudeMeta?.toolName === "Task");
+    const isControl = isNativeSubagentControlUpdate(update);
 
     if (!this.enabled) return notification;
 
     if (this.enabled && isControl) {
+      const toolCallId = update.toolCallId;
+      if (update.sessionUpdate === "tool_call") {
+        this.controlByToolUse.set(toolCallId, notification);
+      }
       const identity = subagentIdentity(update.rawInput);
       if (identity) {
         this.identityByToolUse.set(
-          update.toolCallId,
-          mergeSubagentIdentity(this.identityByToolUse.get(update.toolCallId), identity),
+          toolCallId,
+          mergeSubagentIdentity(this.identityByToolUse.get(toolCallId), identity),
         );
       }
-      const parentTaskId = claudeMeta.parentToolUseId
-        ? this.taskByToolUse.get(claudeMeta.parentToolUseId)
-        : undefined;
-      const parentSessionId = parentTaskId
-        ? this.children.get(parentTaskId)?.sessionId
+      const parentSessionId = claudeMeta?.parentToolUseId
+        ? this.childByParentToolUse.get(claudeMeta.parentToolUseId)?.sessionId
         : this.rootSessionId;
-      this.parentByToolUse.set(update.toolCallId, parentSessionId ?? this.rootSessionId);
+      this.parentByToolUse.set(toolCallId, parentSessionId ?? this.rootSessionId);
 
-      const childTaskId = this.childTaskByParentToolUse.get(update.toolCallId);
-      const child = childTaskId ? this.children.get(childTaskId) : undefined;
+      const child = this.childByParentToolUse.get(toolCallId);
       if (child && !child.announced) {
         child.parentSessionId = parentSessionId ?? this.rootSessionId;
-        applySubagentIdentity(child, this.identityByToolUse.get(update.toolCallId));
+        applySubagentIdentity(child, this.identityByToolUse.get(toolCallId));
         await announceNativeSubagent(child, this.publish);
-        for (const pending of this.takePending(update.toolCallId)) await deliver(pending);
+        for (const pending of this.takePending(toolCallId)) await deliver(pending);
+      }
+      if (!child && isFailedToolCallUpdate(update)) {
+        this.takePending(toolCallId);
+        const initial = this.controlByToolUse.get(toolCallId);
+        this.cleanupControl(toolCallId);
+        if (forcedSessionId) {
+          return { ...notification, sessionId: forcedSessionId };
+        }
+        return failedControlFallback(initial, notification, parentSessionId ?? this.rootSessionId);
       }
       return forcedSessionId ? { ...notification, sessionId: forcedSessionId } : null;
     }
@@ -119,13 +133,12 @@ export class NativeSubagentRuntime {
     if (forcedSessionId) return { ...notification, sessionId: forcedSessionId };
 
     if (this.enabled && claudeMeta?.parentToolUseId) {
-      const taskId = this.taskByToolUse.get(claudeMeta.parentToolUseId);
-      const child = taskId ? this.children.get(taskId) : undefined;
+      const child = this.childByParentToolUse.get(claudeMeta.parentToolUseId);
       if (!child || !child.announced) {
         this.buffer(claudeMeta.parentToolUseId, notification);
         return null;
       }
-      if (child.terminalState !== undefined) {
+      if (child.terminalState !== undefined || child.terminalPromise) {
         this.logger.log(
           `Session ${this.rootSessionId}: ignoring late update for terminal subagent ${child.sessionId}`,
         );
@@ -140,17 +153,21 @@ export class NativeSubagentRuntime {
   async taskStarted(task: TaskStarted, deliver: Publish): Promise<void> {
     if (!this.enabled) return;
     if (!task.subagentType) {
-      if (task.toolUseId) this.takePending(task.toolUseId);
+      if (task.toolUseId) {
+        this.takePending(task.toolUseId);
+        this.cleanupControl(task.toolUseId);
+      }
       return;
     }
-    if (this.children.has(task.taskId)) return;
+    const previous = this.children.get(task.taskId);
+    if (previous && previous.terminalState === undefined) return;
 
     const knownParentSessionId = task.toolUseId
       ? this.parentByToolUse.get(task.toolUseId)
       : undefined;
     const identity = task.toolUseId ? this.identityByToolUse.get(task.toolUseId) : undefined;
     const child: NativeSubagent = {
-      sessionId: task.taskId,
+      sessionId: this.nextChildSessionId(task.taskId, previous),
       parentSessionId: knownParentSessionId ?? this.rootSessionId,
       parentToolUseId: task.toolUseId ?? undefined,
       name: subagentDisplayName(
@@ -159,7 +176,7 @@ export class NativeSubagentRuntime {
         identity?.subagentType ?? task.subagentType,
         task.taskId,
       ),
-      description: subagentDescription(
+      task: subagentDescription(
         identity?.prompt ?? task.prompt,
         identity?.description ?? task.description,
       ),
@@ -167,7 +184,8 @@ export class NativeSubagentRuntime {
     this.children.set(task.taskId, child);
     if (task.toolUseId) {
       this.taskByToolUse.set(task.toolUseId, task.taskId);
-      this.childTaskByParentToolUse.set(task.toolUseId, task.taskId);
+      this.childByParentToolUse.set(task.toolUseId, child);
+      this.controlByToolUse.delete(task.toolUseId);
     }
 
     // A nested child must wait for the spawning Agent/Task frame to establish
@@ -180,30 +198,60 @@ export class NativeSubagentRuntime {
     }
   }
 
-  async finishTask(taskId: string, status: unknown, deliver: Publish): Promise<void> {
+  async finishTask(
+    taskId: string,
+    status: unknown,
+    deliver: Publish,
+    toolUseId?: string | null,
+  ): Promise<void> {
     if (!this.enabled) return;
     const state = nativeSubagentState(status);
-    const child = this.children.get(taskId);
+    const child = toolUseId ? this.childByParentToolUse.get(toolUseId) : this.children.get(taskId);
+    if (child && toolUseId && this.taskByToolUse.get(toolUseId) !== taskId) return;
     if (!state || !child || child.terminalState !== undefined) return;
+    const existing = this.taskFinishPromises.get(taskId);
+    if (existing) return existing;
 
-    await announceNativeSubagent(child, this.publish);
-    if (child.parentToolUseId) {
-      for (const pending of this.takePending(child.parentToolUseId)) await deliver(pending);
-    }
-    await finishNativeSubagent(this.session, taskId, state, this.publish);
-    if (child.parentToolUseId) {
-      this.identityByToolUse.delete(child.parentToolUseId);
-      this.parentByToolUse.delete(child.parentToolUseId);
-      this.childTaskByParentToolUse.delete(child.parentToolUseId);
+    const finish = Promise.resolve().then(async () => {
+      try {
+        await announceNativeSubagent(child, this.publish);
+        if (child.parentToolUseId) {
+          for (const pending of this.takePending(child.parentToolUseId)) await deliver(pending);
+        }
+        await finishNativeSubagent(this.session, taskId, state, this.publish);
+      } finally {
+        if (child.parentToolUseId) {
+          this.cleanupControl(child.parentToolUseId);
+        }
+      }
+    });
+    this.taskFinishPromises.set(taskId, finish);
+    try {
+      await finish;
+    } finally {
+      if (this.taskFinishPromises.get(taskId) === finish) this.taskFinishPromises.delete(taskId);
     }
   }
 
   async finishAll(state: SubagentState, deliver: Publish): Promise<void> {
-    for (const taskId of [...this.children.keys()].reverse()) {
-      await this.finishTask(taskId, state, deliver);
+    const errors: unknown[] = [];
+    try {
+      for (const taskId of [...this.children.keys()].reverse()) {
+        try {
+          await this.finishTask(taskId, state, deliver);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    } finally {
+      this.pending.clear();
+      this.pendingCount = 0;
+      this.identityByToolUse.clear();
+      this.controlByToolUse.clear();
+      this.parentByToolUse.clear();
     }
-    this.pending.clear();
-    this.pendingCount = 0;
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) throw new AggregateError(errors, "Failed to finish native subagents");
   }
 
   discardPending(parentToolUseId: string): void {
@@ -215,7 +263,10 @@ export class NativeSubagentRuntime {
     this.taskByToolUse.clear();
     this.parentByToolUse.clear();
     this.identityByToolUse.clear();
-    this.childTaskByParentToolUse.clear();
+    this.controlByToolUse.clear();
+    this.childByParentToolUse.clear();
+    this.taskFinishPromises.clear();
+    this.generationByTaskId.clear();
     this.pending.clear();
     this.pendingCount = 0;
   }
@@ -245,6 +296,22 @@ export class NativeSubagentRuntime {
     else this.pending.set(parentToolUseId, [notification]);
     this.pendingCount++;
   }
+
+  private cleanupControl(toolUseId: string): void {
+    this.identityByToolUse.delete(toolUseId);
+    this.controlByToolUse.delete(toolUseId);
+    this.parentByToolUse.delete(toolUseId);
+  }
+
+  private nextChildSessionId(taskId: string, previous: NativeSubagent | undefined): string {
+    if (!previous) {
+      this.generationByTaskId.set(taskId, 1);
+      return taskId;
+    }
+    const generation = (this.generationByTaskId.get(taskId) ?? 1) + 1;
+    this.generationByTaskId.set(taskId, generation);
+    return `${taskId}:generation:${generation}`;
+  }
 }
 
 export async function announceNativeSubagent(
@@ -252,17 +319,26 @@ export async function announceNativeSubagent(
   publish: Publish,
 ): Promise<void> {
   if (child.announced) return;
-  await publish({
-    sessionId: child.parentSessionId,
-    update: {
-      sessionUpdate: "subagent_spawned",
-      subagentSessionId: child.sessionId,
-      name: child.name,
-      description: child.description,
-      capabilities: {},
-    },
+  if (child.announcePromise) return child.announcePromise;
+  const announce = Promise.resolve().then(async () => {
+    await publish({
+      sessionId: child.parentSessionId,
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagentSessionId: child.sessionId,
+        name: child.name,
+        task: child.task,
+        capabilities: {},
+      },
+    });
+    child.announced = true;
   });
-  child.announced = true;
+  child.announcePromise = announce;
+  try {
+    await announce;
+  } finally {
+    if (child.announcePromise === announce) child.announcePromise = undefined;
+  }
 }
 
 export async function finishNativeSubagent(
@@ -273,33 +349,122 @@ export async function finishNativeSubagent(
 ): Promise<void> {
   const child = session.nativeSubagentsByTaskId?.get(taskId);
   if (!child || child.terminalState !== undefined) return;
-  await announceNativeSubagent(child, publish);
-  await publish({
-    sessionId: child.parentSessionId,
-    update: {
-      sessionUpdate: "subagent_state_update",
-      subagentSessionId: child.sessionId,
-      state,
-    },
+  if (child.terminalPromise) return child.terminalPromise;
+  const finish = Promise.resolve().then(async () => {
+    await announceNativeSubagent(child, publish);
+    await publish({
+      sessionId: child.parentSessionId,
+      update: {
+        sessionUpdate: "subagent_state_update",
+        subagentSessionId: child.sessionId,
+        state,
+      },
+    });
+    child.terminalState = state;
   });
-  child.terminalState = state;
-}
-
-export async function finishNativeSubagents(
-  session: NativeSubagentSession,
-  state: SubagentState,
-  publish: Publish,
-): Promise<void> {
-  for (const taskId of [...(session.nativeSubagentsByTaskId?.keys() ?? [])].reverse()) {
-    await finishNativeSubagent(session, taskId, state, publish);
+  child.terminalPromise = finish;
+  try {
+    await finish;
+  } finally {
+    if (child.terminalPromise === finish) child.terminalPromise = undefined;
   }
 }
 
-function nativeSubagentState(status: unknown): SubagentState | undefined {
+export function nativeSubagentState(status: unknown): SubagentState | undefined {
   if (status === "completed") return "completed";
   if (status === "failed") return "failed";
+  if (status === "disconnected") return "disconnected";
   if (status === "killed" || status === "cancelled" || status === "stopped") return "cancelled";
   return undefined;
+}
+
+export function isNativeSubagentControlUpdate(
+  update: AcpSessionNotification["update"],
+): update is Extract<
+  AcpSessionNotification["update"],
+  { sessionUpdate: "tool_call" | "tool_call_update" }
+> {
+  if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
+    return false;
+  }
+  const claudeMeta = update._meta?.claudeCode as { subagent?: true; toolName?: string } | undefined;
+  return claudeMeta?.subagent === true || isNativeSubagentControlTool(claudeMeta?.toolName);
+}
+
+export function isNativeSubagentControlTool(toolName: unknown): boolean {
+  return toolName === "Agent" || toolName === "Task";
+}
+
+function isFailedToolCallUpdate(update: AcpSessionNotification["update"]): boolean {
+  return (
+    (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+    update.status === "failed"
+  );
+}
+
+function failedControlFallback(
+  initial: AcpSessionNotification | undefined,
+  terminal: AcpSessionNotification,
+  sessionId: string,
+): AcpSessionNotification {
+  if (
+    terminal.update.sessionUpdate !== "tool_call" &&
+    terminal.update.sessionUpdate !== "tool_call_update"
+  ) {
+    return { ...terminal, sessionId };
+  }
+  if (!initial || initial.update.sessionUpdate !== "tool_call") {
+    const claudeMeta = terminal.update._meta?.claudeCode as { toolName?: unknown } | undefined;
+    return {
+      ...terminal,
+      sessionId,
+      update: {
+        ...terminal.update,
+        sessionUpdate: "tool_call",
+        status: "failed",
+        title:
+          typeof terminal.update.title === "string" && terminal.update.title.length > 0
+            ? terminal.update.title
+            : claudeMeta?.toolName === "Task"
+              ? "Task"
+              : "Agent",
+        _meta: ordinaryToolMeta(terminal.update._meta),
+      } as AcpSessionNotification["update"],
+    };
+  }
+  return {
+    ...initial,
+    sessionId,
+    update: {
+      ...initial.update,
+      ...terminal.update,
+      sessionUpdate: "tool_call",
+      status: "failed",
+      title:
+        typeof terminal.update.title === "string" && terminal.update.title.trim().length > 0
+          ? terminal.update.title
+          : initial.update.title,
+      _meta: {
+        ...initial.update._meta,
+        ...terminal.update._meta,
+        ...ordinaryToolMeta(initial.update._meta, terminal.update._meta),
+      },
+    } as AcpSessionNotification["update"],
+  };
+}
+
+function ordinaryToolMeta(
+  ...values: Array<Record<string, unknown> | null | undefined>
+): Record<string, unknown> {
+  const merged = Object.assign({}, ...values);
+  const claudeCode = Object.assign(
+    {},
+    ...values.map(
+      (value) => (value?.claudeCode as Record<string, unknown> | null | undefined) ?? {},
+    ),
+  );
+  delete claudeCode.subagent;
+  return { ...merged, claudeCode };
 }
 
 function subagentDisplayName(
@@ -360,7 +525,7 @@ function applySubagentIdentity(
     );
   }
   if (identity.prompt || identity.description) {
-    child.description = subagentDescription(identity.prompt, identity.description);
+    child.task = subagentDescription(identity.prompt, identity.description);
   }
 }
 

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -1,0 +1,267 @@
+import type { AcpSessionNotification, SubagentState } from "./acp-subagents.js";
+
+export type NativeSubagent = {
+  sessionId: string;
+  parentSessionId: string;
+  parentToolUseId?: string;
+  name: string;
+  task: string;
+  announced?: boolean;
+  terminalState?: SubagentState;
+};
+
+export type NativeSubagentSession = {
+  nativeSubagentsByTaskId?: Map<string, NativeSubagent>;
+  nativeSubagentTaskIdByToolUseId?: Map<string, string>;
+  nativeSubagentParentByToolUseId?: Map<string, string>;
+};
+
+type Publish = (notification: AcpSessionNotification) => Promise<void>;
+type Logger = { log(message: string): void };
+
+type TaskStarted = {
+  taskId: string;
+  toolUseId?: string | null;
+  subagentType?: unknown;
+  description?: unknown;
+};
+
+const MAX_PENDING_PARENTS = 64;
+const MAX_PENDING_UPDATES = 256;
+const MAX_PENDING_UPDATES_PER_PARENT = 32;
+
+/**
+ * Owns the connection-local native subagent registry and all ACP lifecycle
+ * ordering. The main agent only supplies SDK facts and delivers routed output.
+ */
+export class NativeSubagentRuntime {
+  readonly enabled: boolean;
+
+  private readonly children: Map<string, NativeSubagent>;
+  private readonly taskByToolUse: Map<string, string>;
+  private readonly parentByToolUse: Map<string, string>;
+  private readonly pending = new Map<string, AcpSessionNotification[]>();
+  private pendingCount = 0;
+
+  constructor(
+    enabled: boolean,
+    private readonly rootSessionId: string,
+    private readonly session: NativeSubagentSession,
+    private readonly publish: Publish,
+    private readonly logger: Logger,
+  ) {
+    this.enabled = enabled;
+    this.children = session.nativeSubagentsByTaskId ??= new Map();
+    this.taskByToolUse = session.nativeSubagentTaskIdByToolUseId ??= new Map();
+    this.parentByToolUse = session.nativeSubagentParentByToolUseId ??= new Map();
+  }
+
+  async route(
+    notification: AcpSessionNotification,
+    deliver: Publish,
+  ): Promise<AcpSessionNotification | null> {
+    const { update } = notification;
+    const claudeMeta = update._meta?.claudeCode as
+      { parentToolUseId?: string | null; subagent?: true; toolName?: string } | undefined;
+    const isControl =
+      (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+      (claudeMeta?.subagent === true ||
+        claudeMeta?.toolName === "Agent" ||
+        claudeMeta?.toolName === "Task");
+
+    if (!this.enabled && (isControl || claudeMeta?.parentToolUseId)) return null;
+
+    if (this.enabled && isControl) {
+      const parentTaskId = claudeMeta.parentToolUseId
+        ? this.taskByToolUse.get(claudeMeta.parentToolUseId)
+        : undefined;
+      const parentSessionId = parentTaskId
+        ? this.children.get(parentTaskId)?.sessionId
+        : this.rootSessionId;
+      this.parentByToolUse.set(update.toolCallId, parentSessionId ?? this.rootSessionId);
+
+      for (const child of this.children.values()) {
+        if (child.parentToolUseId !== update.toolCallId || child.announced) continue;
+        child.parentSessionId = parentSessionId ?? this.rootSessionId;
+        await announceNativeSubagent(child, this.publish);
+        for (const pending of this.takePending(update.toolCallId)) await deliver(pending);
+      }
+      return null;
+    }
+
+    if (this.enabled && claudeMeta?.parentToolUseId) {
+      const taskId = this.taskByToolUse.get(claudeMeta.parentToolUseId);
+      const child = taskId ? this.children.get(taskId) : undefined;
+      if (!child || !child.announced) {
+        this.buffer(claudeMeta.parentToolUseId, notification);
+        return null;
+      }
+      if (child.terminalState !== undefined) {
+        this.logger.log(
+          `Session ${this.rootSessionId}: ignoring late update for terminal subagent ${child.sessionId}`,
+        );
+        return null;
+      }
+      return { ...notification, sessionId: child.sessionId };
+    }
+
+    return notification;
+  }
+
+  async taskStarted(task: TaskStarted, deliver: Publish): Promise<void> {
+    if (!this.enabled) return;
+    if (!task.subagentType) {
+      if (task.toolUseId) this.takePending(task.toolUseId);
+      return;
+    }
+    if (this.children.has(task.taskId)) return;
+
+    const knownParentSessionId = task.toolUseId
+      ? this.parentByToolUse.get(task.toolUseId)
+      : undefined;
+    const child: NativeSubagent = {
+      sessionId: task.taskId,
+      parentSessionId: knownParentSessionId ?? this.rootSessionId,
+      parentToolUseId: task.toolUseId ?? undefined,
+      name: subagentDisplayName(task.subagentType, task.taskId),
+      task: subagentTask(task.description),
+    };
+    this.children.set(task.taskId, child);
+    if (task.toolUseId) this.taskByToolUse.set(task.toolUseId, task.taskId);
+
+    // A nested child must wait for the spawning Agent/Task frame to establish
+    // its immediate parent. Root children without a tool id can be announced.
+    if (knownParentSessionId || !task.toolUseId) {
+      await announceNativeSubagent(child, this.publish);
+      for (const pending of task.toolUseId ? this.takePending(task.toolUseId) : []) {
+        await deliver(pending);
+      }
+    }
+  }
+
+  async finishTask(taskId: string, status: unknown, deliver: Publish): Promise<void> {
+    if (!this.enabled) return;
+    const state = nativeSubagentState(status);
+    const child = this.children.get(taskId);
+    if (!state || !child || child.terminalState !== undefined) return;
+
+    await announceNativeSubagent(child, this.publish);
+    if (child.parentToolUseId) {
+      for (const pending of this.takePending(child.parentToolUseId)) await deliver(pending);
+    }
+    await finishNativeSubagent(this.session, taskId, state, this.publish);
+  }
+
+  async finishAll(state: SubagentState, deliver: Publish): Promise<void> {
+    for (const taskId of [...this.children.keys()].reverse()) {
+      await this.finishTask(taskId, state, deliver);
+    }
+    this.pending.clear();
+    this.pendingCount = 0;
+  }
+
+  discardPending(parentToolUseId: string): void {
+    this.takePending(parentToolUseId);
+  }
+
+  clear(): void {
+    this.children.clear();
+    this.taskByToolUse.clear();
+    this.parentByToolUse.clear();
+    this.pending.clear();
+    this.pendingCount = 0;
+  }
+
+  private takePending(parentToolUseId: string): AcpSessionNotification[] {
+    const updates = this.pending.get(parentToolUseId) ?? [];
+    if (updates.length > 0) {
+      this.pending.delete(parentToolUseId);
+      this.pendingCount -= updates.length;
+    }
+    return updates;
+  }
+
+  private buffer(parentToolUseId: string, notification: AcpSessionNotification): void {
+    const updates = this.pending.get(parentToolUseId);
+    if (
+      this.pendingCount >= MAX_PENDING_UPDATES ||
+      (updates === undefined && this.pending.size >= MAX_PENDING_PARENTS) ||
+      (updates?.length ?? 0) >= MAX_PENDING_UPDATES_PER_PARENT
+    ) {
+      this.logger.log(
+        `Session ${this.rootSessionId}: dropping unattributed subagent update for ${parentToolUseId}; pending buffer limit reached`,
+      );
+      return;
+    }
+    if (updates) updates.push(notification);
+    else this.pending.set(parentToolUseId, [notification]);
+    this.pendingCount++;
+  }
+}
+
+export async function announceNativeSubagent(
+  child: NativeSubagent,
+  publish: Publish,
+): Promise<void> {
+  if (child.announced) return;
+  await publish({
+    sessionId: child.parentSessionId,
+    update: {
+      sessionUpdate: "subagent_spawned",
+      subagentSessionId: child.sessionId,
+      name: child.name,
+      task: child.task,
+      capabilities: {},
+    },
+  });
+  child.announced = true;
+}
+
+export async function finishNativeSubagent(
+  session: NativeSubagentSession,
+  taskId: string,
+  state: SubagentState,
+  publish: Publish,
+): Promise<void> {
+  const child = session.nativeSubagentsByTaskId?.get(taskId);
+  if (!child || child.terminalState !== undefined) return;
+  await announceNativeSubagent(child, publish);
+  child.terminalState = state;
+  await publish({
+    sessionId: child.parentSessionId,
+    update: {
+      sessionUpdate: "subagent_state_update",
+      subagentSessionId: child.sessionId,
+      state,
+    },
+  });
+}
+
+export async function finishNativeSubagents(
+  session: NativeSubagentSession,
+  state: SubagentState,
+  publish: Publish,
+): Promise<void> {
+  for (const taskId of [...(session.nativeSubagentsByTaskId?.keys() ?? [])].reverse()) {
+    await finishNativeSubagent(session, taskId, state, publish);
+  }
+}
+
+function nativeSubagentState(status: unknown): SubagentState | undefined {
+  if (status === "completed") return "completed";
+  if (status === "failed") return "failed";
+  if (status === "killed" || status === "cancelled" || status === "stopped") return "cancelled";
+  return undefined;
+}
+
+function subagentDisplayName(type: unknown, taskId: string): string {
+  if (typeof type === "string" && type.trim().length > 0) return type.trim();
+  const suffix = taskId.length > 8 ? taskId.slice(-8) : taskId;
+  return `Agent ${suffix}`;
+}
+
+function subagentTask(description: unknown): string {
+  return typeof description === "string" && description.trim().length > 0
+    ? description.trim()
+    : "Delegated task";
+}

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -24,6 +24,14 @@ type TaskStarted = {
   toolUseId?: string | null;
   subagentType?: unknown;
   description?: unknown;
+  prompt?: unknown;
+};
+
+type SubagentIdentity = {
+  name?: string;
+  description?: string;
+  prompt?: string;
+  subagentType?: string;
 };
 
 const MAX_PENDING_PARENTS = 64;
@@ -40,6 +48,7 @@ export class NativeSubagentRuntime {
   private readonly children: Map<string, NativeSubagent>;
   private readonly taskByToolUse: Map<string, string>;
   private readonly parentByToolUse: Map<string, string>;
+  private readonly identityByToolUse = new Map<string, SubagentIdentity>();
   private readonly pending = new Map<string, AcpSessionNotification[]>();
   private pendingCount = 0;
 
@@ -72,6 +81,13 @@ export class NativeSubagentRuntime {
     if (!this.enabled && (isControl || claudeMeta?.parentToolUseId)) return null;
 
     if (this.enabled && isControl) {
+      const identity = subagentIdentity(update.rawInput);
+      if (identity) {
+        this.identityByToolUse.set(
+          update.toolCallId,
+          mergeSubagentIdentity(this.identityByToolUse.get(update.toolCallId), identity),
+        );
+      }
       const parentTaskId = claudeMeta.parentToolUseId
         ? this.taskByToolUse.get(claudeMeta.parentToolUseId)
         : undefined;
@@ -83,6 +99,7 @@ export class NativeSubagentRuntime {
       for (const child of this.children.values()) {
         if (child.parentToolUseId !== update.toolCallId || child.announced) continue;
         child.parentSessionId = parentSessionId ?? this.rootSessionId;
+        applySubagentIdentity(child, this.identityByToolUse.get(update.toolCallId));
         await announceNativeSubagent(child, this.publish);
         for (const pending of this.takePending(update.toolCallId)) await deliver(pending);
       }
@@ -119,12 +136,21 @@ export class NativeSubagentRuntime {
     const knownParentSessionId = task.toolUseId
       ? this.parentByToolUse.get(task.toolUseId)
       : undefined;
+    const identity = task.toolUseId ? this.identityByToolUse.get(task.toolUseId) : undefined;
     const child: NativeSubagent = {
       sessionId: task.taskId,
       parentSessionId: knownParentSessionId ?? this.rootSessionId,
       parentToolUseId: task.toolUseId ?? undefined,
-      name: subagentDisplayName(task.subagentType, task.taskId),
-      task: subagentTask(task.description),
+      name: subagentDisplayName(
+        identity?.name,
+        identity?.description ?? task.description,
+        identity?.subagentType ?? task.subagentType,
+        task.taskId,
+      ),
+      task: subagentTask(
+        identity?.prompt ?? task.prompt,
+        identity?.description ?? task.description,
+      ),
     };
     this.children.set(task.taskId, child);
     if (task.toolUseId) this.taskByToolUse.set(task.toolUseId, task.taskId);
@@ -150,6 +176,7 @@ export class NativeSubagentRuntime {
       for (const pending of this.takePending(child.parentToolUseId)) await deliver(pending);
     }
     await finishNativeSubagent(this.session, taskId, state, this.publish);
+    if (child.parentToolUseId) this.identityByToolUse.delete(child.parentToolUseId);
   }
 
   async finishAll(state: SubagentState, deliver: Publish): Promise<void> {
@@ -168,6 +195,7 @@ export class NativeSubagentRuntime {
     this.children.clear();
     this.taskByToolUse.clear();
     this.parentByToolUse.clear();
+    this.identityByToolUse.clear();
     this.pending.clear();
     this.pendingCount = 0;
   }
@@ -254,14 +282,68 @@ function nativeSubagentState(status: unknown): SubagentState | undefined {
   return undefined;
 }
 
-function subagentDisplayName(type: unknown, taskId: string): string {
-  if (typeof type === "string" && type.trim().length > 0) return type.trim();
+function subagentDisplayName(
+  explicitName: unknown,
+  description: unknown,
+  type: unknown,
+  taskId: string,
+): string {
+  for (const value of [explicitName, description, type]) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
   const suffix = taskId.length > 8 ? taskId.slice(-8) : taskId;
   return `Agent ${suffix}`;
 }
 
-function subagentTask(description: unknown): string {
-  return typeof description === "string" && description.trim().length > 0
-    ? description.trim()
-    : "Delegated task";
+function subagentTask(prompt: unknown, description: unknown): string {
+  for (const value of [prompt, description]) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return "Delegated task";
+}
+
+function subagentIdentity(input: unknown): SubagentIdentity | undefined {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+  const value = input as Record<string, unknown>;
+  const identity: SubagentIdentity = {
+    name: nonBlankString(value.name),
+    description: nonBlankString(value.description),
+    prompt: nonBlankString(value.prompt),
+    subagentType: nonBlankString(value.subagent_type),
+  };
+  return Object.values(identity).some(Boolean) ? identity : undefined;
+}
+
+function mergeSubagentIdentity(
+  previous: SubagentIdentity | undefined,
+  next: SubagentIdentity,
+): SubagentIdentity {
+  return {
+    name: next.name ?? previous?.name,
+    description: next.description ?? previous?.description,
+    prompt: next.prompt ?? previous?.prompt,
+    subagentType: next.subagentType ?? previous?.subagentType,
+  };
+}
+
+function applySubagentIdentity(
+  child: NativeSubagent,
+  identity: SubagentIdentity | undefined,
+): void {
+  if (!identity) return;
+  if (identity.name || identity.description) {
+    child.name = subagentDisplayName(
+      identity.name,
+      identity.description,
+      identity.subagentType,
+      child.sessionId,
+    );
+  }
+  if (identity.prompt || identity.description) {
+    child.task = subagentTask(identity.prompt, identity.description);
+  }
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }

--- a/src/native-subagents.ts
+++ b/src/native-subagents.ts
@@ -5,7 +5,7 @@ export type NativeSubagent = {
   parentSessionId: string;
   parentToolUseId?: string;
   name: string;
-  task: string;
+  description: string;
   announced?: boolean;
   terminalState?: SubagentState;
 };
@@ -147,7 +147,7 @@ export class NativeSubagentRuntime {
         identity?.subagentType ?? task.subagentType,
         task.taskId,
       ),
-      task: subagentTask(
+      description: subagentDescription(
         identity?.prompt ?? task.prompt,
         identity?.description ?? task.description,
       ),
@@ -238,7 +238,7 @@ export async function announceNativeSubagent(
       sessionUpdate: "subagent_spawned",
       subagentSessionId: child.sessionId,
       name: child.name,
-      task: child.task,
+      description: child.description,
       capabilities: {},
     },
   });
@@ -295,7 +295,7 @@ function subagentDisplayName(
   return `Agent ${suffix}`;
 }
 
-function subagentTask(prompt: unknown, description: unknown): string {
+function subagentDescription(prompt: unknown, description: unknown): string {
   for (const value of [prompt, description]) {
     if (typeof value === "string" && value.trim().length > 0) return value.trim();
   }
@@ -340,7 +340,7 @@ function applySubagentIdentity(
     );
   }
   if (identity.prompt || identity.description) {
-    child.task = subagentTask(identity.prompt, identity.description);
+    child.description = subagentDescription(identity.prompt, identity.description);
   }
 }
 

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -7,12 +7,9 @@ import {
 import { randomUUID } from "node:crypto";
 import {
   AIR_SESSION_FAILURE_CAPABILITY,
-  AIR_META_KEY,
-  AIR_EXTENSION_VERSION,
-  AIR_EXTENSION_VERSION_KEY,
-  JETBRAINS_META_KEY,
   airCapabilityMeta,
   clientSupportsAirCapability,
+  withAirMeta,
 } from "./air-extension.js";
 
 export function airSessionFailureCapabilityMeta(...additionalCapabilities: string[]) {
@@ -154,22 +151,15 @@ const AIR_FAILURE_POLICY: Record<
 };
 
 export function sessionFailureMeta(failure: PublishedSessionFailure) {
-  return {
-    [JETBRAINS_META_KEY]: {
-      [AIR_META_KEY]: {
-        [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
-        [AIR_SESSION_FAILURE_CAPABILITY]: {
-          id: failure.id,
-          revision: failure.revision,
-          category: failure.category,
-          severity: failure.severity,
-          title: failure.title,
-          ...(failure.details ? { details: failure.details } : {}),
-          actions: failure.actions,
-        },
-      },
-    },
-  };
+  return withAirMeta(undefined, AIR_SESSION_FAILURE_CAPABILITY, {
+    id: failure.id,
+    revision: failure.revision,
+    category: failure.category,
+    severity: failure.severity,
+    title: failure.title,
+    ...(failure.details ? { details: failure.details } : {}),
+    actions: failure.actions,
+  });
 }
 
 /** `getSessionMessages` deliberately exposes only the API message and strips

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -5,23 +5,18 @@ import {
   USAGE_LIMIT_ERROR_PREFIXES,
 } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "node:crypto";
-
-const JETBRAINS_META_KEY = "jetbrains";
-const AIR_META_KEY = "air";
-const AIR_EXTENSION_VERSION_KEY = "version";
-const AIR_EXTENSION_CAPABILITIES_KEY = "capabilities";
-const AIR_SESSION_FAILURE_KEY = "sessionFailure";
-const AIR_EXTENSION_VERSION = 1;
+import {
+  AIR_SESSION_FAILURE_CAPABILITY,
+  AIR_META_KEY,
+  AIR_EXTENSION_VERSION,
+  AIR_EXTENSION_VERSION_KEY,
+  JETBRAINS_META_KEY,
+  airCapabilityMeta,
+  clientSupportsAirCapability,
+} from "./air-extension.js";
 
 export function airSessionFailureCapabilityMeta(...additionalCapabilities: string[]) {
-  return {
-    [JETBRAINS_META_KEY]: {
-      [AIR_META_KEY]: {
-        [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
-        [AIR_EXTENSION_CAPABILITIES_KEY]: [AIR_SESSION_FAILURE_KEY, ...additionalCapabilities],
-      },
-    },
-  };
+  return airCapabilityMeta(AIR_SESSION_FAILURE_CAPABILITY, ...additionalCapabilities);
 }
 
 export type ClaudeFailureKind =
@@ -163,7 +158,7 @@ export function sessionFailureMeta(failure: PublishedSessionFailure) {
     [JETBRAINS_META_KEY]: {
       [AIR_META_KEY]: {
         [AIR_EXTENSION_VERSION_KEY]: AIR_EXTENSION_VERSION,
-        [AIR_SESSION_FAILURE_KEY]: {
+        [AIR_SESSION_FAILURE_CAPABILITY]: {
           id: failure.id,
           revision: failure.revision,
           category: failure.category,
@@ -234,19 +229,7 @@ export function activeUsageLimitMessage(
 }
 
 export function supportsAirSessionFailures(capabilities?: ClientCapabilities): boolean {
-  const jetbrains = capabilities?._meta?.[JETBRAINS_META_KEY] as
-    Record<string, unknown> | undefined;
-  const air = jetbrains?.[AIR_META_KEY] as Record<string, unknown> | undefined;
-  const version = air?.[AIR_EXTENSION_VERSION_KEY];
-  const advertised = air?.[AIR_EXTENSION_CAPABILITIES_KEY];
-  return (
-    typeof version === "number" &&
-    Number.isFinite(version) &&
-    Number.isInteger(version) &&
-    version >= AIR_EXTENSION_VERSION &&
-    Array.isArray(advertised) &&
-    advertised.some((capability) => capability === AIR_SESSION_FAILURE_KEY)
-  );
+  return clientSupportsAirCapability(capabilities, AIR_SESSION_FAILURE_CAPABILITY);
 }
 
 function sessionFailureRecoveryPolicy(

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -2139,10 +2139,34 @@ describe("subagent transcript replay", () => {
     },
   ] as Awaited<ReturnType<typeof getSessionMessages>>;
 
-  async function replay(capability: "native" | "legacy" | false): Promise<SessionNotification[]> {
-    const updates: SessionNotification[] = [];
+  const agentResult = (isError: boolean, content: string) =>
+    ({
+      type: "user",
+      uuid: `agent-result-${content}`,
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "parent-agent-call",
+            is_error: isError,
+            content,
+          },
+        ],
+      },
+    }) as unknown as Awaited<ReturnType<typeof getSessionMessages>>[number];
+
+  async function replay(
+    capability: "native" | "legacy" | false,
+    history = replayHistory,
+  ): Promise<AcpSessionNotification[]> {
+    const updates: AcpSessionNotification[] = [];
     const client = {
-      sessionUpdate: async (update: SessionNotification) => updates.push(update),
+      sessionUpdate: async (update: SessionNotification) =>
+        updates.push(update as AcpSessionNotification),
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
     (agent as any).clientCapabilities =
@@ -2151,7 +2175,7 @@ describe("subagent transcript replay", () => {
         : capability === "legacy"
           ? { _meta: { "subagent-transcript": true } }
           : {};
-    vi.mocked(getSessionMessages).mockResolvedValueOnce(replayHistory);
+    vi.mocked(getSessionMessages).mockResolvedValueOnce(history);
 
     await (
       agent as unknown as { replaySessionHistory(sessionId: string): Promise<void> }
@@ -2159,9 +2183,164 @@ describe("subagent transcript replay", () => {
     return updates;
   }
 
-  it("does not replay child output without authoritative native lifecycle", async () => {
+  it("replays an unattributed sidechain as a deterministic disconnected child", async () => {
     const updates = await replay("native");
-    expect(updates).toEqual([]);
+    expect(updates.map(({ sessionId, update }) => [sessionId, update.sessionUpdate])).toEqual([
+      ["s1", "subagent_spawned"],
+      ["s1:replay-subagent:parent-agent-call", "agent_message_chunk"],
+      ["s1:replay-subagent:parent-agent-call", "tool_call"],
+      ["s1", "subagent_state_update"],
+    ]);
+    expect(updates[0]?.update).toMatchObject({
+      subagentSessionId: "s1:replay-subagent:parent-agent-call",
+      name: "Disconnected agent",
+    });
+    expect(updates.at(-1)?.update).toMatchObject({ state: "disconnected" });
+  });
+
+  it("reconstructs a persisted Agent launch before child updates", async () => {
+    const launch = {
+      type: "assistant" as const,
+      uuid: "launch-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: {
+        id: "api-launch-message",
+        model: "claude-sonnet-4-5",
+        role: "assistant" as const,
+        type: "message",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use" as const,
+            id: "parent-agent-call",
+            name: "Agent",
+            input: { name: "Reviewer", prompt: "Review the implementation" },
+          },
+        ],
+      },
+    };
+    const updates = await replay("native", [launch, ...replayHistory, agentResult(false, "done")]);
+
+    expect(updates[0]?.update).toMatchObject({
+      sessionUpdate: "subagent_spawned",
+      name: "Reviewer",
+      task: "Review the implementation",
+    });
+    expect(updates.at(-1)?.update).toMatchObject({
+      sessionUpdate: "subagent_state_update",
+      state: "completed",
+    });
+    expect(
+      updates.some(
+        ({ update }) =>
+          (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+          update.toolCallId === "parent-agent-call",
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    { content: "subagent failed", state: "failed" },
+    { content: "Request interrupted by user", state: "cancelled" },
+  ])("restores a persisted $state Agent result", async ({ content, state }) => {
+    const launch = {
+      type: "assistant" as const,
+      uuid: "launch-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: {
+        id: "api-launch-message",
+        model: "claude-sonnet-4-5",
+        role: "assistant" as const,
+        type: "message",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use" as const,
+            id: "parent-agent-call",
+            name: "Agent",
+            input: { name: "Reviewer", prompt: "Review" },
+          },
+        ],
+      },
+    };
+
+    const updates = await replay("native", [launch, ...replayHistory, agentResult(true, content)]);
+    expect(updates.at(-1)?.update).toMatchObject({
+      sessionUpdate: "subagent_state_update",
+      state,
+    });
+  });
+
+  it("marks a launched child without a persisted result as disconnected", async () => {
+    const launch = {
+      type: "assistant" as const,
+      uuid: "launch-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      message: {
+        id: "api-launch-message",
+        model: "claude-sonnet-4-5",
+        role: "assistant" as const,
+        type: "message",
+        stop_reason: "tool_use",
+        content: [
+          {
+            type: "tool_use" as const,
+            id: "parent-agent-call",
+            name: "Agent",
+            input: { name: "Reviewer", prompt: "Review" },
+          },
+        ],
+      },
+    };
+
+    const updates = await replay("native", [launch, ...replayHistory]);
+    expect(updates.at(-1)?.update).toMatchObject({
+      sessionUpdate: "subagent_state_update",
+      state: "disconnected",
+    });
+  });
+
+  it("breaks malformed replay lineage cycles deterministically", async () => {
+    const cyclicLaunch = (id: string, parentToolUseId: string) => ({
+      type: "assistant" as const,
+      uuid: `launch-${id}`,
+      session_id: "s1",
+      parent_tool_use_id: parentToolUseId,
+      parent_agent_id: "malformed",
+      message: {
+        id: `api-launch-${id}`,
+        model: "claude-sonnet-4-5",
+        role: "assistant" as const,
+        type: "message",
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use" as const, id, name: "Agent", input: { prompt: `Run ${id}` } }],
+      },
+    });
+
+    const updates = await replay("native", [
+      cyclicLaunch("agent-a", "agent-b"),
+      cyclicLaunch("agent-b", "agent-a"),
+      {
+        ...replayHistory[0],
+        parent_tool_use_id: "agent-a",
+      },
+    ] as Awaited<ReturnType<typeof getSessionMessages>>);
+
+    expect(
+      updates.filter(({ update }) => update.sessionUpdate === "subagent_spawned"),
+    ).toHaveLength(2);
+    expect(
+      updates.some(
+        ({ update }) =>
+          update.sessionUpdate === "subagent_state_update" && update.state === "disconnected",
+      ),
+    ).toBe(true);
   });
 
   it("keeps legacy text filtering without losing child tool attribution", async () => {
@@ -3572,7 +3751,7 @@ describe("subagent permission attribution (issue #851)", () => {
           parentSessionId: "session-1",
           parentToolUseId: "toolu_parent",
           name: "Explore",
-          description: "Investigate",
+          task: "Investigate",
           announced: true,
         },
       ],
@@ -3609,7 +3788,7 @@ describe("subagent permission attribution (issue #851)", () => {
           parentSessionId: "session-1",
           parentToolUseId: "toolu_parent",
           name: "Explore",
-          description: "Investigate",
+          task: "Investigate",
         },
       ],
     ]);
@@ -3646,7 +3825,7 @@ describe("subagent permission attribution (issue #851)", () => {
           parentSessionId: "session-1",
           parentToolUseId: "toolu_parent",
           name: "Explore",
-          description: "Investigate",
+          task: "Investigate",
           announced: true,
         },
       ],
@@ -3943,7 +4122,7 @@ describe("subagent permission attribution (issue #851)", () => {
           sessionUpdate: "subagent_spawned",
           subagentSessionId: "agent-42",
           name: "Investigate",
-          description: "Investigate",
+          task: "Investigate",
           capabilities: {},
         },
         {
@@ -4113,7 +4292,7 @@ describe("subagent permission attribution (issue #851)", () => {
     expect(nestedSpawn?.sessionId).toBe("agent-outer");
     expect(nestedSpawn?.update).toMatchObject({
       name: "toolu_inner-name",
-      description: "toolu_inner full prompt",
+      task: "toolu_inner full prompt",
     });
     expect(
       updates.find(
@@ -4122,7 +4301,7 @@ describe("subagent permission attribution (issue #851)", () => {
       )?.update,
     ).toMatchObject({
       name: "toolu_outer-name",
-      description: "toolu_outer full prompt",
+      task: "toolu_outer full prompt",
     });
     expect(
       updates.filter(
@@ -4256,7 +4435,7 @@ describe("subagent permission attribution (issue #851)", () => {
         sessionUpdate: "subagent_spawned",
         subagentSessionId: "agent-42",
         name: "Investigate",
-        description: "Investigate",
+        task: "Investigate",
         capabilities: {},
       },
       {
@@ -4650,7 +4829,7 @@ describe("native subagent eager tool ownership", () => {
             parentSessionId: "root",
             parentToolUseId: "toolu_agent",
             name: "Explore",
-            description: "Investigate",
+            task: "Investigate",
             announced: true,
           },
         ],
@@ -7231,7 +7410,7 @@ describe("logout", () => {
     expect(response.agentCapabilities?.auth?.logout).toEqual({});
   });
 
-  it("advertises subagents only after client negotiation", async () => {
+  it("advertises the agent subagent capability independently of client negotiation", async () => {
     const agent = createMockAgent();
     const unsupported = await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
     const supported = await agent.initialize({
@@ -7243,7 +7422,7 @@ describe("logout", () => {
 
     expect(
       (unsupported.agentCapabilities?.sessionCapabilities as { subagents?: unknown }).subagents,
-    ).toBeUndefined();
+    ).toEqual({});
     expect(
       (supported.agentCapabilities?.sessionCapabilities as { subagents?: unknown }).subagents,
     ).toEqual({});
@@ -10731,6 +10910,31 @@ describe("post-error recovery", () => {
     expect(agent.sessions["test-session"].abortController.signal.aborted).toBe(false);
   });
 
+  it("still interrupts and cleans up when native subagent cancellation publication fails", async () => {
+    const errors: unknown[][] = [];
+    const agent = new ClaudeAcpAgent({} as AcpClient, {
+      log: () => {},
+      error: (...args) => errors.push(args),
+    });
+    async function* emptyQuery() {}
+    const session = mockSessionState({
+      query: wrapQuery(emptyQuery()),
+      nativeSubagentRuntime: {
+        finishAll: vi.fn(async () => {
+          throw new Error("client disconnected");
+        }),
+      } as unknown as NativeSubagentRuntime,
+      eagerToolCallSessions: new Map([["tool", "test-session"]]),
+    });
+    agent.sessions["test-session"] = session;
+
+    await expect(agent.cancel({ sessionId: "test-session" })).resolves.toBeUndefined();
+
+    expect(session.query.interrupt).toHaveBeenCalledOnce();
+    expect(session.eagerToolCallSessions).toEqual(new Map());
+    expect(errors.flat().join(" ")).toContain("failed to publish cancelled subagent state");
+  });
+
   it("settles a turn that ends via the stream-done path even if releasing resources throws", async () => {
     const agent = createMockAgent();
     // The turn is activated by its echo but the stream then ends with NO terminal
@@ -11046,6 +11250,9 @@ describe("post-error recovery", () => {
 
     await agent.cancel({ sessionId: "test-session" }); // counts turn 2, then the receipt uncounts it
     expect(agent.sessions["test-session"]?.pendingOrphanResults).toBe(0);
+    expect(
+      agent.sessions["test-session"]?.pendingEmptyInterruptionDiagnosticCommands?.size ?? 0,
+    ).toBe(0);
     const compact = agent.prompt({
       sessionId: "test-session",
       prompt: [{ type: "text", text: "/compact" }],
@@ -11119,6 +11326,9 @@ describe("post-error recovery", () => {
 
     await agent.cancel({ sessionId: "test-session" });
     expect(agent.sessions["test-session"]?.pendingOrphanResults).toBe(1);
+    expect(agent.sessions["test-session"]?.pendingEmptyInterruptionDiagnosticCommands).toEqual(
+      new Set([survivingUuid]),
+    );
     const compact = agent.prompt({
       sessionId: "test-session",
       prompt: [{ type: "text", text: "/compact" }],
@@ -16726,7 +16936,11 @@ describe("permission_denied", () => {
   >;
 
   /** Run a turn carrying `messages` and return the updates it produced. */
-  async function run(messages: any[], overrides: Record<string, any> = {}) {
+  async function run(
+    messages: any[],
+    overrides: Record<string, any> = {},
+    clientCapabilities?: ClientCapabilities,
+  ) {
     const updates: SessionNotification["update"][] = [];
     const mockClient = {
       sessionUpdate: async (n: SessionNotification) => {
@@ -16734,6 +16948,7 @@ describe("permission_denied", () => {
       },
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+    agent.clientCapabilities = clientCapabilities;
     const input = new Pushable<any>();
     async function* messageGenerator() {
       const { value, done } = await input[Symbol.asyncIterator]().next();
@@ -16943,5 +17158,18 @@ describe("permission_denied", () => {
     const sent = denials(updates);
     expect(sent).toHaveLength(1);
     expect((sent[0]._meta as any).claudeCode).not.toHaveProperty("parentToolUseId");
+  });
+
+  it("uses eager child ownership when native lineage has not arrived yet", async () => {
+    const updates = await run(
+      [denial("toolu_inner", { agent_id: "agent-racing" })],
+      {
+        emittedToolCalls: new Set(["toolu_inner"]),
+        eagerToolCallSessions: new Map([["toolu_inner", "child-session"]]),
+      },
+      { subagents: {} } as ClientCapabilities & { subagents: Record<string, never> },
+    );
+
+    expect(denials(updates)).toHaveLength(1);
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -20,6 +20,7 @@ import {
   WriteTextFileResponse,
 } from "@agentclientprotocol/sdk";
 import type { AcpSessionNotification } from "../acp-subagents.js";
+import { NativeSubagentRuntime } from "../native-subagents.js";
 import { nodeToWebWritable, nodeToWebReadable } from "../utils.js";
 import {
   markdownEscape,
@@ -3419,6 +3420,7 @@ describe("subagent permission attribution (issue #851)", () => {
   function setup() {
     const updates: SessionNotification[] = [];
     const requests: RequestPermissionRequest[] = [];
+    const elicitations: CreateElicitationRequest[] = [];
     const log = vi.fn();
     const mockClient = {
       sessionUpdate: async (n: SessionNotification) => {
@@ -3428,14 +3430,17 @@ describe("subagent permission attribution (issue #851)", () => {
         requests.push(params);
         return { outcome: { outcome: "selected", optionId: "allow-once" } };
       },
-      unstable_createElicitation: async () => ({
-        action: "accept",
-        content: { question_0: "Fast", question_0_custom: "" },
-      }),
+      unstable_createElicitation: async (request: CreateElicitationRequest) => {
+        elicitations.push(request);
+        return {
+          action: "accept",
+          content: { question_0: "Fast", question_0_custom: "" },
+        };
+      },
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(mockClient, { log, error: () => {} });
     agent.sessions["session-1"] = mockSessionState();
-    return { agent, updates, requests, log, session: agent.sessions["session-1"]! };
+    return { agent, updates, requests, elicitations, log, session: agent.sessions["session-1"]! };
   }
 
   it("keeps the legacy child tool call before its root permission request", async () => {
@@ -3618,6 +3623,57 @@ describe("subagent permission attribution (issue #851)", () => {
 
     expect(updates[0].sessionId).toBe("session-1");
     expect(requests[0].sessionId).toBe("session-1");
+  });
+
+  it("routes a native child AskUserQuestion and its tool call to the child session", async () => {
+    const { agent, updates, elicitations, session } = setup();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        subagents: {},
+        elicitation: { form: {} },
+      } as ClientCapabilities & { subagents: Record<string, never> },
+    });
+    session.liveBackgroundTasks.set("agent-42", {
+      parentToolUseId: "toolu_parent",
+      isSubagent: true,
+    });
+    session.nativeSubagentsByTaskId = new Map([
+      [
+        "agent-42",
+        {
+          sessionId: "child-session",
+          parentSessionId: "session-1",
+          parentToolUseId: "toolu_parent",
+          name: "Explore",
+          description: "Investigate",
+          announced: true,
+        },
+      ],
+    ]);
+
+    await agent.canUseTool("session-1")(
+      "AskUserQuestion",
+      {
+        questions: [
+          {
+            question: "Which mode?",
+            header: "Mode",
+            options: [{ label: "Fast", description: "Fast mode" }],
+            multiSelect: false,
+          },
+        ],
+      },
+      {
+        signal: new AbortController().signal,
+        suggestions: [],
+        toolUseID: "toolu_question",
+        agentID: "agent-42",
+      } as any,
+    );
+
+    expect(updates[0].sessionId).toBe("child-session");
+    expect((elicitations[0] as { sessionId?: string }).sessionId).toBe("child-session");
   });
 
   function taskStarted(taskId: string, toolUseId: string) {
@@ -4263,6 +4319,362 @@ describe("subagent permission attribution (issue #851)", () => {
       updates.filter(({ update }) => update.sessionUpdate === "agent_message_chunk"),
     ).toHaveLength(32);
     expect(logs).toContainEqual(expect.stringContaining("pending buffer limit reached"));
+  });
+
+  it("propagates a terminal SDK output_file through the async task lifecycle", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => updates.push(notification),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        _meta: { jetbrains: { air: { version: 1, capabilities: ["asyncTasks"] } } },
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          ...taskStarted("workflow-1", "toolu_workflow"),
+          task_type: "local_workflow",
+          workflow_name: "assets",
+          is_backgrounded: true,
+        },
+        {
+          type: "system",
+          subtype: "task_notification",
+          task_id: "workflow-1",
+          tool_use_id: "toolu_workflow",
+          status: "completed",
+          output_file: "/tmp/tasks/workflow-1.output",
+          summary: "done",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(updates.map(({ update }) => update)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionUpdate: "async_task_spawned",
+          asyncTaskId: "workflow-1",
+          name: "assets",
+        }),
+        expect.objectContaining({
+          sessionUpdate: "async_task_state_update",
+          asyncTaskId: "workflow-1",
+          state: "completed",
+          outputFilePath: "/tmp/tasks/workflow-1.output",
+        }),
+      ]),
+    );
+  });
+
+  it("attaches a Bash tool id discovered after async_task_spawned", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => updates.push(notification),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        _meta: { jetbrains: { air: { version: 1, capabilities: ["asyncTasks"] } } },
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          type: "assistant",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "bash-tool",
+                name: "Bash",
+                input: { command: "npm run build", run_in_background: true },
+              },
+            ],
+            usage: SUBAGENT_TEST_USAGE,
+          },
+        },
+        {
+          type: "system",
+          subtype: "task_started",
+          task_id: "shell-1",
+          task_type: "local_bash",
+          description: "Build",
+          is_backgrounded: true,
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        {
+          type: "user",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          tool_use_result: { backgroundTaskId: "shell-1" },
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "bash-tool",
+                content:
+                  "Command running in background. Output is being written to: /tmp/tasks/shell-1.output. You will be notified when it completes.",
+              },
+            ],
+          },
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    const lifecycle = updates
+      .map(({ update }) => update)
+      .filter(
+        (update) =>
+          update.sessionUpdate === "async_task_spawned" ||
+          update.sessionUpdate === "async_task_progress",
+      );
+    expect(lifecycle[0]).toMatchObject({
+      sessionUpdate: "async_task_spawned",
+      asyncTaskId: "shell-1",
+    });
+    expect(lifecycle[0]).not.toHaveProperty("toolCallId");
+    expect(lifecycle[1]).toMatchObject({
+      sessionUpdate: "async_task_progress",
+      asyncTaskId: "shell-1",
+      toolCallId: "bash-tool",
+      outputFilePath: "/tmp/tasks/shell-1.output",
+    });
+  });
+});
+
+describe("native subagent eager tool ownership", () => {
+  it("completes an Agent card created by a permission after its control frame was suppressed", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => updates.push(notification),
+        requestPermission: async () => ({
+          outcome: { outcome: "selected", optionId: "allow-once" },
+        }),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    let controlConsumed!: () => void;
+    const consumed = new Promise<void>((resolve) => (controlConsumed = resolve));
+    let release!: () => void;
+    const released = new Promise<void>((resolve) => (release = resolve));
+    injectGeneratorSession(agent, (input) => {
+      async function* messages() {
+        const iter = input[Symbol.asyncIterator]();
+        const user = await iter.next();
+        yield userEcho(user.value);
+        yield {
+          type: "assistant",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_agent",
+                name: "Agent",
+                input: { description: "Investigate", prompt: "Find the bug" },
+              },
+            ],
+            usage: {},
+          },
+        };
+        controlConsumed();
+        await released;
+        yield {
+          type: "system",
+          subtype: "task_started",
+          task_id: "agent-1",
+          tool_use_id: "toolu_agent",
+          subagent_type: "Explore",
+          description: "Investigate",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        };
+        yield {
+          type: "user",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "toolu_agent", content: "done" }],
+          },
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          stop_reason: "end_turn",
+          is_error: false,
+          result: "",
+          errors: [],
+          duration_ms: 0,
+          duration_api_ms: 0,
+          num_turns: 1,
+          total_cost_usd: 0,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          modelUsage: {},
+          permission_denials: [],
+          uuid: randomUUID(),
+          session_id: "test-session",
+        };
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messages();
+    });
+
+    const prompt = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+    await consumed;
+    await agent.canUseTool("test-session")(
+      "Agent",
+      { description: "Investigate", prompt: "Find the bug" },
+      {
+        signal: new AbortController().signal,
+        suggestions: [],
+        toolUseID: "toolu_agent",
+      } as any,
+    );
+    release();
+    await prompt;
+
+    const controlUpdates = updates.filter(
+      ({ update }) =>
+        (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+        update.toolCallId === "toolu_agent",
+    );
+    expect(controlUpdates.map(({ sessionId }) => sessionId)).toEqual([
+      "test-session",
+      "test-session",
+    ]);
+    expect(
+      controlUpdates.map(({ update }) => ("status" in update ? update.status : undefined)),
+    ).toEqual(["pending", "completed"]);
+  });
+
+  it("keeps permission-visible Agent control lifecycle in its original session", async () => {
+    const published: AcpSessionNotification[] = [];
+    const session = {
+      nativeSubagentsByTaskId: new Map(),
+      nativeSubagentTaskIdByToolUseId: new Map(),
+      nativeSubagentParentByToolUseId: new Map(),
+    };
+    const runtime = new NativeSubagentRuntime(
+      true,
+      "root",
+      session,
+      async (notification) => {
+        published.push(notification);
+      },
+      { log: () => {} },
+    );
+    await runtime.taskStarted(
+      {
+        taskId: "agent-1",
+        toolUseId: "toolu_agent",
+        subagentType: "Explore",
+        description: "Investigate",
+      },
+      async (notification) => {
+        published.push(notification);
+      },
+    );
+    const control = {
+      sessionId: "root",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "toolu_agent",
+        status: "completed",
+        rawInput: { description: "Investigate", prompt: "Find the bug" },
+        _meta: { claudeCode: { toolName: "Agent", subagent: true } },
+      },
+    } as AcpSessionNotification;
+
+    const routed = await runtime.route(control, async () => {}, "root");
+
+    expect(routed).toEqual(control);
+    expect(published[0]).toMatchObject({
+      sessionId: "root",
+      update: { sessionUpdate: "subagent_spawned", subagentSessionId: "agent-1" },
+    });
+  });
+
+  it("pins a raced child tool lifecycle to the root where permission created it", async () => {
+    const session = {
+      nativeSubagentsByTaskId: new Map([
+        [
+          "agent-1",
+          {
+            sessionId: "agent-1",
+            parentSessionId: "root",
+            parentToolUseId: "toolu_agent",
+            name: "Explore",
+            description: "Investigate",
+            announced: true,
+          },
+        ],
+      ]),
+      nativeSubagentTaskIdByToolUseId: new Map([["toolu_agent", "agent-1"]]),
+      nativeSubagentParentByToolUseId: new Map(),
+    };
+    const runtime = new NativeSubagentRuntime(true, "root", session, async () => {}, {
+      log: () => {},
+    });
+    const terminal = {
+      sessionId: "root",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "toolu_child",
+        status: "completed",
+        _meta: { claudeCode: { toolName: "Bash", parentToolUseId: "toolu_agent" } },
+      },
+    } as AcpSessionNotification;
+
+    await expect(runtime.route(terminal, async () => {}, "root")).resolves.toEqual(terminal);
+    await expect(runtime.route(terminal, async () => {})).resolves.toMatchObject({
+      sessionId: "agent-1",
+    });
   });
 });
 
@@ -13981,6 +14393,91 @@ describe("turn steering (_session/steering)", () => {
       agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "plan" }] }),
     ).rejects.toThrow("[ede_diagnostic]");
     expect(agent.sessions["test-session"].pendingExitPlanModeInterruption).toBeUndefined();
+  });
+
+  it("does not fail a replacement prompt on the cancelled prompt's late SDK diagnostic", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: SessionNotification) => updates.push(notification),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const original = await iter.next();
+        // The first prompt is cancelled before the SDK echoes it. Once startup
+        // unblocks, the CLI still replays that prompt, its interruption marker,
+        // and the replacement prompt before emitting the cancelled cycle's
+        // diagnostic result — the ordering observed in the raw Claude session.
+        await gate;
+        const replacement = await iter.next();
+        yield userEcho(original.value);
+        yield userEcho({
+          uuid: randomUUID(),
+          message: { role: "user", content: "[Request interrupted by user]" },
+        });
+        yield userEcho(replacement.value);
+        yield {
+          ...createResultMessage(),
+          subtype: "success",
+          is_error: true,
+          result: "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+        };
+        yield createAssistantText("replacement answer");
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(
+      () =>
+        agent.sessions["test-session"]?.turnQueue?.length === 1 &&
+        agent.sessions["test-session"]?.activeTurn == null,
+    );
+    await agent.cancel({ sessionId: "test-session" });
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    release();
+
+    await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    expect(JSON.stringify(updates)).not.toContain("[Request interrupted by user]");
+  });
+
+  it("does not hide an empty user-interruption diagnostic without a cancelled predecessor", async () => {
+    const agent = createMockAgent();
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const original = await iter.next();
+        yield userEcho(original.value);
+        yield {
+          ...createResultMessage(),
+          subtype: "success",
+          is_error: true,
+          result: "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+        };
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "first" }] }),
+    ).rejects.toThrow("[ede_diagnostic]");
   });
 
   // The other steer ordering: the cycle had already finished when the steer

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vites
 import { spawn, spawnSync } from "child_process";
 import {
   AvailableCommand,
+  ClientCapabilities,
   client as acpClient,
   CreateElicitationRequest,
   CreateElicitationResponse,
@@ -18,6 +19,7 @@ import {
   WriteTextFileRequest,
   WriteTextFileResponse,
 } from "@agentclientprotocol/sdk";
+import type { AcpSessionNotification } from "../acp-subagents.js";
 import { nodeToWebWritable, nodeToWebReadable } from "../utils.js";
 import {
   markdownEscape,
@@ -3396,6 +3398,12 @@ describe("canUseTool in bypassPermissions mode", () => {
 });
 
 describe("subagent permission attribution (issue #851)", () => {
+  const SUBAGENT_TEST_USAGE = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  };
   // A background subagent's permission requests reach canUseTool with only an
   // `agentID`; the streamed subagent messages carry `parent_tool_use_id`
   // instead. `task_started` bridges the two (for subagent tasks its `task_id`
@@ -3488,6 +3496,79 @@ describe("subagent permission attribution (issue #851)", () => {
       toolCallId: "toolu_sub",
       _meta: { claudeCode: { parentToolUseId: "toolu_parent" } },
     });
+  });
+
+  it("routes native child tool calls and permission requests to the child session", async () => {
+    const { agent, updates, requests, session } = setup();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    session.liveBackgroundTasks.set("agent-42", {
+      parentToolUseId: "toolu_parent",
+      isSubagent: true,
+    });
+    session.nativeSubagentsByTaskId = new Map([
+      [
+        "agent-42",
+        {
+          sessionId: "child-session",
+          parentSessionId: "session-1",
+          parentToolUseId: "toolu_parent",
+          name: "Explore",
+          task: "Investigate",
+          announced: true,
+        },
+      ],
+    ]);
+
+    await agent.canUseTool("session-1")("Bash", { command: "ls" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "toolu_sub",
+      agentID: "agent-42",
+    } as any);
+
+    expect(updates[0].sessionId).toBe("child-session");
+    expect(requests[0].sessionId).toBe("child-session");
+  });
+
+  it("keeps a raced permission on the root until the child is announced", async () => {
+    const { agent, updates, requests, session } = setup();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    session.liveBackgroundTasks.set("agent-42", {
+      parentToolUseId: "toolu_parent",
+      isSubagent: true,
+    });
+    session.nativeSubagentsByTaskId = new Map([
+      [
+        "agent-42",
+        {
+          sessionId: "child-session",
+          parentSessionId: "session-1",
+          parentToolUseId: "toolu_parent",
+          name: "Explore",
+          task: "Investigate",
+        },
+      ],
+    ]);
+
+    await agent.canUseTool("session-1")("Bash", { command: "ls" }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "toolu_sub",
+      agentID: "agent-42",
+    } as any);
+
+    expect(updates[0].sessionId).toBe("session-1");
+    expect(requests[0].sessionId).toBe("session-1");
   });
 
   function taskStarted(taskId: string, toolUseId: string) {
@@ -3633,6 +3714,406 @@ describe("subagent permission attribution (issue #851)", () => {
     const map = agent.sessions["test-session"]!.liveBackgroundTasks;
     expect(map.has("agent-42")).toBe(false);
     expect(map.get("agent-43")?.parentToolUseId).toBe("toolu_parent_2");
+  });
+
+  it("emits native subagent lifecycle when both peers advertise support", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          ...taskStarted("agent-42", "toolu_parent"),
+          subagent_type: "Explore",
+        },
+        {
+          type: "system",
+          subtype: "task_notification",
+          task_id: "agent-42",
+          tool_use_id: "toolu_parent",
+          status: "completed",
+          output_file: "",
+          summary: "done",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(updates.map((notification) => notification.update)).toEqual(
+      expect.arrayContaining([
+        {
+          sessionUpdate: "subagent_spawned",
+          subagentSessionId: "agent-42",
+          name: "Explore",
+          task: "Investigate",
+          capabilities: {},
+        },
+        {
+          sessionUpdate: "subagent_state_update",
+          subagentSessionId: "agent-42",
+          state: "completed",
+        },
+      ]),
+    );
+  });
+
+  it("buffers child output until spawn and drops duplicates and late updates", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    const childMessage = (text: string) => ({
+      type: "stream_event" as const,
+      parent_tool_use_id: "toolu_parent",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      event: {
+        type: "content_block_delta" as const,
+        index: 0,
+        delta: { type: "text_delta" as const, text },
+      },
+    });
+    const terminal = {
+      type: "system",
+      subtype: "task_notification",
+      task_id: "agent-42",
+      tool_use_id: "toolu_parent",
+      status: "completed",
+      output_file: "",
+      summary: "done",
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+    const childTool = {
+      type: "assistant" as const,
+      parent_tool_use_id: "toolu_parent",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      message: {
+        id: randomUUID(),
+        role: "assistant" as const,
+        model: "claude-sonnet-4-20250514",
+        content: [
+          { type: "tool_use" as const, id: "toolu_child", name: "Bash", input: { command: "pwd" } },
+        ],
+        usage: SUBAGENT_TEST_USAGE,
+      },
+    };
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        childMessage("buffered"),
+        { ...taskStarted("agent-42", "toolu_parent"), subagent_type: "Explore" },
+        childTool,
+        childMessage("routed"),
+        terminal,
+        terminal,
+        childMessage("late"),
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(updates.map(({ sessionId, update }) => [sessionId, update.sessionUpdate])).toEqual([
+      ["test-session", "subagent_spawned"],
+      ["agent-42", "agent_message_chunk"],
+      ["agent-42", "tool_call"],
+      ["agent-42", "agent_message_chunk"],
+      ["test-session", "subagent_state_update"],
+    ]);
+    expect(JSON.stringify(updates)).not.toContain("late");
+  });
+
+  it("uses the immediate child as parent for a nested subagent", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    const agentTool = (id: string, parent_tool_use_id: string | null) => ({
+      type: "assistant" as const,
+      parent_tool_use_id,
+      uuid: randomUUID(),
+      session_id: "test-session",
+      message: {
+        id: randomUUID(),
+        role: "assistant" as const,
+        model: "claude-sonnet-4-20250514",
+        content: [{ type: "tool_use" as const, id, name: "Agent", input: { prompt: "work" } }],
+        usage: SUBAGENT_TEST_USAGE,
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        agentTool("toolu_outer", null),
+        { ...taskStarted("agent-outer", "toolu_outer"), subagent_type: "Explore" },
+        // The SDK does not guarantee that task_started follows the assistant
+        // frame containing the spawning tool_use. Lineage must still attach
+        // the nested child to agent-outer, not to the root session.
+        { ...taskStarted("agent-inner", "toolu_inner"), subagent_type: "Explore" },
+        agentTool("toolu_inner", "toolu_outer"),
+        {
+          type: "system",
+          subtype: "task_updated",
+          task_id: "agent-inner",
+          patch: { status: "completed" },
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        {
+          type: "system",
+          subtype: "task_updated",
+          task_id: "agent-outer",
+          patch: { status: "completed" },
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    const nestedSpawn = updates.find(
+      ({ update }) =>
+        update.sessionUpdate === "subagent_spawned" && update.subagentSessionId === "agent-inner",
+    );
+    expect(nestedSpawn?.sessionId).toBe("agent-outer");
+    expect(
+      updates.filter(
+        ({ update }) =>
+          (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+          (update._meta?.claudeCode as { toolName?: string } | undefined)?.toolName === "Agent",
+      ),
+    ).toEqual([]);
+  });
+
+  it("fails an announced child if the provider stream ends without a terminal event", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        { ...taskStarted("agent-42", "toolu_parent"), subagent_type: "Explore" },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(updates.at(-1)).toEqual({
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "subagent_state_update",
+        subagentSessionId: "agent-42",
+        state: "failed",
+      },
+    });
+  });
+
+  it("maps the SDK stopped terminal status to ACP cancelled", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => updates.push(update),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        { ...taskStarted("agent-42", "toolu_parent"), subagent_type: "Explore" },
+        {
+          type: "system",
+          subtype: "task_notification",
+          task_id: "agent-42",
+          tool_use_id: "toolu_parent",
+          status: "stopped",
+          output_file: "",
+          summary: "stopped",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(updates.at(-1)?.update).toEqual({
+      sessionUpdate: "subagent_state_update",
+      subagentSessionId: "agent-42",
+      state: "cancelled",
+    });
+  });
+
+  it("finishes every announced child as cancelled when the parent is cancelled", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => updates.push(update),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    let childStarted!: () => void;
+    const started = new Promise<void>((resolve) => (childStarted = resolve));
+    let releaseStream!: () => void;
+    const released = new Promise<void>((resolve) => (releaseStream = resolve));
+    injectGeneratorSession(agent, (input) => {
+      async function* messages() {
+        const iter = input[Symbol.asyncIterator]();
+        const user = await iter.next();
+        yield userEcho(user.value);
+        yield { ...taskStarted("agent-42", "toolu_parent"), subagent_type: "Explore" };
+        childStarted();
+        await released;
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messages();
+    });
+
+    const prompt = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+    await started;
+    await agent.cancel({ sessionId: "test-session" });
+    releaseStream();
+    await prompt;
+
+    expect(updates.slice(-2).map(({ update }) => update)).toEqual([
+      {
+        sessionUpdate: "subagent_spawned",
+        subagentSessionId: "agent-42",
+        name: "Explore",
+        task: "Investigate",
+        capabilities: {},
+      },
+      {
+        sessionUpdate: "subagent_state_update",
+        subagentSessionId: "agent-42",
+        state: "cancelled",
+      },
+    ]);
+  });
+
+  it("bounds unattributed child output while waiting for its spawn", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const logs: string[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => updates.push(update),
+      } as unknown as AcpClient,
+      { log: (message) => logs.push(String(message)), error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+    const childMessages = Array.from({ length: 40 }, (_, index) => ({
+      type: "stream_event" as const,
+      parent_tool_use_id: "toolu_parent",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      event: {
+        type: "content_block_delta" as const,
+        index: 0,
+        delta: { type: "text_delta" as const, text: `chunk-${index}` },
+      },
+    }));
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        ...childMessages,
+        { ...taskStarted("agent-42", "toolu_parent"), subagent_type: "Explore" },
+        {
+          type: "system",
+          subtype: "task_notification",
+          task_id: "agent-42",
+          tool_use_id: "toolu_parent",
+          status: "completed",
+          output_file: "",
+          summary: "done",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(
+      updates.filter(({ update }) => update.sessionUpdate === "agent_message_chunk"),
+    ).toHaveLength(32);
+    expect(logs).toContainEqual(expect.stringContaining("pending buffer limit reached"));
   });
 });
 
@@ -6187,6 +6668,24 @@ describe("logout", () => {
       clientCapabilities: {},
     });
     expect(response.agentCapabilities?.auth?.logout).toEqual({});
+  });
+
+  it("advertises subagents only after client negotiation", async () => {
+    const agent = createMockAgent();
+    const unsupported = await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+    const supported = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as ClientCapabilities & {
+        subagents: Record<string, never>;
+      },
+    });
+
+    expect(
+      (unsupported.agentCapabilities?.sessionCapabilities as { subagents?: unknown }).subagents,
+    ).toBeUndefined();
+    expect(
+      (supported.agentCapabilities?.sessionCapabilities as { subagents?: unknown }).subagents,
+    ).toEqual({});
   });
 
   it("advertises canonical AIR sessionFailure support during initialize", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -2148,50 +2148,14 @@ describe("subagent transcript replay", () => {
     return updates;
   }
 
-  it("preserves nested text and child tool attribution for capable clients", async () => {
+  it("does not replay child output without authoritative native lifecycle", async () => {
     const updates = await replay(true);
-    expect(updates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          update: expect.objectContaining({
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "nested report" },
-            _meta: expect.objectContaining({
-              claudeCode: expect.objectContaining({ parentToolUseId: "parent-agent-call" }),
-            }),
-          }),
-        }),
-        expect.objectContaining({
-          update: expect.objectContaining({
-            sessionUpdate: "tool_call",
-            toolCallId: "child-tool",
-            _meta: expect.objectContaining({
-              claudeCode: expect.objectContaining({ parentToolUseId: "parent-agent-call" }),
-            }),
-          }),
-        }),
-      ]),
-    );
+    expect(updates).toEqual([]);
   });
 
-  it("keeps legacy text filtering without losing child tool attribution", async () => {
+  it("does not create a legacy child representation for unsupported clients", async () => {
     const updates = await replay(false);
-    expect(updates.some(({ update }) => update.sessionUpdate === "agent_message_chunk")).toBe(
-      false,
-    );
-    expect(updates).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          update: expect.objectContaining({
-            sessionUpdate: "tool_call",
-            toolCallId: "child-tool",
-            _meta: expect.objectContaining({
-              claudeCode: expect.objectContaining({ parentToolUseId: "parent-agent-call" }),
-            }),
-          }),
-        }),
-      ]),
-    );
+    expect(updates).toEqual([]);
   });
 });
 
@@ -16091,6 +16055,26 @@ describe("tool_progress heartbeats", () => {
 
     expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_inner"]);
   });
+
+  it("hides a child tool beat without native negotiation", async () => {
+    const sent = await run(
+      [
+        {
+          type: "system",
+          subtype: "task_started",
+          task_id: "agent-1",
+          tool_use_id: "toolu_task",
+          subagent_type: "general-purpose",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        beat("toolu_inner", "toolu_task", { heartbeat: undefined }),
+      ],
+      ["toolu_task", "toolu_inner"],
+    );
+
+    expect(sent).toEqual([]);
+  });
 });
 
 describe("permission_denied", () => {
@@ -16309,17 +16293,12 @@ describe("permission_denied", () => {
     expect(denials(updates)).toEqual([]);
   });
 
-  // The attribution rests on `task_started` having been seen for the agent id.
-  // If it wasn't, the denial still resolves the call — unattributed beats
-  // dropped.
-  it("still resolves a subagent denial when the parent is unknown", async () => {
+  it("drops an agent-scoped denial when the parent is unknown", async () => {
     const updates = await run([
       toolUse("toolu_inner", "toolu_agent"),
       denial("toolu_inner", { agent_id: "agent-unknown" }),
     ]);
 
-    const sent = denials(updates);
-    expect(sent).toHaveLength(1);
-    expect((sent[0]._meta as any).claudeCode).not.toHaveProperty("parentToolUseId");
+    expect(denials(updates)).toEqual([]);
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6845,7 +6845,12 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure", "agentFileChangeReport", "nativeSubagentSessions"],
+      capabilities: [
+        "sessionFailure",
+        "agentFileChangeReport",
+        "nativeSubagentSessions",
+        "asyncTasks",
+      ],
     });
   });
 
@@ -6858,7 +6863,12 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure", "agentFileChangeReport", "nativeSubagentSessions"],
+      capabilities: [
+        "sessionFailure",
+        "agentFileChangeReport",
+        "nativeSubagentSessions",
+        "asyncTasks",
+      ],
     });
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -751,7 +751,13 @@ describe("tool conversions", () => {
 
       expect(notifications[0]?.update).toMatchObject({
         sessionUpdate: "tool_call",
-        _meta: { claudeCode: { toolName: name, subagent: true } },
+        _meta: {
+          claudeCode: {
+            toolName: name,
+            subagent: true,
+            tags: [{ label: "Delegate", color: "#059669" }],
+          },
+        },
       });
     }
 
@@ -781,6 +787,32 @@ describe("tool conversions", () => {
         },
       },
     });
+  });
+
+  it("adds stable colored category tags to tool calls", () => {
+    const cases = [
+      ["Bash", "Execute", "#D97706"],
+      ["Edit", "Edit", "#2563EB"],
+      ["Grep", "Search", "#7C3AED"],
+      ["Skill", "Skill", "#DB2777"],
+      ["CustomTool", "Tool", "#6B7280"],
+    ] as const;
+
+    for (const [name, label, color] of cases) {
+      const notifications = toAcpNotifications(
+        [{ type: "tool_use", id: `toolu_${name}`, name, input: {} }] as any,
+        "assistant",
+        "test-session",
+        {},
+        {} as AcpClient,
+        console,
+      );
+
+      expect(notifications[0]?.update).toMatchObject({
+        sessionUpdate: "tool_call",
+        _meta: { claudeCode: { toolName: name, tags: [{ label, color }] } },
+      });
+    }
   });
 
   it("should handle Grep tool calls", () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -2165,13 +2165,18 @@ describe("subagent transcript replay", () => {
     },
   ] as Awaited<ReturnType<typeof getSessionMessages>>;
 
-  async function replay(capable: boolean): Promise<SessionNotification[]> {
+  async function replay(capability: "native" | "legacy" | false): Promise<SessionNotification[]> {
     const updates: SessionNotification[] = [];
     const client = {
       sessionUpdate: async (update: SessionNotification) => updates.push(update),
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
-    (agent as any).clientCapabilities = capable ? { subagents: {} } : {};
+    (agent as any).clientCapabilities =
+      capability === "native"
+        ? { subagents: {} }
+        : capability === "legacy"
+          ? { _meta: { "subagent-transcript": true } }
+          : {};
     vi.mocked(getSessionMessages).mockResolvedValueOnce(replayHistory);
 
     await (
@@ -2181,13 +2186,45 @@ describe("subagent transcript replay", () => {
   }
 
   it("does not replay child output without authoritative native lifecycle", async () => {
-    const updates = await replay(true);
+    const updates = await replay("native");
     expect(updates).toEqual([]);
   });
 
-  it("does not create a legacy child representation for unsupported clients", async () => {
+  it("keeps legacy text filtering without losing child tool attribution", async () => {
     const updates = await replay(false);
-    expect(updates).toEqual([]);
+    expect(updates.some(({ update }) => update.sessionUpdate === "agent_message_chunk")).toBe(
+      false,
+    );
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: "tool_call",
+            toolCallId: "child-tool",
+            _meta: expect.objectContaining({
+              claudeCode: expect.objectContaining({ parentToolUseId: "parent-agent-call" }),
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("replays the flattened transcript for the legacy opt-in", async () => {
+    const updates = await replay("legacy");
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "nested report" },
+          }),
+        }),
+        expect.objectContaining({
+          update: expect.objectContaining({ sessionUpdate: "tool_call", toolCallId: "child-tool" }),
+        }),
+      ]),
+    );
   });
 });
 
@@ -3428,7 +3465,7 @@ describe("subagent permission attribution (issue #851)", () => {
     return { agent, updates, requests, log, session: agent.sessions["session-1"]! };
   }
 
-  it("forwards only the permission when native subagents were not negotiated", async () => {
+  it("keeps the legacy child tool call before its root permission request", async () => {
     const { agent, updates, requests, session } = setup();
     session.liveBackgroundTasks.set("agent-42", {
       parentToolUseId: "toolu_parent",
@@ -3442,7 +3479,11 @@ describe("subagent permission attribution (issue #851)", () => {
       agentID: "agent-42",
     } as any);
 
-    expect(updates).toEqual([]);
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_sub",
+      _meta: { claudeCode: { parentToolUseId: "toolu_parent" } },
+    });
     expect(requests[0].sessionId).toBe("session-1");
     expect(requests[0].toolCall._meta).toMatchObject({
       claudeCode: { toolName: "Bash", parentToolUseId: "toolu_parent" },
@@ -3496,7 +3537,10 @@ describe("subagent permission attribution (issue #851)", () => {
       agentID: "agent-unknown",
     } as any);
 
-    expect(updates).toEqual([]);
+    expect(updates[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_sub",
+    });
     expect(requests[0].toolCall._meta).toBeUndefined();
     // The task_id === agentID invariant is undocumented SDK behavior; a miss
     // must be observable so an SDK bump that breaks it doesn't regress silently.
@@ -3748,7 +3792,7 @@ describe("subagent permission attribution (issue #851)", () => {
     expect(map.get("agent-43")?.parentToolUseId).toBe("toolu_parent_2");
   });
 
-  it("hides legacy subagent lifecycle and child output without capability negotiation", async () => {
+  it("keeps legacy Agent lifecycle and flattened child output without capability negotiation", async () => {
     const updates: AcpSessionNotification[] = [];
     const agent = new ClaudeAcpAgent(
       {
@@ -3809,11 +3853,19 @@ describe("subagent permission attribution (issue #851)", () => {
       updates.some(
         ({ update }) =>
           update.sessionUpdate === "subagent_spawned" ||
-          update.sessionUpdate === "subagent_state_update" ||
-          JSON.stringify(update).includes("hidden child output") ||
-          JSON.stringify(update).includes("toolu_parent"),
+          update.sessionUpdate === "subagent_state_update",
       ),
     ).toBe(false);
+    expect(
+      updates.some(({ update }) => JSON.stringify(update).includes("hidden child output")),
+    ).toBe(true);
+    expect(
+      updates.some(
+        ({ update }) =>
+          (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") &&
+          update.toolCallId === "toolu_parent",
+      ),
+    ).toBe(true);
   });
 
   it("emits native subagent lifecycle when both peers advertise support", async () => {
@@ -9043,7 +9095,7 @@ describe("assembled assistant text fallback", () => {
     expect(thoughtChunkTexts(updates)).toEqual([]);
   });
 
-  it("does not treat the legacy transcript extension as native subagent negotiation", async () => {
+  it("forwards subagent text and thinking through the legacy transcript extension", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     (agent as any).clientCapabilities = { _meta: { "subagent-transcript": true } };
     injectSession(agent, [
@@ -9066,7 +9118,12 @@ describe("assembled assistant text fallback", () => {
         update.sessionUpdate === "agent_message_chunk" ||
         update.sessionUpdate === "agent_thought_chunk",
     );
-    expect(nestedUpdates).toEqual([]);
+    expect(nestedUpdates).toHaveLength(2);
+    for (const { update } of nestedUpdates) {
+      expect(update._meta).toMatchObject({ claudeCode: { parentToolUseId: "tool_use_1" } });
+    }
+    expect(messageChunkTexts(updates)).toContain("nested report");
+    expect(thoughtChunkTexts(updates)).toContain("checking");
   });
 
   it("forwards distinct blocks that a gateway splits across same-id messages", async () => {
@@ -16120,7 +16177,7 @@ describe("tool_progress heartbeats", () => {
   // report under `agent_<assistant_message_id>`, with the retrying Agent call's
   // real id in `parent_tool_use_id`. Resolving via the suffix alone dropped
   // them, leaving a stalled spawn with no explanation.
-  it("hides a subagent retry beat without native negotiation", async () => {
+  it("reports a subagent retry beat against the Agent call without native negotiation", async () => {
     const sent = await run(
       [
         {
@@ -16145,7 +16202,14 @@ describe("tool_progress heartbeats", () => {
       ["toolu_task"],
     );
 
-    expect(sent).toEqual([]);
+    expect(sent[0].toolCallId).toBe("toolu_task");
+    expect((sent[0]._meta as any).claudeCode).toMatchObject({
+      toolName: "Task",
+      toolResponse: {
+        subagentType: "code-reviewer",
+        subagentRetry: { attempt: 2, max_retries: 5, error_status: 529 },
+      },
+    });
   });
 
   // A subagent's own `bash_progress` reports the inner tool's real id, with the
@@ -16160,7 +16224,7 @@ describe("tool_progress heartbeats", () => {
     expect(sent.map((u) => u.toolCallId)).toEqual(["toolu_inner"]);
   });
 
-  it("hides a child tool beat without native negotiation", async () => {
+  it("keeps a child tool beat in the legacy flattened transcript", async () => {
     const sent = await run(
       [
         {
@@ -16177,7 +16241,7 @@ describe("tool_progress heartbeats", () => {
       ["toolu_task", "toolu_inner"],
     );
 
-    expect(sent).toEqual([]);
+    expect(sent.map((update) => update.toolCallId)).toEqual(["toolu_inner"]);
   });
 });
 
@@ -16379,7 +16443,7 @@ describe("permission_denied", () => {
   // call that spawned it, so without the `liveBackgroundTasks` lookup the update
   // lands at the top level while the tool_call it resolves sits in the
   // subagent's transcript.
-  it("hides a subagent denial tool update without native negotiation", async () => {
+  it("attributes a legacy subagent denial to the Agent call that spawned it", async () => {
     const updates = await run([
       {
         type: "system",
@@ -16394,15 +16458,20 @@ describe("permission_denied", () => {
       denial("toolu_inner", { agent_id: "agent-1" }),
     ]);
 
-    expect(denials(updates)).toEqual([]);
+    expect((denials(updates)[0]._meta as any).claudeCode).toMatchObject({
+      toolName: "Write",
+      parentToolUseId: "toolu_agent",
+    });
   });
 
-  it("drops an agent-scoped denial when the parent is unknown", async () => {
+  it("still resolves a legacy subagent denial when the parent is unknown", async () => {
     const updates = await run([
       toolUse("toolu_inner", "toolu_agent"),
       denial("toolu_inner", { agent_id: "agent-unknown" }),
     ]);
 
-    expect(denials(updates)).toEqual([]);
+    const sent = denials(updates);
+    expect(sent).toHaveLength(1);
+    expect((sent[0]._meta as any).claudeCode).not.toHaveProperty("parentToolUseId");
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -755,7 +755,6 @@ describe("tool conversions", () => {
           claudeCode: {
             toolName: name,
             subagent: true,
-            tags: [{ label: "Delegate", color: "#059669" }],
           },
         },
       });
@@ -787,32 +786,6 @@ describe("tool conversions", () => {
         },
       },
     });
-  });
-
-  it("adds stable colored category tags to tool calls", () => {
-    const cases = [
-      ["Bash", "Execute", "#D97706"],
-      ["Edit", "Edit", "#2563EB"],
-      ["Grep", "Search", "#7C3AED"],
-      ["Skill", "Skill", "#DB2777"],
-      ["CustomTool", "Tool", "#6B7280"],
-    ] as const;
-
-    for (const [name, label, color] of cases) {
-      const notifications = toAcpNotifications(
-        [{ type: "tool_use", id: `toolu_${name}`, name, input: {} }] as any,
-        "assistant",
-        "test-session",
-        {},
-        {} as AcpClient,
-        console,
-      );
-
-      expect(notifications[0]?.update).toMatchObject({
-        sessionUpdate: "tool_call",
-        _meta: { claudeCode: { toolName: name, tags: [{ label, color }] } },
-      });
-    }
   });
 
   it("should handle Grep tool calls", () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -3386,6 +3386,10 @@ describe("subagent permission attribution (issue #851)", () => {
         requests.push(params);
         return { outcome: { outcome: "selected", optionId: "allow-once" } };
       },
+      unstable_createElicitation: async () => ({
+        action: "accept",
+        content: { question_0: "Fast", question_0_custom: "" },
+      }),
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(mockClient, { log, error: () => {} });
     agent.sessions["session-1"] = mockSessionState();
@@ -3413,7 +3417,7 @@ describe("subagent permission attribution (issue #851)", () => {
     });
   });
 
-  it("does not forward child elicitation when only permissions are allowed", async () => {
+  it("forwards child elicitation to the root when native subagents were not negotiated", async () => {
     const { agent, updates, requests, session } = setup();
     (agent as any).clientCapabilities = { elicitation: { form: {} } };
     session.liveBackgroundTasks.set("agent-42", {
@@ -3421,15 +3425,32 @@ describe("subagent permission attribution (issue #851)", () => {
       isSubagent: true,
     });
 
-    const result = await agent.canUseTool("session-1")("AskUserQuestion", { questions: [] }, {
-      signal: new AbortController().signal,
-      suggestions: [],
-      toolUseID: "toolu_question",
-      agentID: "agent-42",
-    } as any);
+    const result = await agent.canUseTool("session-1")(
+      "AskUserQuestion",
+      {
+        questions: [
+          {
+            question: "Which mode?",
+            header: "Mode",
+            options: [
+              { label: "Fast", description: "Fast mode" },
+              { label: "Safe", description: "Safe mode" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      {
+        signal: new AbortController().signal,
+        suggestions: [],
+        toolUseID: "toolu_question",
+        agentID: "agent-42",
+      } as any,
+    );
 
-    expect(result).toMatchObject({ behavior: "deny" });
-    expect(updates).toEqual([]);
+    expect(result).toMatchObject({ behavior: "allow" });
+    expect(updates).toHaveLength(1);
+    expect(updates[0].sessionId).toBe("session-1");
     expect(requests).toEqual([]);
   });
 
@@ -3443,8 +3464,7 @@ describe("subagent permission attribution (issue #851)", () => {
       agentID: "agent-unknown",
     } as any);
 
-    const meta = updates[0].update._meta as { claudeCode?: { parentToolUseId?: string } };
-    expect(meta.claudeCode?.parentToolUseId).toBeUndefined();
+    expect(updates).toEqual([]);
     expect(requests[0].toolCall._meta).toBeUndefined();
     // The task_id === agentID invariant is undocumented SDK behavior; a miss
     // must be observable so an SDK bump that breaks it doesn't regress silently.

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -3861,7 +3861,7 @@ describe("subagent permission attribution (issue #851)", () => {
         {
           sessionUpdate: "subagent_spawned",
           subagentSessionId: "agent-42",
-          name: "Explore",
+          name: "Investigate",
           task: "Investigate",
           capabilities: {},
         },
@@ -3978,7 +3978,18 @@ describe("subagent permission attribution (issue #851)", () => {
         id: randomUUID(),
         role: "assistant" as const,
         model: "claude-sonnet-4-20250514",
-        content: [{ type: "tool_use" as const, id, name: "Agent", input: { prompt: "work" } }],
+        content: [
+          {
+            type: "tool_use" as const,
+            id,
+            name: "Agent",
+            input: {
+              name: `${id}-name`,
+              description: `${id} description`,
+              prompt: `${id} full prompt`,
+            },
+          },
+        ],
         usage: SUBAGENT_TEST_USAGE,
       },
     });
@@ -4019,6 +4030,19 @@ describe("subagent permission attribution (issue #851)", () => {
         update.sessionUpdate === "subagent_spawned" && update.subagentSessionId === "agent-inner",
     );
     expect(nestedSpawn?.sessionId).toBe("agent-outer");
+    expect(nestedSpawn?.update).toMatchObject({
+      name: "toolu_inner-name",
+      task: "toolu_inner full prompt",
+    });
+    expect(
+      updates.find(
+        ({ update }) =>
+          update.sessionUpdate === "subagent_spawned" && update.subagentSessionId === "agent-outer",
+      )?.update,
+    ).toMatchObject({
+      name: "toolu_outer-name",
+      task: "toolu_outer full prompt",
+    });
     expect(
       updates.filter(
         ({ update }) =>
@@ -4150,7 +4174,7 @@ describe("subagent permission attribution (issue #851)", () => {
       {
         sessionUpdate: "subagent_spawned",
         subagentSessionId: "agent-42",
-        name: "Explore",
+        name: "Investigate",
         task: "Investigate",
         capabilities: {},
       },
@@ -6788,6 +6812,24 @@ describe("logout", () => {
     ).toEqual({});
   });
 
+  it("negotiates subagents through AIR metadata when the SDK strips the draft field", async () => {
+    const agent = createMockAgent();
+    const supported = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        _meta: {
+          jetbrains: {
+            air: { version: 1, capabilities: ["nativeSubagentSessions"] },
+          },
+        },
+      },
+    });
+
+    expect(
+      (supported.agentCapabilities?.sessionCapabilities as { subagents?: unknown }).subagents,
+    ).toEqual({});
+  });
+
   it("advertises canonical AIR sessionFailure support during initialize", async () => {
     const agent = createMockAgent();
     const response = await agent.initialize({
@@ -6803,7 +6845,7 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure", "agentFileChangeReport"],
+      capabilities: ["sessionFailure", "agentFileChangeReport", "nativeSubagentSessions"],
     });
   });
 
@@ -6816,7 +6858,7 @@ describe("logout", () => {
 
     expect((response._meta as any)?.jetbrains?.air).toEqual({
       version: 1,
-      capabilities: ["sessionFailure", "agentFileChangeReport"],
+      capabilities: ["sessionFailure", "agentFileChangeReport", "nativeSubagentSessions"],
     });
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -2139,7 +2139,7 @@ describe("subagent transcript replay", () => {
       sessionUpdate: async (update: SessionNotification) => updates.push(update),
     } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
-    (agent as any).clientCapabilities = capable ? { _meta: { "subagent-transcript": true } } : {};
+    (agent as any).clientCapabilities = capable ? { subagents: {} } : {};
     vi.mocked(getSessionMessages).mockResolvedValueOnce(replayHistory);
 
     await (
@@ -3428,7 +3428,7 @@ describe("subagent permission attribution (issue #851)", () => {
     return { agent, updates, requests, log, session: agent.sessions["session-1"]! };
   }
 
-  it("attributes a subagent tool's eager tool_call and permission request to the spawning tool call", async () => {
+  it("forwards only the permission when native subagents were not negotiated", async () => {
     const { agent, updates, requests, session } = setup();
     session.liveBackgroundTasks.set("agent-42", {
       parentToolUseId: "toolu_parent",
@@ -3442,15 +3442,31 @@ describe("subagent permission attribution (issue #851)", () => {
       agentID: "agent-42",
     } as any);
 
-    expect(updates[0].update).toMatchObject({
-      sessionUpdate: "tool_call",
-      toolCallId: "toolu_sub",
-      _meta: { claudeCode: { parentToolUseId: "toolu_parent" } },
-    });
-    // Keep the stable claudeCode metadata shape while adding the parent link.
-    expect(requests[0].toolCall._meta).toEqual({
+    expect(updates).toEqual([]);
+    expect(requests[0].sessionId).toBe("session-1");
+    expect(requests[0].toolCall._meta).toMatchObject({
       claudeCode: { toolName: "Bash", parentToolUseId: "toolu_parent" },
     });
+  });
+
+  it("does not forward child elicitation when only permissions are allowed", async () => {
+    const { agent, updates, requests, session } = setup();
+    (agent as any).clientCapabilities = { elicitation: { form: {} } };
+    session.liveBackgroundTasks.set("agent-42", {
+      parentToolUseId: "toolu_parent",
+      isSubagent: true,
+    });
+
+    const result = await agent.canUseTool("session-1")("AskUserQuestion", { questions: [] }, {
+      signal: new AbortController().signal,
+      suggestions: [],
+      toolUseID: "toolu_question",
+      agentID: "agent-42",
+    } as any);
+
+    expect(result).toMatchObject({ behavior: "deny" });
+    expect(updates).toEqual([]);
+    expect(requests).toEqual([]);
   });
 
   it("omits the attribution (and logs the miss) when the agent id has no recorded parent", async () => {
@@ -3714,6 +3730,74 @@ describe("subagent permission attribution (issue #851)", () => {
     const map = agent.sessions["test-session"]!.liveBackgroundTasks;
     expect(map.has("agent-42")).toBe(false);
     expect(map.get("agent-43")?.parentToolUseId).toBe("toolu_parent_2");
+  });
+
+  it("hides legacy subagent lifecycle and child output without capability negotiation", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          type: "assistant",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            id: randomUUID(),
+            role: "assistant",
+            model: "claude-sonnet-4-20250514",
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_parent",
+                name: "Agent",
+                input: { description: "Investigate", subagent_type: "Explore" },
+              },
+            ],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: SUBAGENT_TEST_USAGE,
+          },
+        },
+        {
+          ...taskStarted("agent-42", "toolu_parent"),
+          subagent_type: "Explore",
+        },
+        {
+          type: "stream_event",
+          parent_tool_use_id: "toolu_parent",
+          uuid: randomUUID(),
+          session_id: "test-session",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "hidden child output" },
+          },
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(
+      updates.some(
+        ({ update }) =>
+          update.sessionUpdate === "subagent_spawned" ||
+          update.sessionUpdate === "subagent_state_update" ||
+          JSON.stringify(update).includes("hidden child output") ||
+          JSON.stringify(update).includes("toolu_parent"),
+      ),
+    ).toBe(false);
   });
 
   it("emits native subagent lifecycle when both peers advertise support", async () => {
@@ -8891,7 +8975,7 @@ describe("assembled assistant text fallback", () => {
     expect(thoughtChunkTexts(updates)).toEqual([]);
   });
 
-  it("forwards subagent text and thinking as nested chunks for capable clients", async () => {
+  it("does not treat the legacy transcript extension as native subagent negotiation", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     (agent as any).clientCapabilities = { _meta: { "subagent-transcript": true } };
     injectSession(agent, [
@@ -8914,14 +8998,7 @@ describe("assembled assistant text fallback", () => {
         update.sessionUpdate === "agent_message_chunk" ||
         update.sessionUpdate === "agent_thought_chunk",
     );
-    expect(nestedUpdates).toHaveLength(2);
-    for (const { update } of nestedUpdates) {
-      expect(update._meta).toMatchObject({
-        claudeCode: { parentToolUseId: "tool_use_1" },
-      });
-    }
-    expect(messageChunkTexts(updates)).toContain("nested report");
-    expect(thoughtChunkTexts(updates)).toContain("checking");
+    expect(nestedUpdates).toEqual([]);
   });
 
   it("forwards distinct blocks that a gateway splits across same-id messages", async () => {
@@ -15975,7 +16052,7 @@ describe("tool_progress heartbeats", () => {
   // report under `agent_<assistant_message_id>`, with the retrying Agent call's
   // real id in `parent_tool_use_id`. Resolving via the suffix alone dropped
   // them, leaving a stalled spawn with no explanation.
-  it("reports a subagent retry beat against the Agent call that is retrying", async () => {
+  it("hides a subagent retry beat without native negotiation", async () => {
     const sent = await run(
       [
         {
@@ -16000,14 +16077,7 @@ describe("tool_progress heartbeats", () => {
       ["toolu_task"],
     );
 
-    expect(sent[0].toolCallId).toBe("toolu_task");
-    expect((sent[0]._meta as any).claudeCode).toMatchObject({
-      toolName: "Task",
-      toolResponse: {
-        subagentType: "code-reviewer",
-        subagentRetry: { attempt: 2, max_retries: 5, error_status: 529 },
-      },
-    });
+    expect(sent).toEqual([]);
   });
 
   // A subagent's own `bash_progress` reports the inner tool's real id, with the
@@ -16221,7 +16291,7 @@ describe("permission_denied", () => {
   // call that spawned it, so without the `liveBackgroundTasks` lookup the update
   // lands at the top level while the tool_call it resolves sits in the
   // subagent's transcript.
-  it("attributes a subagent denial to the Agent call that spawned it", async () => {
+  it("hides a subagent denial tool update without native negotiation", async () => {
     const updates = await run([
       {
         type: "system",
@@ -16236,10 +16306,7 @@ describe("permission_denied", () => {
       denial("toolu_inner", { agent_id: "agent-1" }),
     ]);
 
-    expect((denials(updates)[0]._meta as any).claudeCode).toMatchObject({
-      toolName: "Write",
-      parentToolUseId: "toolu_agent",
-    });
+    expect(denials(updates)).toEqual([]);
   });
 
   // The attribution rests on `task_started` having been seen for the agent id.

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4611,6 +4611,15 @@ describe("subagent permission attribution (issue #851)", () => {
         }),
       ]),
     );
+    // One transcript line for the two stop attempts: the failed one never
+    // reached a terminal state, and the retry says it once.
+    expect(
+      updates.filter(({ update }) => update.sessionUpdate === "agent_message_chunk"),
+    ).toHaveLength(1);
+    expect(updates.at(-1)?.update).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text" },
+    });
   });
 
   it("attaches a Bash tool id discovered after async_task_spawned", async () => {
@@ -4700,6 +4709,88 @@ describe("subagent permission attribution (issue #851)", () => {
       toolCallId: "bash-tool",
       outputFilePath: "/tmp/tasks/shell-1.output",
     });
+
+    // The Bash card completes as soon as the command detaches, so this marker is
+    // the only thing telling a client it is backgrounded work, not finished work.
+    const bashUpdate = updates
+      .map(({ update }) => update)
+      .findLast(
+        (update) =>
+          update.sessionUpdate === "tool_call_update" && update.toolCallId === "bash-tool",
+      );
+    expect(bashUpdate).toMatchObject({
+      status: "completed",
+      _meta: {
+        jetbrains: { air: { version: 1, asyncTasks: { backgrounded: true } } },
+      },
+    });
+    // Agent-native tool metadata keeps its own namespace alongside it.
+    expect(bashUpdate?._meta?.claudeCode).toMatchObject({ toolName: "Bash" });
+  });
+
+  it("omits the background task link for a client without the asyncTasks capability", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => updates.push(notification),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          type: "assistant",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "bash-tool",
+                name: "Bash",
+                input: { command: "npm run build", run_in_background: true },
+              },
+            ],
+            usage: SUBAGENT_TEST_USAGE,
+          },
+        },
+        {
+          type: "user",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          tool_use_result: { backgroundTaskId: "shell-1" },
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "bash-tool",
+                content:
+                  "Command running in background. Output is being written to: /tmp/tasks/shell-1.output. You will be notified when it completes.",
+              },
+            ],
+          },
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // The id would name an `async_task_spawned` this client is never sent.
+    const bashUpdate = updates
+      .map(({ update }) => update)
+      .findLast(
+        (update) =>
+          update.sessionUpdate === "tool_call_update" && update.toolCallId === "bash-tool",
+      );
+    expect(bashUpdate).toMatchObject({ status: "completed" });
+    expect(bashUpdate?._meta).not.toHaveProperty("jetbrains");
   });
 });
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -3594,7 +3594,7 @@ describe("subagent permission attribution (issue #851)", () => {
           parentSessionId: "session-1",
           parentToolUseId: "toolu_parent",
           name: "Explore",
-          task: "Investigate",
+          description: "Investigate",
           announced: true,
         },
       ],
@@ -3631,7 +3631,7 @@ describe("subagent permission attribution (issue #851)", () => {
           parentSessionId: "session-1",
           parentToolUseId: "toolu_parent",
           name: "Explore",
-          task: "Investigate",
+          description: "Investigate",
         },
       ],
     ]);
@@ -3914,7 +3914,7 @@ describe("subagent permission attribution (issue #851)", () => {
           sessionUpdate: "subagent_spawned",
           subagentSessionId: "agent-42",
           name: "Investigate",
-          task: "Investigate",
+          description: "Investigate",
           capabilities: {},
         },
         {
@@ -4084,7 +4084,7 @@ describe("subagent permission attribution (issue #851)", () => {
     expect(nestedSpawn?.sessionId).toBe("agent-outer");
     expect(nestedSpawn?.update).toMatchObject({
       name: "toolu_inner-name",
-      task: "toolu_inner full prompt",
+      description: "toolu_inner full prompt",
     });
     expect(
       updates.find(
@@ -4093,7 +4093,7 @@ describe("subagent permission attribution (issue #851)", () => {
       )?.update,
     ).toMatchObject({
       name: "toolu_outer-name",
-      task: "toolu_outer full prompt",
+      description: "toolu_outer full prompt",
     });
     expect(
       updates.filter(
@@ -4227,7 +4227,7 @@ describe("subagent permission attribution (issue #851)", () => {
         sessionUpdate: "subagent_spawned",
         subagentSessionId: "agent-42",
         name: "Investigate",
-        task: "Investigate",
+        description: "Investigate",
         capabilities: {},
       },
       {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4557,6 +4557,62 @@ describe("subagent permission attribution (issue #851)", () => {
     );
   });
 
+  it("stops one advertised async task through the SDK without cancelling the prompt", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => updates.push(notification),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        _meta: { jetbrains: { air: { version: 1, capabilities: ["asyncTasks"] } } },
+      },
+    });
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          ...taskStarted("workflow-1", "toolu_workflow"),
+          task_type: "local_workflow",
+          is_backgrounded: true,
+        },
+        successResult(),
+      ]),
+    );
+    const query = agent.sessions["test-session"].query as any;
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+    query.stopTask.mockRejectedValueOnce(new Error("SDK stop failed"));
+    await expect(
+      agent.stopAsyncTask({ sessionId: "test-session", asyncTaskId: "workflow-1" }),
+    ).rejects.toThrow("SDK stop failed");
+    await expect(
+      agent.stopAsyncTask({ sessionId: "test-session", asyncTaskId: "workflow-1" }),
+    ).resolves.toEqual({ stopped: true });
+
+    expect(query.stopTask).toHaveBeenCalledTimes(2);
+    expect(query.stopTask).toHaveBeenNthCalledWith(1, "workflow-1");
+    expect(query.stopTask).toHaveBeenNthCalledWith(2, "workflow-1");
+    expect(query.interrupt).not.toHaveBeenCalled();
+    expect(updates.map(({ update }) => update)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionUpdate: "async_task_spawned",
+          asyncTaskId: "workflow-1",
+          canStop: true,
+        }),
+        expect.objectContaining({
+          sessionUpdate: "async_task_state_update",
+          asyncTaskId: "workflow-1",
+          state: "stopped",
+        }),
+      ]),
+    );
+  });
+
   it("attaches a Bash tool id discovered after async_task_spawned", async () => {
     const updates: AcpSessionNotification[] = [];
     const agent = new ClaudeAcpAgent(

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -1,8 +1,74 @@
 import { describe, expect, it } from "vitest";
 import type { AcpSessionNotification } from "../acp-subagents.js";
-import { AsyncTaskRuntime, clientSupportsAsyncTasks } from "../async-tasks.js";
+import {
+  AsyncTaskRuntime,
+  backgroundBashTaskFromToolResult,
+  clientSupportsAsyncTasks,
+} from "../async-tasks.js";
 
 describe("AsyncTaskRuntime", () => {
+  it("recovers a background Bash task from its structured tool result", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "root", async (notification) => {
+      updates.push(notification);
+    });
+    const task = backgroundBashTaskFromToolResult(
+      [{ type: "tool_result", tool_use_id: "bash-tool", content: "running" }],
+      { backgroundTaskId: "bpux8xmfg", stdout: "", stderr: "" },
+      {
+        "bash-tool": {
+          name: "Bash",
+          input: { command: "npm run build", run_in_background: true },
+        },
+      },
+    );
+
+    expect(task).toEqual({
+      taskId: "bpux8xmfg",
+      taskType: "local_bash",
+      description: "npm run build",
+      isBackgrounded: true,
+    });
+    await runtime.taskStarted(task!);
+    await runtime.taskNotification("bpux8xmfg", "completed", "Build finished");
+
+    expect(updates.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+    ]);
+    expect(updates[0].update).toMatchObject({
+      asyncTaskId: "bpux8xmfg",
+      name: "npm run build",
+      taskType: "shell",
+      description: "npm run build",
+      showInTranscript: true,
+    });
+  });
+
+  it("does not infer a background task without one unambiguous Bash result", () => {
+    const toolUseResult = { backgroundTaskId: "task-1" };
+    const bash = { bash: { name: "Bash", input: { command: "npm run build" } } };
+
+    expect(backgroundBashTaskFromToolResult([], toolUseResult, bash)).toBeUndefined();
+    expect(
+      backgroundBashTaskFromToolResult(
+        [
+          { type: "tool_result", tool_use_id: "bash" },
+          { type: "tool_result", tool_use_id: "other" },
+        ],
+        toolUseResult,
+        bash,
+      ),
+    ).toBeUndefined();
+    expect(
+      backgroundBashTaskFromToolResult(
+        [{ type: "tool_result", tool_use_id: "read" }],
+        toolUseResult,
+        { read: { name: "Read", input: {} } },
+      ),
+    ).toBeUndefined();
+  });
+
   it("detects the negotiated AIR capability", () => {
     expect(
       clientSupportsAsyncTasks({

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -36,6 +36,7 @@ describe("AsyncTaskRuntime", () => {
       description: "npm run build",
       isBackgrounded: true,
       outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
+      toolCallId: "bash-tool",
     });
     // The SDK can report local_bash before the Bash result proves that it was
     // backgrounded. The structured result must promote that existing task.
@@ -58,6 +59,7 @@ describe("AsyncTaskRuntime", () => {
       description: "npm run build",
       showInTranscript: true,
       outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
+      toolCallId: "bash-tool",
     });
   });
 

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -86,10 +86,76 @@ describe("AsyncTaskRuntime", () => {
     expect(published.map(({ update }) => update.sessionUpdate)).toEqual([
       "async_task_spawned",
       "async_task_state_update",
+      "agent_message_chunk",
     ]);
-    expect(published.at(-1)?.update).toMatchObject({
+    expect(published[1]?.update).toMatchObject({
       asyncTaskId: "task-1",
       state: "stopped",
+    });
+    // The panel drops a stopped task immediately; a summary there is unread.
+    expect(published[1]?.update).not.toHaveProperty("summary");
+    expect(published.at(-1)?.update).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "**Task stopped by user:** Build generated assets." },
+    });
+  });
+
+  it("still announces a stop whose SDK notification landed first", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      taskId: "task-1",
+      taskType: "local_bash",
+      description: "npm run build",
+      isBackgrounded: true,
+    });
+    expect(runtime.claimStop("task-1")).toBe(true);
+    // The SDK kills the process and reports it before `stopTask` resolves, so
+    // the task is already terminal by the time the stop path resumes. The
+    // acknowledgement is still owed to the user who clicked.
+    await runtime.taskNotification({ taskId: "task-1", status: "killed" });
+    await runtime.taskStopped("task-1");
+
+    expect(published.map(({ update }) => update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+      "agent_message_chunk",
+    ]);
+    expect(published.at(-1)?.update).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "**Task stopped by user:** npm run build." },
+    });
+  });
+
+  it("announces a stop for a panel-only task too", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    // A background Bash task is panel-only because its tool call already draws
+    // it in the transcript. That must not swallow the stop acknowledgement --
+    // it is the only signal the user gets that their click landed.
+    await runtime.taskStarted({
+      taskId: "task-1",
+      taskType: "local_bash",
+      description: "npm run build",
+      isBackgrounded: true,
+      skipTranscript: true,
+    });
+    expect(runtime.claimStop("task-1")).toBe(true);
+    await runtime.taskStopped("task-1");
+
+    expect(published[0]?.update).toMatchObject({
+      sessionUpdate: "async_task_spawned",
+      showInTranscript: false,
+    });
+    expect(published.at(-1)?.update).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "**Task stopped by user:** npm run build." },
     });
   });
 
@@ -117,6 +183,33 @@ describe("AsyncTaskRuntime", () => {
           },
         ],
         toolUseResult,
+        tools,
+      ),
+    ).toMatchObject({
+      taskId: "task-1",
+      toolCallId: "bash",
+      description: "npm run build",
+      outputFilePath: "/private/tmp/claude/tasks/task-1.output",
+    });
+  });
+
+  it("recovers a background Bash task when the structured result omits its id", () => {
+    const tools = {
+      bash: { name: "Bash", input: { command: "npm run build" } },
+    };
+
+    expect(
+      backgroundBashTaskFromToolResult(
+        [
+          {
+            type: "tool_result",
+            tool_use_id: "bash",
+            content:
+              "Command running in background with ID: task-1. Output is being written to: " +
+              "/private/tmp/claude/tasks/task-1.output. You will be notified when done.",
+          },
+        ],
+        undefined,
         tools,
       ),
     ).toMatchObject({

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -63,7 +63,41 @@ describe("AsyncTaskRuntime", () => {
     });
   });
 
-  it("does not infer a background task without one unambiguous Bash result", () => {
+  it("correlates a background Bash result inside a batched structured message", () => {
+    const toolUseResult = { backgroundTaskId: "task-1" };
+    const tools = {
+      read: { name: "Read", input: { file_path: "package.json" } },
+      bash: { name: "Bash", input: { command: "npm run build" } },
+    };
+
+    expect(
+      backgroundBashTaskFromToolResult(
+        [
+          { type: "tool_result", tool_use_id: "read", content: "package" },
+          {
+            type: "tool_result",
+            tool_use_id: "bash",
+            content: [
+              { type: "text", text: "Command running. Output is being written to: " },
+              {
+                type: "text",
+                text: "/private/tmp/claude/tasks/task-1.output. You will be notified when done.",
+              },
+            ],
+          },
+        ],
+        toolUseResult,
+        tools,
+      ),
+    ).toMatchObject({
+      taskId: "task-1",
+      toolCallId: "bash",
+      description: "npm run build",
+      outputFilePath: "/private/tmp/claude/tasks/task-1.output",
+    });
+  });
+
+  it("does not infer a background task without an unambiguous Bash result", () => {
     const toolUseResult = { backgroundTaskId: "task-1" };
     const bash = { bash: { name: "Bash", input: { command: "npm run build" } } };
 
@@ -71,11 +105,14 @@ describe("AsyncTaskRuntime", () => {
     expect(
       backgroundBashTaskFromToolResult(
         [
-          { type: "tool_result", tool_use_id: "bash" },
-          { type: "tool_result", tool_use_id: "other" },
+          { type: "tool_result", tool_use_id: "bash-1" },
+          { type: "tool_result", tool_use_id: "bash-2" },
         ],
         toolUseResult,
-        bash,
+        {
+          "bash-1": { name: "Bash", input: { command: "first" } },
+          "bash-2": { name: "Bash", input: { command: "second" } },
+        },
       ),
     ).toBeUndefined();
     expect(
@@ -98,6 +135,40 @@ describe("AsyncTaskRuntime", () => {
         toolUseResult,
         bash,
       )?.outputFilePath,
+    ).toBeUndefined();
+    expect(
+      backgroundBashTaskFromToolResult(
+        [{ type: "tool_result", tool_use_id: "bash" }],
+        [{ backgroundTaskId: "task-1" }, { backgroundTaskId: "task-2" }],
+        bash,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("uses a structured result tool id to disambiguate batched Bash results", () => {
+    expect(
+      backgroundBashTaskFromToolResult(
+        [
+          { type: "tool_result", tool_use_id: "bash-1", content: "first" },
+          { type: "tool_result", tool_use_id: "bash-2", content: "second" },
+        ],
+        { tool_use_id: "bash-2", background_task_id: "task-2" },
+        {
+          "bash-1": { name: "Bash", input: { command: "first" } },
+          "bash-2": { name: "Bash", input: { command: "second" } },
+        },
+      ),
+    ).toMatchObject({ taskId: "task-2", toolCallId: "bash-2", description: "second" });
+
+    expect(
+      backgroundBashTaskFromToolResult(
+        [{ type: "tool_result", tool_use_id: "bash-1", content: "first" }],
+        { tool_use_id: "read", background_task_id: "task-2" },
+        {
+          "bash-1": { name: "Bash", input: { command: "first" } },
+          read: { name: "Read", input: {} },
+        },
+      ),
     ).toBeUndefined();
   });
 
@@ -177,10 +248,294 @@ describe("AsyncTaskRuntime", () => {
       description: "Research",
       subagentType: "Explore",
     });
+    await runtime.taskStarted({
+      task_id: "agent-without-subtype",
+      task_type: "local_agent",
+      description: "Research",
+      is_backgrounded: true,
+    });
     expect(published).toEqual([]);
 
     await runtime.taskUpdated("shell", { isBackgrounded: true });
     expect(published).toHaveLength(1);
     expect(published[0]?.update).toMatchObject({ asyncTaskId: "shell", taskType: "shell" });
+  });
+
+  it("normalizes snake_case SDK task events and propagates a late output file", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Run build",
+      is_backgrounded: true,
+      tool_use_id: "bash-tool",
+    });
+    await runtime.taskProgress({
+      task_id: "shell",
+      last_tool_name: "Bash",
+      usage: { totalTokens: 2, toolUses: 1, durationMs: 50 },
+    });
+    await runtime.taskNotification({
+      task_id: "shell",
+      status: "completed",
+      summary: "Done",
+      output_file: "/tmp/tasks/shell.output",
+    });
+
+    expect(published[0]?.update).toMatchObject({
+      asyncTaskId: "shell",
+      taskType: "shell",
+      toolCallId: "bash-tool",
+    });
+    expect(published[1]?.update).toMatchObject({
+      lastToolName: "Bash",
+      usage: { totalTokens: 2, toolUses: 1, durationMs: 50 },
+    });
+    expect(published[2]?.update).toMatchObject({
+      state: "completed",
+      summary: "Done",
+      outputFilePath: "/tmp/tasks/shell.output",
+    });
+  });
+
+  it("keeps a terminal tombstone until a late Bash result proves the task was backgrounded", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskNotification({
+      task_id: "fast-shell",
+      status: "completed",
+      summary: "Already done",
+      output_file: "/tmp/tasks/fast-shell.output",
+    });
+    expect(published).toEqual([]);
+
+    await runtime.taskBackgrounded({
+      taskId: "fast-shell",
+      taskType: "local_bash",
+      description: "Fast build",
+      isBackgrounded: true,
+      toolCallId: "bash-tool",
+    });
+    await runtime.taskUpdated("fast-shell", { status: "running" });
+
+    expect(published.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+    ]);
+    expect(published[0]?.update).toMatchObject({
+      description: "Fast build",
+      outputFilePath: "/tmp/tasks/fast-shell.output",
+    });
+    expect(published[1]?.update).toMatchObject({
+      state: "completed",
+      summary: "Already done",
+      outputFilePath: "/tmp/tasks/fast-shell.output",
+    });
+  });
+
+  it("retains a terminal task_updated tombstone until background promotion", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskUpdated({
+      task_id: "fast-shell",
+      patch: { status: "failed", error: "boom" },
+    });
+    await runtime.taskBackgrounded({
+      task_id: "fast-shell",
+      task_type: "local_bash",
+      description: "Fast build",
+      is_backgrounded: true,
+    });
+
+    expect(published.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+    ]);
+    expect(published[1]?.update).toMatchObject({ state: "failed", summary: "boom" });
+  });
+
+  it("publishes a mutable output path after an already announced task", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      taskId: "shell",
+      taskType: "local_bash",
+      description: "Build",
+      isBackgrounded: true,
+    });
+    await runtime.taskUpdated("shell", { output_file: "/tmp/tasks/one.output" });
+    await runtime.taskUpdated("shell", { outputFilePath: "/tmp/tasks/two.output" });
+
+    expect(published.slice(1).map((notification) => notification.update)).toEqual([
+      expect.objectContaining({
+        sessionUpdate: "async_task_progress",
+        outputFilePath: "/tmp/tasks/one.output",
+      }),
+      expect.objectContaining({
+        sessionUpdate: "async_task_progress",
+        outputFilePath: "/tmp/tasks/two.output",
+      }),
+    ]);
+  });
+
+  it("publishes a tool id discovered after spawn", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Build",
+      is_backgrounded: true,
+    });
+    await runtime.taskBackgrounded({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Build",
+      is_backgrounded: true,
+      tool_use_id: "bash-tool",
+    });
+
+    expect(published[0]?.update).not.toHaveProperty("toolCallId");
+    expect(published[1]?.update).toMatchObject({
+      sessionUpdate: "async_task_progress",
+      asyncTaskId: "shell",
+      toolCallId: "bash-tool",
+    });
+  });
+
+  it("reconciles foreground promotion and a lost terminal edge from the live task level", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Build",
+      is_backgrounded: false,
+    });
+    await runtime.backgroundTasksChanged({
+      tasks: [{ task_id: "shell", task_type: "local_bash", description: "Build" }],
+    });
+    await runtime.backgroundTasksChanged([]);
+
+    expect(published.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+    ]);
+    expect(published[1]?.update).toMatchObject({ state: "stopped" });
+
+    // The level is deliberately best-effort: an authoritative edge that was
+    // merely ordered after it may correct the terminal state.
+    await runtime.taskNotification("shell", "completed", "Done");
+    expect(published[2]?.update).toMatchObject({ state: "completed", summary: "Done" });
+  });
+
+  it("lets the terminal edge win when the live level is ordered before it", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Build",
+      is_backgrounded: true,
+    });
+    await runtime.backgroundTasksChanged([]);
+    await runtime.taskNotification("shell", "completed", "Done");
+
+    expect(published.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+      "async_task_state_update",
+    ]);
+    expect(published[1]?.update).toMatchObject({ state: "stopped" });
+    expect(published[2]?.update).toMatchObject({ state: "completed", summary: "Done" });
+  });
+
+  it("heals a lone lost terminal edge at the replace-level boundary", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      task_id: "shell",
+      task_type: "local_bash",
+      description: "Build",
+      is_backgrounded: true,
+    });
+    await runtime.backgroundTasksChanged([]);
+
+    expect(published.at(-1)?.update).toMatchObject({
+      sessionUpdate: "async_task_state_update",
+      asyncTaskId: "shell",
+      state: "stopped",
+    });
+  });
+
+  it("recovers a live task whose task_started edge was lost", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.backgroundTasksChanged([
+      { task_id: "lost-start", task_type: "local_bash", description: "Build" },
+    ]);
+
+    expect(published[0]?.update).toMatchObject({
+      sessionUpdate: "async_task_spawned",
+      asyncTaskId: "lost-start",
+      taskType: "shell",
+      description: "Build",
+      showInTranscript: false,
+    });
+  });
+
+  it("keeps level-only recovery panel-only when task_started arrives late", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.backgroundTasksChanged([
+      { task_id: "lost-start", task_type: "local_workflow", description: "Build assets" },
+    ]);
+    await runtime.taskStarted({
+      task_id: "lost-start",
+      task_type: "local_workflow",
+      workflow_name: "assets",
+      description: "Build generated assets",
+      skip_transcript: true,
+      is_backgrounded: true,
+    });
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.update).toMatchObject({
+      sessionUpdate: "async_task_spawned",
+      asyncTaskId: "lost-start",
+      name: "Build assets",
+      showInTranscript: false,
+    });
   });
 });

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -13,7 +13,14 @@ describe("AsyncTaskRuntime", () => {
       updates.push(notification);
     });
     const task = backgroundBashTaskFromToolResult(
-      [{ type: "tool_result", tool_use_id: "bash-tool", content: "running" }],
+      [
+        {
+          type: "tool_result",
+          tool_use_id: "bash-tool",
+          content:
+            "Command running in background with ID: bpux8xmfg. Output is being written to: /private/tmp/claude/tasks/bpux8xmfg.output. You will be notified when it completes.",
+        },
+      ],
       { backgroundTaskId: "bpux8xmfg", stdout: "", stderr: "" },
       {
         "bash-tool": {
@@ -28,6 +35,7 @@ describe("AsyncTaskRuntime", () => {
       taskType: "local_bash",
       description: "npm run build",
       isBackgrounded: true,
+      outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
     });
     // The SDK can report local_bash before the Bash result proves that it was
     // backgrounded. The structured result must promote that existing task.
@@ -49,6 +57,7 @@ describe("AsyncTaskRuntime", () => {
       taskType: "shell",
       description: "npm run build",
       showInTranscript: true,
+      outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
     });
   });
 
@@ -73,6 +82,20 @@ describe("AsyncTaskRuntime", () => {
         toolUseResult,
         { read: { name: "Read", input: {} } },
       ),
+    ).toBeUndefined();
+    expect(
+      backgroundBashTaskFromToolResult(
+        [
+          {
+            type: "tool_result",
+            tool_use_id: "bash",
+            content:
+              "Output is being written to: /private/tmp/claude/tasks/not-task-1.output. You will be notified",
+          },
+        ],
+        toolUseResult,
+        bash,
+      )?.outputFilePath,
     ).toBeUndefined();
   });
 

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -58,8 +58,38 @@ describe("AsyncTaskRuntime", () => {
       taskType: "shell",
       description: "npm run build",
       showInTranscript: true,
+      canStop: true,
       outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
       toolCallId: "bash-tool",
+    });
+  });
+
+  it("publishes a stopped terminal after a task-specific stop", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      taskId: "task-1",
+      taskType: "local_workflow",
+      description: "Build generated assets",
+    });
+    expect(runtime.canStop("task-1")).toBe(true);
+    expect(runtime.claimStop("task-1")).toBe(true);
+    expect(runtime.claimStop("task-1")).toBe(false);
+
+    await runtime.taskStopped("task-1");
+    await runtime.taskStopped("task-1");
+
+    expect(runtime.canStop("task-1")).toBe(false);
+    expect(published.map(({ update }) => update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_state_update",
+    ]);
+    expect(published.at(-1)?.update).toMatchObject({
+      asyncTaskId: "task-1",
+      state: "stopped",
     });
   });
 

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { AcpSessionNotification } from "../acp-subagents.js";
+import { AsyncTaskRuntime, clientSupportsAsyncTasks } from "../async-tasks.js";
+
+describe("AsyncTaskRuntime", () => {
+  it("detects the negotiated AIR capability", () => {
+    expect(
+      clientSupportsAsyncTasks({
+        _meta: { jetbrains: { air: { version: 1, capabilities: ["asyncTasks"] } } },
+      }),
+    ).toBe(true);
+    expect(clientSupportsAsyncTasks({})).toBe(false);
+  });
+
+  it("publishes one durable lifecycle with progress and a terminal state", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      taskId: "task-1",
+      taskType: "local_workflow",
+      description: "Build generated assets",
+      workflowName: "assets",
+    });
+    await runtime.taskProgress({
+      taskId: "task-1",
+      summary: "Generated 3 files",
+      lastToolName: "Write",
+      usage: { total_tokens: 12, tool_uses: 3, duration_ms: 500 },
+    });
+    await runtime.taskUpdated("task-1", { status: "paused" });
+    await runtime.taskUpdated("task-1", { status: "running" });
+    await runtime.taskNotification("task-1", "completed", "Done");
+    await runtime.taskProgress({ taskId: "task-1", summary: "late" });
+    await runtime.taskNotification("task-1", "failed", "duplicate terminal");
+
+    expect(published.map((notification) => notification.update.sessionUpdate)).toEqual([
+      "async_task_spawned",
+      "async_task_progress",
+      "async_task_state_update",
+      "async_task_state_update",
+      "async_task_state_update",
+    ]);
+    expect(published[0]?.update).toMatchObject({
+      asyncTaskId: "task-1",
+      name: "assets",
+      taskType: "workflow",
+      showInTranscript: true,
+    });
+    expect(published[1]?.update).toMatchObject({
+      summary: "Generated 3 files",
+      usage: { totalTokens: 12, toolUses: 3, durationMs: 500 },
+    });
+    expect(published.at(-1)?.update).toMatchObject({ state: "completed", summary: "Done" });
+  });
+
+  it("waits until foreground shell work is backgrounded and excludes subagents", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      published.push(notification);
+    });
+
+    await runtime.taskStarted({
+      taskId: "foreground-shell",
+      taskType: "local_bash",
+      description: "Read one file",
+    });
+    await runtime.taskNotification("foreground-shell", "completed", "Done");
+    await runtime.taskStarted({
+      taskId: "shell",
+      taskType: "local_bash",
+      description: "Run tests",
+    });
+    await runtime.taskStarted({
+      taskId: "agent",
+      taskType: "local_agent",
+      description: "Research",
+      subagentType: "Explore",
+    });
+    expect(published).toEqual([]);
+
+    await runtime.taskUpdated("shell", { isBackgrounded: true });
+    expect(published).toHaveLength(1);
+    expect(published[0]?.update).toMatchObject({ asyncTaskId: "shell", taskType: "shell" });
+  });
+});

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -538,4 +538,47 @@ describe("AsyncTaskRuntime", () => {
       showInTranscript: false,
     });
   });
+
+  it("finishes remaining tasks and can retry a task whose terminal publication failed", async () => {
+    const published: AcpSessionNotification[] = [];
+    let failFirstTask = true;
+    const runtime = new AsyncTaskRuntime(true, "session", async (notification) => {
+      if (
+        failFirstTask &&
+        notification.update.sessionUpdate === "async_task_state_update" &&
+        notification.update.asyncTaskId === "first"
+      ) {
+        failFirstTask = false;
+        throw new Error("client disconnected");
+      }
+      published.push(notification);
+    });
+    for (const taskId of ["first", "second"]) {
+      await runtime.taskStarted({
+        task_id: taskId,
+        task_type: "local_bash",
+        description: taskId,
+        is_backgrounded: true,
+      });
+    }
+
+    await expect(runtime.finishAll("failed")).rejects.toThrow("client disconnected");
+    expect(published).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: "async_task_state_update",
+            asyncTaskId: "second",
+            state: "failed",
+          }),
+        }),
+      ]),
+    );
+
+    await expect(runtime.finishAll("failed")).resolves.toBeUndefined();
+    const terminalIds = published.flatMap(({ update }) =>
+      update.sessionUpdate === "async_task_state_update" ? [update.asyncTaskId] : [],
+    );
+    expect(terminalIds).toEqual(["second", "first"]);
+  });
 });

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -29,7 +29,14 @@ describe("AsyncTaskRuntime", () => {
       description: "npm run build",
       isBackgrounded: true,
     });
-    await runtime.taskStarted(task!);
+    // The SDK can report local_bash before the Bash result proves that it was
+    // backgrounded. The structured result must promote that existing task.
+    await runtime.taskStarted({
+      taskId: "bpux8xmfg",
+      taskType: "local_bash",
+      description: "Shell",
+    });
+    await runtime.taskBackgrounded(task!);
     await runtime.taskNotification("bpux8xmfg", "completed", "Build finished");
 
     expect(updates.map((notification) => notification.update.sessionUpdate)).toEqual([

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -271,17 +271,17 @@ describe("createSession options merging", () => {
       expect(capturedOptions!.forwardSubagentText).toBe(false);
     });
 
-    it("ignores caller forwarding without native ACP negotiation", async () => {
+    it("preserves caller-provided legacy transcript forwarding", async () => {
       await agent.newSession({
         cwd: process.cwd(),
         mcpServers: [],
         _meta: { claudeCode: { options: { forwardSubagentText: true } } },
       });
 
-      expect(capturedOptions!.forwardSubagentText).toBe(false);
+      expect(capturedOptions!.forwardSubagentText).toBe(true);
     });
 
-    it("does not accept the legacy transcript extension", async () => {
+    it("accepts the legacy transcript extension", async () => {
       await agent.initialize({
         protocolVersion: 1,
         clientCapabilities: { _meta: { "subagent-transcript": true } },
@@ -292,7 +292,7 @@ describe("createSession options merging", () => {
         _meta: { claudeCode: { options: { forwardSubagentText: false } } },
       });
 
-      expect(capturedOptions!.forwardSubagentText).toBe(false);
+      expect(capturedOptions!.forwardSubagentText).toBe(true);
     });
 
     it("enables SDK forwarding after native ACP negotiation", async () => {

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { RequestError, SessionNotification } from "@agentclientprotocol/sdk";
+import type { ClientCapabilities } from "@agentclientprotocol/sdk";
 import type { Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
 import * as fs from "node:fs";
@@ -270,20 +271,34 @@ describe("createSession options merging", () => {
       expect(capturedOptions!.forwardSubagentText).toBe(false);
     });
 
-    it("preserves the pre-existing caller-provided SDK option", async () => {
+    it("ignores caller forwarding without native ACP negotiation", async () => {
       await agent.newSession({
         cwd: process.cwd(),
         mcpServers: [],
         _meta: { claudeCode: { options: { forwardSubagentText: true } } },
       });
 
-      expect(capturedOptions!.forwardSubagentText).toBe(true);
+      expect(capturedOptions!.forwardSubagentText).toBe(false);
     });
 
-    it("enables SDK forwarding when the ACP client advertises support", async () => {
+    it("does not accept the legacy transcript extension", async () => {
       await agent.initialize({
         protocolVersion: 1,
         clientCapabilities: { _meta: { "subagent-transcript": true } },
+      });
+      await agent.newSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+        _meta: { claudeCode: { options: { forwardSubagentText: false } } },
+      });
+
+      expect(capturedOptions!.forwardSubagentText).toBe(false);
+    });
+
+    it("enables SDK forwarding after native ACP negotiation", async () => {
+      await agent.initialize({
+        protocolVersion: 1,
+        clientCapabilities: { subagents: {} } as ClientCapabilities,
       });
       await agent.newSession({
         cwd: process.cwd(),

--- a/src/tests/native-subagents.test.ts
+++ b/src/tests/native-subagents.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpSessionNotification } from "../acp-subagents.js";
+import {
+  announceNativeSubagent,
+  finishNativeSubagent,
+  NativeSubagent,
+  NativeSubagentRuntime,
+  NativeSubagentSession,
+} from "../native-subagents.js";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function child(overrides: Partial<NativeSubagent> = {}): NativeSubagent {
+  return {
+    sessionId: "child-1",
+    parentSessionId: "root",
+    parentToolUseId: "agent-tool",
+    name: "Explore",
+    task: "Inspect the project",
+    ...overrides,
+  };
+}
+
+function sessionWith(value: NativeSubagent): NativeSubagentSession {
+  return {
+    nativeSubagentsByTaskId: new Map([[value.sessionId, value]]),
+    nativeSubagentTaskIdByToolUseId: new Map([[value.parentToolUseId!, value.sessionId]]),
+    nativeSubagentParentByToolUseId: new Map(),
+  };
+}
+
+function control(
+  sessionUpdate: "tool_call" | "tool_call_update",
+  status?: "pending" | "failed",
+  parentToolUseId?: string,
+): AcpSessionNotification {
+  return {
+    sessionId: "root",
+    update: {
+      sessionUpdate,
+      toolCallId: "agent-tool",
+      title: "Investigate failure",
+      status,
+      rawInput: { description: "Investigate failure", prompt: "Find the cause" },
+      _meta: {
+        claudeCode: { toolName: "Agent", subagent: true, parentToolUseId },
+      },
+    },
+  } as AcpSessionNotification;
+}
+
+describe("NativeSubagentRuntime lifecycle", () => {
+  it("publishes a raced spawn exactly once", async () => {
+    const release = deferred();
+    const published: AcpSessionNotification[] = [];
+    const value = child();
+    const publish = vi.fn(async (notification: AcpSessionNotification) => {
+      published.push(notification);
+      await release.promise;
+    });
+
+    const first = announceNativeSubagent(value, publish);
+    const second = announceNativeSubagent(value, publish);
+
+    await Promise.resolve();
+    expect(publish).toHaveBeenCalledTimes(1);
+    release.resolve();
+    await Promise.all([first, second]);
+    expect(published.map(({ update }) => update.sessionUpdate)).toEqual(["subagent_spawned"]);
+  });
+
+  it("publishes a raced terminal exactly once after the spawn", async () => {
+    const releaseSpawn = deferred();
+    const published: AcpSessionNotification[] = [];
+    const value = child();
+    const session = sessionWith(value);
+    const publish = vi.fn(async (notification: AcpSessionNotification) => {
+      published.push(notification);
+      if (notification.update.sessionUpdate === "subagent_spawned") await releaseSpawn.promise;
+    });
+
+    const first = finishNativeSubagent(session, value.sessionId, "completed", publish);
+    const second = finishNativeSubagent(session, value.sessionId, "cancelled", publish);
+    releaseSpawn.resolve();
+    await Promise.all([first, second]);
+
+    expect(published.map(({ update }) => update.sessionUpdate)).toEqual([
+      "subagent_spawned",
+      "subagent_state_update",
+    ]);
+    expect(published[1]?.update).toMatchObject({ state: "completed" });
+  });
+
+  it("falls back to one ordinary failed tool call when no child ever starts", async () => {
+    const runtime = new NativeSubagentRuntime(true, "root", {}, async () => {}, { log: () => {} });
+
+    await expect(
+      runtime.route(control("tool_call", "pending"), async () => {}),
+    ).resolves.toBeNull();
+    const fallback = await runtime.route(control("tool_call_update", "failed"), async () => {});
+
+    expect(fallback).toMatchObject({
+      sessionId: "root",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "agent-tool",
+        title: "Investigate failure",
+        status: "failed",
+        _meta: { claudeCode: { toolName: "Agent" } },
+      },
+    });
+    expect(
+      (fallback?.update._meta?.claudeCode as Record<string, unknown>).subagent,
+    ).toBeUndefined();
+  });
+
+  it("creates a schema-valid non-native failed tool call without a cached initial call", async () => {
+    const runtime = new NativeSubagentRuntime(true, "root", {}, async () => {}, { log: () => {} });
+
+    const fallback = await runtime.route(
+      {
+        sessionId: "root",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "agent-tool",
+          status: "failed",
+          _meta: { claudeCode: { toolName: "Agent", subagent: true } },
+        },
+      } as AcpSessionNotification,
+      async () => {},
+    );
+
+    expect(fallback).toMatchObject({
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "agent-tool",
+        title: "Agent",
+        status: "failed",
+        _meta: { claudeCode: { toolName: "Agent" } },
+      },
+    });
+    expect(
+      (fallback?.update._meta?.claudeCode as Record<string, unknown>).subagent,
+    ).toBeUndefined();
+  });
+
+  it("clears failed-control identity and parent affinity before an id is reused", async () => {
+    const outer = child({
+      sessionId: "outer-child",
+      parentToolUseId: "outer-tool",
+      announced: true,
+    });
+    const session = sessionWith(outer);
+    const published: AcpSessionNotification[] = [];
+    const runtime = new NativeSubagentRuntime(
+      true,
+      "root",
+      session,
+      async (notification) => {
+        published.push(notification);
+      },
+      { log: () => {} },
+    );
+
+    await runtime.route(control("tool_call", "pending", "outer-tool"), async () => {});
+    await runtime.route(control("tool_call_update", "failed", "outer-tool"), async () => {});
+    await runtime.taskStarted(
+      {
+        taskId: "reused-child",
+        toolUseId: "agent-tool",
+        subagentType: "Review",
+        description: "Fresh identity",
+      },
+      async () => {},
+    );
+    await runtime.route(
+      {
+        ...control("tool_call", "pending"),
+        update: {
+          ...control("tool_call", "pending").update,
+          rawInput: { description: "Fresh identity", prompt: "Review again" },
+        },
+      } as AcpSessionNotification,
+      async () => {},
+    );
+
+    expect(published.at(-1)).toMatchObject({
+      sessionId: "root",
+      update: {
+        sessionUpdate: "subagent_spawned",
+        subagentSessionId: "reused-child",
+        name: "Fresh identity",
+      },
+    });
+  });
+
+  it("discards unknown pending child updates during finishAll", async () => {
+    const published: AcpSessionNotification[] = [];
+    const delivered: AcpSessionNotification[] = [];
+    const runtime = new NativeSubagentRuntime(
+      true,
+      "root",
+      {},
+      async (notification) => {
+        published.push(notification);
+      },
+      { log: () => {} },
+    );
+    const pending = {
+      sessionId: "root",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "stale" },
+        _meta: { claudeCode: { parentToolUseId: "agent-tool" } },
+      },
+    } as AcpSessionNotification;
+
+    await expect(
+      runtime.route(pending, async (value) => {
+        delivered.push(value);
+      }),
+    ).resolves.toBeNull();
+    await runtime.finishAll("cancelled", async (value) => {
+      delivered.push(value);
+    });
+    await runtime.taskStarted(
+      {
+        taskId: "child-1",
+        toolUseId: "agent-tool",
+        subagentType: "Explore",
+        description: "New child",
+      },
+      async (value) => {
+        delivered.push(value);
+      },
+    );
+    await runtime.route(control("tool_call", "pending"), async (value) => {
+      delivered.push(value);
+    });
+
+    expect(delivered).toEqual([]);
+    expect(published).toHaveLength(1);
+  });
+
+  it("creates a distinct ACP lifecycle when the SDK restarts the same task id", async () => {
+    const published: AcpSessionNotification[] = [];
+    const runtime = new NativeSubagentRuntime(
+      true,
+      "root",
+      {},
+      async (notification) => {
+        published.push(notification);
+      },
+      { log: () => {} },
+    );
+    const launch = (toolCallId: string) =>
+      ({
+        ...control("tool_call", "pending"),
+        update: { ...control("tool_call", "pending").update, toolCallId },
+      }) as AcpSessionNotification;
+    const output = (parentToolUseId: string, text: string) =>
+      ({
+        sessionId: "root",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text },
+          _meta: { claudeCode: { parentToolUseId } },
+        },
+      }) as AcpSessionNotification;
+
+    await runtime.route(launch("launch-1"), async () => {});
+    await runtime.taskStarted(
+      {
+        taskId: "worker-1",
+        toolUseId: "launch-1",
+        subagentType: "Explore",
+        description: "First run",
+      },
+      async () => {},
+    );
+    await expect(runtime.route(output("launch-1", "first"), async () => {})).resolves.toMatchObject(
+      { sessionId: "worker-1" },
+    );
+    await runtime.finishTask("worker-1", "completed", async () => {});
+
+    await runtime.route(launch("launch-2"), async () => {});
+    await runtime.taskStarted(
+      {
+        taskId: "worker-1",
+        toolUseId: "launch-2",
+        subagentType: "Explore",
+        description: "Second run",
+      },
+      async () => {},
+    );
+    await expect(
+      runtime.route(output("launch-2", "second"), async () => {}),
+    ).resolves.toMatchObject({ sessionId: "worker-1:generation:2" });
+    await runtime.finishTask("worker-1", "failed", async () => {}, "launch-1");
+    expect(
+      published.filter(({ update }) => update.sessionUpdate === "subagent_state_update"),
+    ).toHaveLength(1);
+    await expect(
+      runtime.route(output("launch-2", "still running"), async () => {}),
+    ).resolves.toMatchObject({ sessionId: "worker-1:generation:2" });
+    await expect(runtime.route(output("launch-1", "late"), async () => {})).resolves.toBeNull();
+    await runtime.finishTask("worker-1", "completed", async () => {}, "launch-2");
+
+    const spawnedIds = published.flatMap(({ update }) =>
+      update.sessionUpdate === "subagent_spawned" ? [update.subagentSessionId] : [],
+    );
+    const terminalIds = published.flatMap(({ update }) =>
+      update.sessionUpdate === "subagent_state_update" ? [update.subagentSessionId] : [],
+    );
+    expect(spawnedIds).toEqual(["worker-1", "worker-1:generation:2"]);
+    expect(terminalIds).toEqual(spawnedIds);
+  });
+});

--- a/src/tests/session-doubles.ts
+++ b/src/tests/session-doubles.ts
@@ -38,6 +38,7 @@ export function userEcho(u: any) {
 export function wrapQuery(generator: AsyncGenerator<any>) {
   return Object.assign(generator, {
     interrupt: vi.fn(async () => {}),
+    stopTask: vi.fn(async () => {}),
     close: vi.fn(),
     setModel: vi.fn(async () => {}),
   }) as any;

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -18,6 +18,8 @@ import {
   toolUpdateFromToolResult,
   createPostToolUseHook,
   createTaskHook,
+  clearHookCallbacks,
+  registerHookCallback,
   toolInfoFromToolUse,
   planEntries,
   applyTaskCreate,
@@ -28,6 +30,32 @@ import {
   taskStateToPlanEntries,
   TaskState,
 } from "../tools.js";
+
+describe("PostToolUse callback ownership", () => {
+  it("clears only callbacks owned by the cancelled session", async () => {
+    const first = vi.fn(async () => {});
+    const second = vi.fn(async () => {});
+    registerHookCallback("owned-first", { onPostToolUseHook: first }, "session-one");
+    registerHookCallback("owned-second", { onPostToolUseHook: second }, "session-two");
+
+    clearHookCallbacks("session-one");
+    const hook = createPostToolUseHook();
+    const context = { signal: new AbortController().signal };
+    await hook(
+      { hook_event_name: "PostToolUse", tool_input: {}, tool_response: {} } as any,
+      "owned-first",
+      context,
+    );
+    await hook(
+      { hook_event_name: "PostToolUse", tool_input: {}, tool_response: {} } as any,
+      "owned-second",
+      context,
+    );
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+});
 
 describe("rawOutput in tool call updates", () => {
   const mockClient = {} as AcpClient;
@@ -1116,6 +1144,7 @@ describe("Bash terminal output", () => {
         toolUseCache,
         mockClientWithUpdate,
         mockLogger,
+        { parentToolUseId: "parent-agent-tool" },
       );
 
       // Fire PostToolUse hook with a structuredPatch in tool_response
@@ -1155,6 +1184,7 @@ describe("Bash terminal output", () => {
       expect(hookUpdates).toHaveLength(1);
       const hookUpdate = hookUpdates[0].update;
       expect(hookUpdate._meta.claudeCode.toolName).toBe("Edit");
+      expect(hookUpdate._meta.claudeCode.parentToolUseId).toBe("parent-agent-tool");
       expect(hookUpdate.content).toEqual([
         {
           type: "diff",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1336,16 +1336,20 @@ export function toolUpdateFromDiffToolResponse(toolResponse: unknown): {
   return result;
 }
 
-/* A global variable to store callbacks that should be executed when receiving hooks from Claude Code */
-const toolUseCallbacks: {
-  [toolUseId: string]: {
+/* Callbacks are keyed globally because the SDK hook is process-wide, but each
+ * entry retains its owning ACP session so cancellation/teardown can release it. */
+const toolUseCallbacks = new Map<
+  string,
+  {
+    ownerId?: string;
+    cleanupTimer?: ReturnType<typeof setTimeout>;
     onPostToolUseHook?: (
       toolUseID: string,
       toolInput: unknown,
       toolResponse: unknown,
     ) => Promise<void>;
-  };
-} = {};
+  }
+>();
 
 /* Setup callbacks that will be called when receiving hooks from Claude Code */
 export const registerHookCallback = (
@@ -1359,11 +1363,35 @@ export const registerHookCallback = (
       toolResponse: unknown,
     ) => Promise<void>;
   },
+  ownerId?: string,
 ) => {
-  toolUseCallbacks[toolUseID] = {
+  unregisterHookCallback(toolUseID);
+  toolUseCallbacks.set(toolUseID, {
+    ownerId,
     onPostToolUseHook,
-  };
+  });
 };
+
+export function unregisterHookCallback(toolUseID: string): void {
+  const callback = toolUseCallbacks.get(toolUseID);
+  if (callback?.cleanupTimer) clearTimeout(callback.cleanupTimer);
+  toolUseCallbacks.delete(toolUseID);
+}
+
+/** PostToolUse normally follows tool_result, so keep the callback for a short
+ * grace period while still bounding retention when the hook never arrives. */
+export function completeHookCallback(toolUseID: string): void {
+  const callback = toolUseCallbacks.get(toolUseID);
+  if (!callback || callback.cleanupTimer) return;
+  callback.cleanupTimer = setTimeout(() => unregisterHookCallback(toolUseID), 30_000);
+  callback.cleanupTimer.unref?.();
+}
+
+export function clearHookCallbacks(ownerId: string): void {
+  for (const [toolUseID, callback] of toolUseCallbacks) {
+    if (callback.ownerId === ownerId) unregisterHookCallback(toolUseID);
+  }
+}
 
 /* A callback for Claude Code that is called when receiving a PostToolUse hook */
 export const createPostToolUseHook =
@@ -1376,11 +1404,14 @@ export const createPostToolUseHook =
       }
 
       if (toolUseID) {
-        const onPostToolUseHook = toolUseCallbacks[toolUseID]?.onPostToolUseHook;
-        if (onPostToolUseHook) {
-          await onPostToolUseHook(toolUseID, input.tool_input, input.tool_response);
+        const onPostToolUseHook = toolUseCallbacks.get(toolUseID)?.onPostToolUseHook;
+        try {
+          if (onPostToolUseHook) {
+            await onPostToolUseHook(toolUseID, input.tool_input, input.tool_response);
+          }
+        } finally {
+          unregisterHookCallback(toolUseID);
         }
-        delete toolUseCallbacks[toolUseID]; // Cleanup after execution
       }
     }
     return { continue: true };


### PR DESCRIPTION
## Summary

- negotiate native ACP subagent sessions and AIR async task support
- map Claude Agent/Task lifecycle to independent child session streams
- publish background workflow, monitor, MCP, and backgrounded shell work as async tasks
- attach background shell tasks to their originating tool calls so clients can update one command card and open its output log
- stream task progress and preserve running, paused, completed, failed, and stopped states
- keep synchronous shell work, generic tools, and task notifications out of user message chunks
- preserve typed session failures and root permission/elicitation requests
- preserve the legacy generic Agent/Task representation and flattened transcript opt-ins for clients without native subagent capability

## Compatibility

The published ACP SDK does not yet contain PR #1992 types, so the change isolates the temporary structural cast in `src/acp-subagents.ts`. Clients that do not negotiate native subagent sessions retain the existing generic tool-call fallback, including the historical `_meta["subagent-transcript"]` capability and `forwardSubagentText` session option. Async tasks use the negotiated `asyncTasks` AIR capability and remain invisible to clients that do not advertise it. Claude does not expose a safe targeted child-cancel primitive, therefore child `cancel` and `close` capabilities remain disabled.

## Validation

- `npm run check`
- `npm run build`
- `env -u ANTHROPIC_BASE_URL npm run test:run` (830 passed, 20 skipped)
- `npm run test:run -- src/tests/async-tasks.test.ts` (5 passed)
