### PR TITLE
Fix/replay persisted subagents

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -63,6 +63,8 @@ import {
   FastModeDisabledReason,
   FastModeState,
   getSessionMessages,
+  getSubagentMessages,
+  listSubagents,
   listSessions,
   McpServerConfig,
   ModelInfo,
@@ -962,6 +964,63 @@ function supportsSubagentTranscript(capabilities?: ClientCapabilities | null): b
 function parentToolUseIdOf(message: { parent_tool_use_id?: unknown }): string | null {
   if (!("parent_tool_use_id" in message)) return null;
   return typeof message.parent_tool_use_id === "string" ? message.parent_tool_use_id : null;
+}
+
+type SessionHistoryMessage = Awaited<ReturnType<typeof getSessionMessages>>[number];
+
+function toolUseIdsOf(message: SessionHistoryMessage): string[] {
+  if (message.type !== "assistant") return [];
+  const content = (message as unknown as { message?: { content?: unknown } }).message?.content;
+  if (!Array.isArray(content)) return [];
+
+  const ids: string[] = [];
+  for (const block of content) {
+    if (
+      block &&
+      typeof block === "object" &&
+      "type" in block &&
+      block.type === "tool_use" &&
+      "id" in block &&
+      typeof block.id === "string"
+    ) {
+      ids.push(block.id);
+    }
+  }
+  return ids;
+}
+
+function interleaveSubagentHistories(
+  messages: SessionHistoryMessage[],
+  subagentHistories: SessionHistoryMessage[][],
+): SessionHistoryMessage[] {
+  const historiesByParent = new Map<string, SessionHistoryMessage[]>();
+  for (const history of subagentHistories) {
+    const parentToolUseId = history.map(parentToolUseIdOf).find((id) => id !== null);
+    if (parentToolUseId) {
+      historiesByParent.set(parentToolUseId, [
+        ...(historiesByParent.get(parentToolUseId) ?? []),
+        ...history,
+      ]);
+    }
+  }
+
+  const inserted = new Set<string>();
+  const interleave = (history: SessionHistoryMessage[]): SessionHistoryMessage[] => {
+    const result: SessionHistoryMessage[] = [];
+    for (const message of history) {
+      result.push(message);
+      for (const toolUseId of toolUseIdsOf(message)) {
+        const childHistory = historiesByParent.get(toolUseId);
+        if (childHistory && !inserted.has(toolUseId)) {
+          inserted.add(toolUseId);
+          result.push(...interleave(childHistory));
+        }
+      }
+    }
+    return result;
+  };
+
+  return interleave(messages);
 }
 
 function stripSubagentTextAndThinking(content: unknown): unknown {
@@ -5126,7 +5185,12 @@ export class ClaudeAcpAgent {
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
     const toolUseCache: ToolUseCache = {};
-    const messages = await getSessionMessages(sessionId);
+    const mainHistory = await getSessionMessages(sessionId);
+    const subagentIds = await listSubagents(sessionId);
+    const subagentHistories = await Promise.all(
+      subagentIds.map((agentId) => getSubagentMessages(sessionId, agentId)),
+    );
+    const messages = interleaveSubagentHistories(mainHistory, subagentHistories);
     const session = this.sessions[sessionId];
     const forwardSubagentText =
       session?.forwardSubagentText ?? supportsSubagentTranscript(this.clientCapabilities);

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -51,6 +51,8 @@ import {
   deleteSession,
   getSessionInfo,
   getSessionMessages,
+  getSubagentMessages,
+  listSubagents,
   query,
   SDKAssistantMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -74,6 +76,8 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
     // actual transcripts keep working; unit tests override per-call with
     // `mockResolvedValueOnce`.
     getSessionMessages: vi.fn(actual.getSessionMessages),
+    getSubagentMessages: vi.fn(actual.getSubagentMessages),
+    listSubagents: vi.fn(actual.listSubagents),
   };
 });
 import type {
@@ -2100,6 +2104,60 @@ describe("subagent transcript replay", () => {
     ).replaySessionHistory("s1");
     return updates;
   }
+
+  it("loads persisted subagent transcripts before replaying child tools", async () => {
+    const updates: SessionNotification[] = [];
+    const client = {
+      sessionUpdate: async (update: SessionNotification) => updates.push(update),
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "parent-message",
+        session_id: "s1",
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "parent-agent-call",
+              name: "Agent",
+              input: { description: "Inspect project", prompt: "List files" },
+            },
+          ],
+        },
+      },
+    ] as Awaited<ReturnType<typeof getSessionMessages>>);
+    vi.mocked(listSubagents).mockResolvedValueOnce(["agent-1"]);
+    vi.mocked(getSubagentMessages).mockResolvedValueOnce(replayHistory);
+
+    await (
+      agent as unknown as { replaySessionHistory(sessionId: string): Promise<void> }
+    ).replaySessionHistory("s1");
+
+    expect(
+      updates
+        .map(({ update }) => (update.sessionUpdate === "tool_call" ? update.toolCallId : undefined))
+        .filter(Boolean),
+    ).toEqual(["parent-agent-call", "child-tool"]);
+    expect(updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          update: expect.objectContaining({
+            sessionUpdate: "tool_call",
+            toolCallId: "child-tool",
+            _meta: expect.objectContaining({
+              claudeCode: expect.objectContaining({ parentToolUseId: "parent-agent-call" }),
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
 
   it("preserves nested text and child tool attribution for capable clients", async () => {
     const updates = await replay(true);


### PR DESCRIPTION
## Summary

Fix `session/load` replay losing tool calls made inside persisted Claude
subagents.

## Problem

The ACP [`session/load` contract](https://agentclientprotocol.com/protocol/v1/session-setup#loading-a-session)
requires the agent to replay the entire conversation through `session/update`
notifications. Tool executions are represented by
[`tool_call` updates](https://agentclientprotocol.com/protocol/v1/tool-calls#creating).

Claude stores subagent messages separately from the main session transcript:

- `getSessionMessages()` returns the main transcript.
- `listSubagents()` discovers persisted subagents.
- `getSubagentMessages()` returns each subagent transcript.

`replaySessionHistory()` only loaded the main transcript. As a result, a nested
tool call appeared during the original live turn but silently disappeared when
the same session was loaded. The parent Agent/Task result remained visible,
making the replay look complete while omitting the subagent's actual work.

This affected the adapter's
[nested subagent transcript behavior](https://github.com/agentclientprotocol/claude-agent-acp#nested-subagent-transcripts).
The client capability controls whether nested updates are rendered or flattened;
it does not transfer session-history recovery to the client.

## Fix

- Discover persisted subagents with `listSubagents()`.
- Load their histories with `getSubagentMessages()`.
- Recursively interleave each subagent history after its launching Agent/Task
  tool call.
- Reuse the existing replay conversion so capability filtering and
  `parentToolUseId` attribution remain unchanged.

## Regression test

The commits intentionally preserve red/green ordering:

1. `fece865` adds a split-storage regression fixture matching the Claude SDK's
   persisted-session layout.
2. Before the implementation, the test fails:

   ```text
   Expected: ["parent-agent-call", "child-tool"]
   Received: ["parent-agent-call"]
   ```

3. `e8f2df4` adds the implementation and makes the same test pass.

## Real-session ACP evidence

The original live session emitted the nested call with its parent relationship:

```json
{
  "method": "session/update",
  "params": {
    "sessionId": "<redacted>",
    "update": {
      "sessionUpdate": "tool_call",
      "toolCallId": "toolu_01AB1x1SdnkvcFoPF6EcmTqr",
      "rawInput": {
        "command": "ls -d <project>/*/ | xargs -n1 basename | paste -sd, -"
      },
      "_meta": {
        "claudeCode": {
          "parentToolUseId": "toolu_018NnXLu4qGQc7e4bei8C52a"
        }
      }
    }
  }
}
```

Before this fix, loading the same session emitted no corresponding child
`tool_call` update. After this fix, the child update is replayed with its
parent attribution and appears in the exported transcript in the expected
parent → child → assistant order.

Full logs are not included because they contain session content and local
environment details. The deterministic regression test provides reproducible
coverage; this excerpt documents the real ACP behavior that motivated it.

## Verification

- Focused regression test: passed
- Full Vitest suite: 811 passed, 20 skipped
- ESLint: passed
- Prettier: passed
- TypeScript build: passed
- Manual `session/load` verification against a real persisted Claude session:
  nested child tool call restored with the correct parent ID