### PR TITLE
feat: expose permission mode kinds

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -183,6 +183,7 @@ import { DEFAULT_AGENT_ID, EFFORT_CONFIG_ID } from "./session-config-ids.js";
 import { parseToolResultMeta } from "./tool-result-meta.js";
 
 export { DEFAULT_AGENT_ID, EFFORT_CONFIG_ID } from "./session-config-ids.js";
+import { MODE_CONFIG_ID, SessionModeManager } from "./session-mode.js";
 
 export const CLAUDE_CONFIG_DIR =
   process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
@@ -544,6 +545,10 @@ export type Session = {
   modes: SessionModeState;
   models: SessionModelState;
   modelInfos: ModelInfo[];
+  /** Prevents the model-specific Auto fallback from spamming the transcript. */
+  autoModeFallbackWarningShown?: boolean;
+  /** Initial mode fallback is reported after session/new, on the first prompt. */
+  autoModeFallbackWarningPending?: boolean;
   configOptions: SessionConfigOption[];
   /** Custom main-thread agent personas the user (or a plugin/project) has
    *  configured, discovered via `supportedAgents()` with Claude Code's built-in
@@ -1370,6 +1375,7 @@ export class ClaudeAcpAgent {
   client: AcpClient;
   clientCapabilities?: ClientCapabilities;
   logger: Logger;
+  private readonly sessionModes: SessionModeManager<Session>;
   gatewayAuthRequest?: GatewayAuthRequest;
   /** Set while ACP overrides the agent's native provider configuration. */
   providerConfig?: ProviderConfig;
@@ -1417,6 +1423,14 @@ export class ClaudeAcpAgent {
         turn.settled = true;
         turn.reject(error);
       },
+    });
+    this.sessionModes = new SessionModeManager({
+      getSession: (sessionId) => this.sessions[sessionId],
+      sessionEndedMessage: SESSION_ENDED_MESSAGE,
+      updateConfigOption: (sessionId, configId, value) =>
+        this.updateConfigOption(sessionId, configId, value),
+      sessionUpdate: (params: SessionNotification) => this.client.sessionUpdate(params),
+      logError: (...args: unknown[]) => this.logger.error(...args),
     });
   }
 
@@ -1832,6 +1846,10 @@ export class ClaudeAcpAgent {
     // settles. Fail clearly and let the client start a fresh session.
     if (session.queryClosed) {
       throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
+    }
+
+    if (session.autoModeFallbackWarningPending) {
+      await this.sessionModes.publishFallbackWarning(params.sessionId, session);
     }
 
     if (Array.from(session.taskState.values()).some((task) => task.status !== "completed")) {
@@ -4936,20 +4954,7 @@ export class ClaudeAcpAgent {
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
-    const session = this.sessions[params.sessionId];
-    if (!session) {
-      throw new Error("Session not found");
-    }
-    // The SDK query stream already ended (see closeQueryStream); the session is
-    // a husk and `query.setPermissionMode` below would act on a closed query.
-    // Fail with the same clear message prompt()/cancel() give for a dead stream.
-    if (session.queryClosed) {
-      throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
-    }
-
-    await this.applySessionMode(params.sessionId, params.modeId);
-    await this.updateConfigOption(params.sessionId, MODE_CONFIG_ID, params.modeId);
-    return {};
+    return this.sessionModes.setSessionMode(params);
   }
 
   async setSessionConfigOption(
@@ -5033,15 +5038,10 @@ export class ClaudeAcpAgent {
     // model ID rather than the caller-supplied alias.
     const resolvedValue = validValue.value;
 
+    let effectiveValue = resolvedValue;
     if (params.configId === MODE_CONFIG_ID) {
-      await this.applySessionMode(params.sessionId, resolvedValue);
-      await this.client.sessionUpdate({
-        sessionId: params.sessionId,
-        update: {
-          sessionUpdate: "current_mode_update",
-          currentModeId: resolvedValue,
-        },
-      });
+      effectiveValue = await this.sessionModes.selectMode(params.sessionId, resolvedValue);
+      await this.sessionModes.publishCurrent(params.sessionId, effectiveValue);
     } else if (params.configId === MODEL_CONFIG_ID) {
       await this.sessions[params.sessionId].query.setModel(resolvedValue);
     }
@@ -5049,45 +5049,9 @@ export class ClaudeAcpAgent {
     // effort changes and effort changes induced by a model switch go through
     // the same path.
 
-    await this.applyConfigOptionValue(params.sessionId, session, params.configId, resolvedValue);
+    await this.applyConfigOptionValue(params.sessionId, session, params.configId, effectiveValue);
 
     return { configOptions: session.configOptions };
-  }
-
-  private async applySessionMode(sessionId: string, modeId: string): Promise<void> {
-    switch (modeId) {
-      case "auto":
-      case "default":
-      case "acceptEdits":
-      case "bypassPermissions":
-      case "dontAsk":
-      case "plan":
-        break;
-      default:
-        throw new Error("Invalid Mode");
-    }
-
-    const session = this.sessions[sessionId];
-    if (!session) {
-      throw new Error("Session not found");
-    }
-    if (!session.modes.availableModes.some((mode) => mode.id === modeId)) {
-      throw new Error(`Mode ${modeId} is not available in this session`);
-    }
-
-    try {
-      await session.query.setPermissionMode(modeId);
-    } catch (error) {
-      if (error instanceof Error) {
-        if (!error.message) {
-          error.message = "Invalid Mode";
-        }
-        throw error;
-      } else {
-        // eslint-disable-next-line preserve-caught-error
-        throw new Error("Invalid Mode");
-      }
-    }
   }
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
@@ -5492,7 +5456,7 @@ export class ClaudeAcpAgent {
         cwd: session.cwd,
         durableChangeSet,
         allowPersistentOptions: matchedAskRule === undefined,
-        availableModes: session.modes.availableModes.map((mode) => mode.id),
+        availableModes: this.sessionModes.availableModeIds(session.modes),
         contextUsedPercent:
           session.contextUsedTokens === undefined || session.contextWindowSize <= 0
             ? undefined
@@ -5516,15 +5480,23 @@ export class ClaudeAcpAgent {
         parentToolUseId,
       );
       if (signal.aborted) throw new Error("Tool use aborted");
-      const { permissionResult, contextResetMode: clearContextMode } =
-        decodeClaudePermissionResponse(
-          response,
-          toolName,
-          toolInput,
-          toolUseID,
-          permissionOptions,
-          durableChangeSet,
-        );
+      const decodedPermission = decodeClaudePermissionResponse(
+        response,
+        toolName,
+        toolInput,
+        toolUseID,
+        permissionOptions,
+        durableChangeSet,
+      );
+      let permissionResult = decodedPermission.permissionResult;
+      const autoFallback = this.sessionModes.applyPermissionFallback(session, permissionResult);
+      permissionResult = autoFallback.permissionResult;
+      if (autoFallback.fallbackApplied) {
+        await this.sessionModes.publishFallbackWarning(sessionId, session);
+      }
+      const clearContextMode = decodedPermission.contextResetMode
+        ? this.sessionModes.effectiveMode(session, decodedPermission.contextResetMode)
+        : undefined;
       if (toolName === "ExitPlanMode" && clearContextMode) {
         const plan = typeof toolInput.plan === "string" ? toolInput.plan.trim() : "";
         if (!plan) throw new Error("ExitPlanMode clear-context selection requires a plan");
@@ -5705,13 +5677,10 @@ export class ClaudeAcpAgent {
     value: string,
   ): Promise<void> {
     if (configId === MODE_CONFIG_ID) {
-      session.modes = { ...session.modes, currentModeId: value };
-      session.configOptions = session.configOptions.map((o) =>
-        o.id === configId && typeof o.currentValue === "string" ? { ...o, currentValue: value } : o,
-      );
+      this.sessionModes.syncConfig(session, value);
     } else if (configId === MODEL_CONFIG_ID) {
-      // `ModelInfo.supportsAutoMode` is the canonical SDK signal for clamping
-      // modes below; its `displayName`/`description` also let us infer the
+      // `ModelInfo.supportsAutoMode` is the canonical SDK signal for applying
+      // the Auto fallback below; its `displayName`/`description` also let us infer the
       // context window for semantic aliases (e.g. `default`) whose ID alone
       // carries no "1m" token.
       const newModelInfo = session.modelInfos.find((m) => m.value === value);
@@ -5734,42 +5703,7 @@ export class ClaudeAcpAgent {
       }
       session.models = { ...session.models, currentModelId: value };
 
-      // Recompute availableModes for the new model and clamp the current
-      // mode if the SDK no longer offers it (today: "auto" on Haiku). An
-      // unknown model (an SDK-initiated refusal fallback to a model outside
-      // the user's `availableModels` allowlist — user-driven switches are
-      // validated against the options first) tells us nothing about its
-      // capabilities, so keep the current modes rather than spuriously
-      // downgrading (e.g. kicking the user out of "auto" for a model that
-      // does support it).
-      const newAvailableModes = newModelInfo
-        ? buildAvailableModes(newModelInfo)
-        : session.modes.availableModes;
-      // Capture BEFORE mutating session.modes so the log message reflects
-      // the invalidated mode rather than "default".
-      const previousModeId = session.modes.currentModeId;
-      let modeDowngraded = false;
-      if (!newAvailableModes.some((m) => m.id === previousModeId)) {
-        session.modes = {
-          availableModes: newAvailableModes,
-          currentModeId: "default",
-        };
-        try {
-          await session.query.setPermissionMode("default");
-        } catch (err) {
-          // Failing the entire model switch over a bookkeeping sync error is
-          // worse UX than logging and continuing; the user explicitly asked
-          // to change models. The next setPermissionMode from the user will
-          // either succeed or surface a fresh error.
-          this.logger.error(
-            `Failed to sync permissionMode to "default" after model switch invalidated "${previousModeId}":`,
-            err,
-          );
-        }
-        modeDowngraded = true;
-      } else {
-        session.modes = { ...session.modes, availableModes: newAvailableModes };
-      }
+      const modeDowngraded = await this.sessionModes.reconcileForModel(session, newModelInfo);
 
       // `model_not_allowed` described the model we just left, so it must not
       // follow us onto the new one; the remaining reasons are account- or
@@ -5818,13 +5752,7 @@ export class ClaudeAcpAgent {
       // still precedes the caller's config_option_update so order-sensitive
       // clients update currentModeId before re-rendering the option list.
       if (modeDowngraded) {
-        await this.client.sessionUpdate({
-          sessionId,
-          update: {
-            sessionUpdate: "current_mode_update",
-            currentModeId: "default",
-          },
-        });
+        await this.sessionModes.publishFallbackState(sessionId, session);
       }
     } else if (configId === AGENT_CONFIG_ID) {
       // Live agent switch — no subprocess restart needed. Apply the SDK flag
@@ -6334,13 +6262,7 @@ export class ClaudeAcpAgent {
             hooks: [
               createPostToolUseHook({
                 onEnterPlanMode: async () => {
-                  await this.client.sessionUpdate({
-                    sessionId,
-                    update: {
-                      sessionUpdate: "current_mode_update",
-                      currentModeId: "plan",
-                    },
-                  });
+                  await this.sessionModes.publishCurrent(sessionId, "plan");
                   await this.updateConfigOption(sessionId, MODE_CONFIG_ID, "plan");
                 },
               }),
@@ -6454,8 +6376,8 @@ export class ClaudeAcpAgent {
       creationOpts.resume !== undefined,
     );
 
-    // Gate `auto` (and future model-specific modes) on the resolved model's
-    // `ModelInfo`. See `buildAvailableModes` for the canonical SDK signal.
+    // Resolve the current model's capabilities separately from the stable
+    // permission-mode catalog advertised to ACP clients.
     // A resumed session can be running a model outside the `availableModels`
     // allowlist (currentModelId is then the verbatim live id, see
     // `matchResumedModel`); its capabilities are still known to the SDK's
@@ -6489,42 +6411,12 @@ export class ClaudeAcpAgent {
           },
         ]
       : allowedModels;
-    const availableModes = buildAvailableModes(currentModelInfo);
-
-    // Clamp `permissionMode` if the resolved session does not offer it. The
-    // common case is `permissions.defaultMode: "auto"` resolving to a model
-    // that does not support auto mode (e.g. Haiku); without this clamp the
-    // SDK would later throw `"auto mode unavailable for this model"` from
-    // `setPermissionMode`. Keep `permissionMode` as the resolved user intent
-    // (matches what was passed into `options.permissionMode` above) and use
-    // `effectiveMode` for the post-clamp value the session actually runs in.
-    let effectiveMode: PermissionMode = initialPermissionMode;
-    if (!availableModes.some((m) => m.id === effectiveMode)) {
-      if (effectiveMode === "auto") {
-        this.logger.error(
-          `permissions.defaultMode "auto" is not available for model ` +
-            `"${models.currentModelId}"; falling back to "default".`,
-        );
-      } else {
-        this.logger.error(
-          `permissions.defaultMode "${effectiveMode}" is not available in ` +
-            `this session; falling back to "default".`,
-        );
-      }
-      effectiveMode = "default";
-      // Sync the SDK so it doesn't keep "auto" cached internally. Wrapped in
-      // try/catch since failing here would abort session creation entirely.
-      try {
-        await q.setPermissionMode("default");
-      } catch (err) {
-        this.logger.error("Failed to sync clamped permissionMode to SDK:", err);
-      }
-    }
-
-    const modes = {
-      currentModeId: effectiveMode,
-      availableModes,
-    };
+    const { modes, autoModeFallbackWarningPending } = await this.sessionModes.initialize({
+      query: q,
+      requestedMode: initialPermissionMode,
+      currentModelInfo,
+      currentModelId: models.currentModelId,
+    });
 
     const agents = await discoverCustomAgents(q);
     // Only adopt the requested agent as the selected value if it's one we
@@ -6630,6 +6522,8 @@ export class ClaudeAcpAgent {
       modes,
       models,
       modelInfos,
+      autoModeFallbackWarningShown: false,
+      autoModeFallbackWarningPending,
       configOptions,
       agents,
       currentAgent,
@@ -6876,53 +6770,6 @@ function isValidBaseUrl(baseUrl: string): boolean {
   return parsed.protocol === "http:" || parsed.protocol === "https:";
 }
 
-/**
- * Build the list of permission modes the agent will advertise for the given
- * model. `auto` is gated by `ModelInfo.supportsAutoMode === true`, which is
- * the SDK's model-level availability signal. `undefined`/`false` both exclude
- * `auto`. `bypassPermissions` is still gated by `ALLOW_BYPASS`.
- */
-function buildAvailableModes(modelInfo: ModelInfo | undefined): SessionModeState["availableModes"] {
-  const modes: SessionModeState["availableModes"] = [
-    {
-      // Claude Code 2.1.200 renamed this mode to "Manual" across its surfaces;
-      // the wire id stays "default" ("manual" is only an accepted input alias).
-      id: "default",
-      name: "Manual",
-      description: "Always ask before making changes",
-    },
-    {
-      id: "acceptEdits",
-      name: "Accept edits",
-      description: "Automatically accept all file edits",
-    },
-    {
-      id: "plan",
-      name: "Plan",
-      description: "Create a plan before making changes",
-    },
-  ];
-
-  // Only advertise "auto" when the SDK reports the model supports it.
-  if (modelInfo?.supportsAutoMode === true) {
-    modes.push({
-      id: "auto",
-      name: "Auto",
-      description: "Claude handles permission decisions",
-    });
-  }
-
-  if (ALLOW_BYPASS) {
-    modes.push({
-      id: "bypassPermissions",
-      name: "Bypass permissions",
-      description: "Accepts all permissions",
-    });
-  }
-
-  return modes;
-}
-
 // Translate a UI effort value into the flag-layer payload. The SDK
 // shallow-merges `applyFlagSettings`, drops `undefined` during JSON transport,
 // and only clears a key when an explicit `null` is sent — see
@@ -6972,7 +6819,7 @@ export async function discoverCustomAgents(q: Query): Promise<AgentInfo[]> {
  *  Centralized so the option declarations in `buildConfigOptions` and the
  *  handlers in `setSessionConfigOption`/`applyConfigOptionValue` reference the
  *  same identifiers and can't drift apart. */
-export const MODE_CONFIG_ID = "mode";
+export { MODE_CONFIG_ID };
 export const MODEL_CONFIG_ID = "model";
 export const AGENT_CONFIG_ID = "agent";
 export const FAST_MODE_CONFIG_ID = "fast";
@@ -7110,19 +6957,7 @@ export function buildConfigOptions(
   fastMode?: FastModeOptionState,
 ): SessionConfigOption[] {
   const options: SessionConfigOption[] = [
-    {
-      id: MODE_CONFIG_ID,
-      name: "Mode",
-      description: "Session permission mode",
-      category: "mode",
-      type: "select",
-      currentValue: modes.currentModeId,
-      options: modes.availableModes.map((m) => ({
-        value: m.id,
-        name: m.name,
-        description: m.description,
-      })),
-    },
+    SessionModeManager.configOption(modes),
     {
       id: MODEL_CONFIG_ID,
       name: "Model",

--- a/src/session-mode.ts
+++ b/src/session-mode.ts
@@ -1,0 +1,333 @@
+import {
+  RequestError,
+  type SessionConfigOption,
+  type SessionModeState,
+  type SessionNotification,
+  type SetSessionModeRequest,
+  type SetSessionModeResponse,
+} from "@agentclientprotocol/sdk";
+import type {
+  ModelInfo,
+  PermissionMode,
+  PermissionResult,
+  Query,
+} from "@anthropic-ai/claude-agent-sdk";
+import { ALLOW_BYPASS } from "./permissions/modes.js";
+
+export const MODE_CONFIG_ID = "mode";
+export const AUTO_MODE_FALLBACK: PermissionMode = "acceptEdits";
+
+const AUTO_MODE_FALLBACK_NOTICE =
+  "**Auto mode unavailable:** the selected model does not support Auto mode; using Accept edits instead.";
+
+export type SessionMode = {
+  query: Pick<Query, "setPermissionMode">;
+  queryClosed?: boolean;
+  modes: SessionModeState;
+  models: { currentModelId: string };
+  modelInfos: ModelInfo[];
+  /** Prevents the model-specific Auto fallback from spamming the transcript. */
+  autoModeFallbackWarningShown?: boolean;
+  /** Initial mode fallback is reported after session/new, on the first prompt. */
+  autoModeFallbackWarningPending?: boolean;
+};
+
+export type SessionModeManagerOptions<S extends SessionMode> = {
+  getSession(sessionId: string): S | undefined;
+  sessionEndedMessage: string;
+  updateConfigOption(sessionId: string, configId: string, value: string): Promise<void>;
+  sessionUpdate(params: SessionNotification): Promise<void>;
+  logError(...args: unknown[]): void;
+};
+
+type ModeConfigSession = SessionMode & {
+  configOptions: SessionConfigOption[];
+};
+
+type InitializeSessionModeParams = {
+  query: Pick<Query, "setPermissionMode">;
+  requestedMode: PermissionMode;
+  currentModelInfo?: ModelInfo;
+  currentModelId: string;
+};
+
+/** Owns session-mode policy and the ACP/SDK synchronization it requires. */
+export class SessionModeManager<S extends SessionMode> {
+  constructor(private readonly options: SessionModeManagerOptions<S>) {}
+
+  async initialize({
+    query,
+    requestedMode,
+    currentModelInfo,
+    currentModelId,
+  }: InitializeSessionModeParams): Promise<{
+    modes: SessionModeState;
+    autoModeFallbackWarningPending: boolean;
+  }> {
+    const availableModes = this.buildAvailableModes();
+    let effectiveMode = requestedMode;
+    let autoModeFallbackWarningPending = false;
+
+    if (
+      effectiveMode === "auto" &&
+      currentModelInfo !== undefined &&
+      currentModelInfo.supportsAutoMode !== true
+    ) {
+      this.options.logError(
+        `permissions.defaultMode "auto" is not available for model ` +
+          `"${currentModelId}"; falling back to "${AUTO_MODE_FALLBACK}".`,
+      );
+      effectiveMode = AUTO_MODE_FALLBACK;
+      autoModeFallbackWarningPending = true;
+      await this.trySyncMode(query, effectiveMode, "Failed to sync clamped permissionMode to SDK:");
+    } else if (!this.isAvailable(availableModes, effectiveMode)) {
+      this.options.logError(
+        `permissions.defaultMode "${effectiveMode}" is not available in ` +
+          `this session; falling back to "default".`,
+      );
+      effectiveMode = "default";
+      await this.trySyncMode(query, effectiveMode, "Failed to sync clamped permissionMode to SDK:");
+    }
+
+    return {
+      modes: { currentModeId: effectiveMode, availableModes },
+      autoModeFallbackWarningPending,
+    };
+  }
+
+  static configOption(modes: SessionModeState): SessionConfigOption {
+    return {
+      id: MODE_CONFIG_ID,
+      name: "Mode",
+      description: "Session permission mode",
+      category: "mode",
+      type: "select",
+      currentValue: modes.currentModeId,
+      options: modes.availableModes.map((mode) => ({
+        value: mode.id,
+        name: mode.name,
+        description: mode.description,
+        _meta: mode._meta,
+      })),
+    };
+  }
+
+  syncConfig(session: ModeConfigSession, mode: string): void {
+    session.modes = { ...session.modes, currentModeId: mode };
+    session.configOptions = session.configOptions.map((option) =>
+      option.id === MODE_CONFIG_ID && typeof option.currentValue === "string"
+        ? { ...option, currentValue: mode }
+        : option,
+    );
+  }
+
+  availableModeIds(modes: SessionModeState): string[] {
+    return modes.availableModes.map((mode) => mode.id);
+  }
+
+  effectiveMode(session: SessionMode, requestedMode: PermissionMode): PermissionMode {
+    return requestedMode === "auto" && this.isAutoUnavailable(session)
+      ? AUTO_MODE_FALLBACK
+      : requestedMode;
+  }
+
+  applyPermissionFallback(
+    session: SessionMode,
+    permissionResult: PermissionResult,
+  ): { permissionResult: PermissionResult; fallbackApplied: boolean } {
+    const fallbackApplied =
+      this.isAutoUnavailable(session) &&
+      permissionResult.behavior === "allow" &&
+      permissionResult.updatedPermissions?.some(
+        (update) => update.type === "setMode" && update.mode === "auto",
+      ) === true;
+    if (!fallbackApplied || permissionResult.behavior !== "allow") {
+      return { permissionResult, fallbackApplied: false };
+    }
+
+    return {
+      permissionResult: {
+        ...permissionResult,
+        updatedPermissions: permissionResult.updatedPermissions?.map((update) =>
+          update.type === "setMode" && update.mode === "auto"
+            ? { ...update, mode: AUTO_MODE_FALLBACK }
+            : update,
+        ),
+      },
+      fallbackApplied: true,
+    };
+  }
+
+  /** Reconcile mode after a model switch. The caller rebuilds config options
+   * before publishing the returned state change. */
+  async reconcileForModel(session: SessionMode, model: ModelInfo | undefined) {
+    if (
+      session.modes.currentModeId !== "auto" ||
+      model === undefined ||
+      model.supportsAutoMode === true
+    ) {
+      return false;
+    }
+
+    session.modes = {
+      availableModes: session.modes.availableModes,
+      currentModeId: AUTO_MODE_FALLBACK,
+    };
+    await this.trySyncMode(
+      session.query,
+      AUTO_MODE_FALLBACK,
+      `Failed to sync permissionMode to "${AUTO_MODE_FALLBACK}" after model switch invalidated "auto":`,
+    );
+    return true;
+  }
+
+  async selectMode(sessionId: string, modeId: string): Promise<PermissionMode> {
+    const session = this.requireOpenSession(sessionId);
+    const requestedMode = this.parseMode(modeId);
+    if (!this.isAvailable(session.modes.availableModes, requestedMode)) {
+      throw new Error(`Mode ${modeId} is not available in this session`);
+    }
+
+    const effectiveMode = this.effectiveMode(session, requestedMode);
+    try {
+      await session.query.setPermissionMode(effectiveMode);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (!error.message) error.message = "Invalid Mode";
+        throw error;
+      }
+      // eslint-disable-next-line preserve-caught-error
+      throw new Error("Invalid Mode");
+    }
+
+    if (effectiveMode !== requestedMode) {
+      await this.publishFallbackWarning(sessionId, session);
+    }
+    return effectiveMode;
+  }
+
+  async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
+    const effectiveMode = await this.selectMode(params.sessionId, params.modeId);
+    if (effectiveMode !== params.modeId) {
+      await this.publishCurrent(params.sessionId, effectiveMode);
+    }
+    await this.options.updateConfigOption(params.sessionId, MODE_CONFIG_ID, effectiveMode);
+    return {};
+  }
+
+  async publishCurrent(sessionId: string, mode: string): Promise<void> {
+    await this.options.sessionUpdate({
+      sessionId,
+      update: { sessionUpdate: "current_mode_update", currentModeId: mode },
+    });
+  }
+
+  async publishFallbackWarning(sessionId: string, session: SessionMode): Promise<void> {
+    session.autoModeFallbackWarningPending = false;
+    if (session.autoModeFallbackWarningShown) return;
+    session.autoModeFallbackWarningShown = true;
+    try {
+      await this.options.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: AUTO_MODE_FALLBACK_NOTICE },
+        },
+      });
+    } catch (error) {
+      // The fallback has already been applied; a failed advisory must not turn
+      // the successful mode change into a failed request.
+      this.options.logError(`Failed to publish Auto mode fallback warning: ${error}`);
+    }
+  }
+
+  async publishFallbackState(sessionId: string, session: SessionMode): Promise<void> {
+    await this.publishCurrent(sessionId, AUTO_MODE_FALLBACK);
+    await this.publishFallbackWarning(sessionId, session);
+  }
+
+  private requireOpenSession(sessionId: string): S {
+    const session = this.options.getSession(sessionId);
+    if (!session) throw new Error("Session not found");
+    if (session.queryClosed) {
+      throw RequestError.internalError(undefined, this.options.sessionEndedMessage);
+    }
+    return session;
+  }
+
+  private isAutoUnavailable(
+    session: SessionMode,
+    modelId = session.models.currentModelId,
+  ): boolean {
+    const modelInfo = session.modelInfos.find((model) => model.value === modelId);
+    return modelInfo !== undefined && modelInfo.supportsAutoMode !== true;
+  }
+
+  private isAvailable(availableModes: SessionModeState["availableModes"], modeId: string): boolean {
+    return availableModes.some((mode) => mode.id === modeId);
+  }
+
+  private parseMode(modeId: string): PermissionMode {
+    switch (modeId) {
+      case "auto":
+      case "default":
+      case "acceptEdits":
+      case "bypassPermissions":
+      case "dontAsk":
+      case "plan":
+        return modeId;
+      default:
+        throw new Error("Invalid Mode");
+    }
+  }
+
+  private buildAvailableModes(): SessionModeState["availableModes"] {
+    const modes: SessionModeState["availableModes"] = [
+      {
+        id: "default",
+        name: "Manual",
+        description: "Always ask before making changes",
+        _meta: { kind: "standard" },
+      },
+      {
+        id: "acceptEdits",
+        name: "Accept edits",
+        description: "Automatically accept all file edits",
+        _meta: { kind: "standard" },
+      },
+      {
+        id: "plan",
+        name: "Plan",
+        description: "Create a plan before making changes",
+        _meta: { kind: "plan" },
+      },
+      {
+        id: "auto",
+        name: "Auto",
+        description: "Claude handles permission decisions",
+        _meta: { kind: "auto_review" },
+      },
+    ];
+    if (ALLOW_BYPASS) {
+      modes.push({
+        id: "bypassPermissions",
+        name: "Bypass permissions",
+        description: "Accepts all permissions",
+        _meta: { kind: "full_access" },
+      });
+    }
+    return modes;
+  }
+
+  private async trySyncMode(
+    query: Pick<Query, "setPermissionMode">,
+    mode: PermissionMode,
+    errorMessage: string,
+  ): Promise<void> {
+    try {
+      await query.setPermissionMode(mode);
+    } catch (error) {
+      this.options.logError(errorMessage, error);
+    }
+  }
+}

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -253,7 +253,7 @@ describe("ClaudeAcpAgent settings", () => {
       };
     }
 
-    it("omits `auto` from availableModes when the resolved model lacks supportsAutoMode", async () => {
+    it("advertises `auto` when the resolved model lacks supportsAutoMode", async () => {
       const projectDir = path.join(tempDir, "project");
       await fs.promises.mkdir(projectDir, { recursive: true });
 
@@ -276,8 +276,7 @@ describe("ClaudeAcpAgent settings", () => {
       });
 
       const modeIds: string[] = response.modes.availableModes.map((m: any) => m.id);
-      expect(modeIds).not.toContain("auto");
-      expect(modeIds).toEqual(expect.arrayContaining(["default", "acceptEdits", "plan"]));
+      expect(modeIds).toEqual(expect.arrayContaining(["default", "acceptEdits", "plan", "auto"]));
       expect(modeIds).not.toContain("dontAsk");
     });
 
@@ -309,21 +308,25 @@ describe("ClaudeAcpAgent settings", () => {
           id: "default",
           name: "Manual",
           description: "Always ask before making changes",
+          _meta: { kind: "standard" },
         },
         {
           id: "acceptEdits",
           name: "Accept edits",
           description: "Automatically accept all file edits",
+          _meta: { kind: "standard" },
         },
         {
           id: "plan",
           name: "Plan",
           description: "Create a plan before making changes",
+          _meta: { kind: "plan" },
         },
         {
           id: "auto",
           name: "Auto",
           description: "Claude handles permission decisions",
+          _meta: { kind: "auto_review" },
         },
       ]);
       const bypass = response.modes.availableModes[4];
@@ -332,12 +335,13 @@ describe("ClaudeAcpAgent settings", () => {
           id: "bypassPermissions",
           name: "Bypass permissions",
           description: "Accepts all permissions",
+          _meta: { kind: "full_access" },
         });
       }
       expect(modeIds).not.toContain("dontAsk");
     });
 
-    it("clamps permissions.defaultMode='auto' to 'default' on a model that lacks supportsAutoMode", async () => {
+    it("falls back permissions.defaultMode='auto' to Accept edits on an unsupported model", async () => {
       await fs.promises.writeFile(
         path.join(tempDir, "settings.json"),
         JSON.stringify({ permissions: { defaultMode: "auto" } }),
@@ -371,9 +375,11 @@ describe("ClaudeAcpAgent settings", () => {
         // carries the user-typed value; the SDK was synced via
         // setPermissionMode after we discovered the model can't honor it.
         expect(getCapturedOptions().permissionMode).toBe("auto");
-        expect(setPermissionModeSpy).toHaveBeenCalledWith("default");
-        expect(response.modes.currentModeId).toBe("default");
-        expect(response.modes.availableModes.map((m: any) => m.id)).not.toContain("auto");
+        expect(setPermissionModeSpy).toHaveBeenCalledWith("acceptEdits");
+        expect(response.modes.currentModeId).toBe("acceptEdits");
+        expect(response.modes.availableModes.map((m: any) => m.id)).toContain("auto");
+        const session = (agent as any).sessions[response.sessionId];
+        expect(session.autoModeFallbackWarningPending).toBe(true);
 
         // A descriptive warning was logged so operators see the clamp.
         const messages = errorSpy.mock.calls.map((c) => c.join(" "));

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -358,50 +358,6 @@ describe("session config options", () => {
     });
   });
 
-  describe("setSessionMode sends config_option_update", () => {
-    beforeEach(() => {
-      populateSession();
-    });
-
-    it("sends config_option_update when mode is changed via setSessionMode", async () => {
-      await agent.setSessionMode({ sessionId: SESSION_ID, modeId: "acceptEdits" });
-
-      const configUpdate = sessionUpdates.find(
-        (n) => n.update.sessionUpdate === "config_option_update",
-      );
-      expect(configUpdate).toBeDefined();
-      expect(configUpdate?.update).toMatchObject({
-        sessionUpdate: "config_option_update",
-        configOptions: expect.arrayContaining([
-          expect.objectContaining({ id: "mode", currentValue: "acceptEdits" }),
-        ]),
-      });
-    });
-
-    it("updates stored configOptions currentValue when mode changes", async () => {
-      await agent.setSessionMode({ sessionId: SESSION_ID, modeId: "plan" });
-
-      const session = (
-        agent as unknown as {
-          sessions: Record<string, { configOptions: typeof MOCK_CONFIG_OPTIONS }>;
-        }
-      ).sessions[SESSION_ID];
-      const modeOption = session.configOptions.find((o) => o.id === "mode");
-      expect(modeOption?.currentValue).toBe("plan");
-    });
-
-    it("does not send config_option_update for an invalid mode", async () => {
-      await expect(
-        agent.setSessionMode({ sessionId: SESSION_ID, modeId: "not-a-mode" as any }),
-      ).rejects.toThrow("Invalid Mode");
-
-      const configUpdate = sessionUpdates.find(
-        (n) => n.update.sessionUpdate === "config_option_update",
-      );
-      expect(configUpdate).toBeUndefined();
-    });
-  });
-
   describe("setSessionConfigOption(model) returns updated configOptions", () => {
     beforeEach(() => {
       populateSession();
@@ -1110,7 +1066,7 @@ describe("session config options", () => {
       populateSession();
     });
 
-    it("drops `auto` from available modes when switching to Haiku", async () => {
+    it("keeps the stable mode catalog when switching to Haiku", async () => {
       setupHaikuOpusSession("default");
 
       const response = await agent.setSessionConfigOption({
@@ -1122,24 +1078,16 @@ describe("session config options", () => {
       const modeOption = response.configOptions.find((o) => o.id === "mode");
       expect(modeOption).toBeDefined();
       const modeValues = (modeOption as any).options.map((o: any) => o.value);
-      expect(modeValues).not.toContain("auto");
-      expect(modeValues).toEqual(expect.arrayContaining(["default", "acceptEdits", "plan"]));
+      expect(modeValues).toEqual(
+        expect.arrayContaining(["default", "acceptEdits", "plan", "auto"]),
+      );
       expect(modeValues).not.toContain("dontAsk");
     });
 
-    it("re-adds `auto` when switching from Haiku back to Opus", async () => {
+    it("keeps the same mode catalog when switching from Haiku back to Opus", async () => {
       const session = setupHaikuOpusSession("default");
-      // Pretend Haiku is the current model with no `auto`.
+      // Pretend Haiku is the current model; its catalog still advertises Auto.
       session.models.currentModelId = "claude-haiku-4-5";
-      session.modes.availableModes = session.modes.availableModes.filter(
-        (m: any) => m.id !== "auto",
-      );
-      const modeOpt = session.configOptions.find((o: any) => o.id === "mode");
-      modeOpt.options = session.modes.availableModes.map((m: any) => ({
-        value: m.id,
-        name: m.name,
-        description: m.description,
-      }));
 
       const response = await agent.setSessionConfigOption({
         sessionId: SESSION_ID,
@@ -1181,8 +1129,8 @@ describe("session config options", () => {
       expect((modeOption as any).currentValue).toBe("plan");
     });
 
-    it("clamps mode and emits current_mode_update via setSessionConfigOption(model)", async () => {
-      // Switching Opus(auto) → Haiku clamps the mode to "default". The
+    it("falls back to Accept edits and emits current_mode_update on a Haiku switch", async () => {
+      // Switching Opus(auto) → Haiku changes only the effective mode. The
       // `current_mode_update` side effect must fire so clients learn about the
       // clamp even though the request/response API returns the new
       // configOptions rather than emitting a config_option_update.
@@ -1194,13 +1142,13 @@ describe("session config options", () => {
         value: "claude-haiku-4-5",
       });
 
-      expect(setPermissionModeSpy).toHaveBeenCalledWith("default");
+      expect(setPermissionModeSpy).toHaveBeenCalledWith("acceptEdits");
 
       const modeUpdates = sessionUpdates.filter(
         (n) => n.update.sessionUpdate === "current_mode_update",
       );
       expect(modeUpdates).toHaveLength(1);
-      expect((modeUpdates[0].update as any).currentModeId).toBe("default");
+      expect((modeUpdates[0].update as any).currentModeId).toBe("acceptEdits");
 
       // setSessionConfigOption is a request/response API: it returns the new
       // configOptions in the response rather than emitting a
@@ -1212,77 +1160,16 @@ describe("session config options", () => {
 
       const modeOption = response.configOptions.find((o: any) => o.id === "mode");
       expect(modeOption).toBeDefined();
-      expect((modeOption as any).currentValue).toBe("default");
-      expect((modeOption as any).options.map((o: any) => o.value)).not.toContain("auto");
-    });
-
-    it("rejects direct setSessionMode to `auto` when the active model does not offer it", async () => {
-      const session = setupHaikuOpusSession("default");
-      session.models.currentModelId = "claude-haiku-4-5";
-      session.modes.availableModes = session.modes.availableModes.filter(
-        (mode: any) => mode.id !== "auto",
-      );
-
-      await expect(agent.setSessionMode({ sessionId: SESSION_ID, modeId: "auto" })).rejects.toThrow(
-        "Mode auto is not available in this session",
-      );
-
-      expect(setPermissionModeSpy).not.toHaveBeenCalledWith("auto");
-      expect(sessionUpdates).toHaveLength(0);
-    });
-  });
-
-  describe("ExitPlanMode permission updates", () => {
-    let capturedPermissionRequest: any;
-    let permissionResponse: any;
-
-    beforeEach(() => {
-      capturedPermissionRequest = null;
-      permissionResponse = { outcome: { outcome: "cancelled" } };
-      // Replace the default mock client with one that captures the
-      // requestPermission call so we can assert on the offered options.
-      (agent as any).client = {
-        sessionUpdate: async (notification: SessionNotification) => {
-          sessionUpdates.push(notification);
-        },
-        requestPermission: async (params: any) => {
-          capturedPermissionRequest = params;
-          return permissionResponse;
-        },
-        readTextFile: async () => ({ content: "" }),
-        writeTextFile: async () => ({}),
-      };
-      populateSession();
-    });
-
-    it("maps an ExitPlanMode choice to the selected session mode effect", async () => {
-      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
-      session.modes = { ...session.modes, currentModeId: "plan" };
-      session.emittedToolCalls.add("toolu_1");
-      permissionResponse = { outcome: { outcome: "selected", optionId: "exit-plan-default" } };
-      const result = await (agent as any).canUseTool(SESSION_ID)(
-        "ExitPlanMode",
-        { plan: "do stuff" },
-        {
-          signal: new AbortController().signal,
-          toolUseID: "toolu_1",
-        },
-      );
-
-      expect(capturedPermissionRequest.options.map((option: any) => option.optionId)).toEqual([
-        "exit-plan-default",
-        "exit-plan-clear-accept-edits",
-        "exit-plan-accept-edits",
-        "reject",
-      ]);
-      expect(capturedPermissionRequest._meta).toEqual({
-        permission: { version: 1, title: "Ready to code?" },
-      });
-      expect(result.updatedPermissions).toEqual([
-        { type: "setMode", mode: "default", destination: "session" },
-      ]);
-      expect(session.modes.currentModeId).toBe("plan");
-      expect(sessionUpdates).toHaveLength(0);
+      expect((modeOption as any).currentValue).toBe("acceptEdits");
+      expect((modeOption as any).options.map((o: any) => o.value)).toContain("auto");
+      expect(
+        sessionUpdates.filter(
+          (n) =>
+            n.update.sessionUpdate === "agent_message_chunk" &&
+            n.update.content.type === "text" &&
+            n.update.content.text.includes("Auto mode unavailable"),
+        ),
+      ).toHaveLength(1);
     });
   });
 });

--- a/src/tests/session-mode.test.ts
+++ b/src/tests/session-mode.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { AUTO_MODE_FALLBACK, type SessionMode, SessionModeManager } from "../session-mode.js";
+
+const SESSION_ID = "session-1";
+
+function createSession(overrides: Partial<SessionMode> = {}): SessionMode {
+  return {
+    query: { setPermissionMode: vi.fn() },
+    modes: {
+      currentModeId: "default",
+      availableModes: [
+        { id: "default", name: "Manual" },
+        { id: "acceptEdits", name: "Accept edits" },
+        { id: "plan", name: "Plan" },
+        { id: "auto", name: "Auto" },
+      ],
+    },
+    models: { currentModelId: "opus" },
+    modelInfos: [{ value: "opus", displayName: "Opus", description: "", supportsAutoMode: true }],
+    ...overrides,
+  };
+}
+
+function createNotifications(updates: SessionNotification[]) {
+  return {
+    sessionUpdate: vi.fn(async (update: SessionNotification) => {
+      updates.push(update);
+    }),
+    logError: vi.fn(),
+  };
+}
+
+function createManager(session: SessionMode | undefined, updates: SessionNotification[] = []) {
+  const notifications = createNotifications(updates);
+  const updateConfigOption = vi.fn();
+  const manager = new SessionModeManager({
+    ...notifications,
+    getSession: () => session,
+    sessionEndedMessage: "start a new session",
+    updateConfigOption,
+  });
+  return { manager, notifications, updateConfigOption };
+}
+
+describe("session mode", () => {
+  it("applies a valid mode to the SDK query", async () => {
+    const session = createSession();
+    const { manager } = createManager(session);
+    await expect(manager.selectMode(SESSION_ID, "plan")).resolves.toBe("plan");
+    expect(session.query.setPermissionMode).toHaveBeenCalledWith("plan");
+  });
+
+  it("rejects invalid and unavailable modes before touching the query", async () => {
+    const session = createSession();
+    const { manager } = createManager(session);
+    await expect(manager.selectMode(SESSION_ID, "future")).rejects.toThrow("Invalid Mode");
+    await expect(manager.selectMode(SESSION_ID, "bypassPermissions")).rejects.toThrow(
+      "Mode bypassPermissions is not available in this session",
+    );
+    expect(session.query.setPermissionMode).not.toHaveBeenCalled();
+  });
+
+  it("detects model-specific Auto availability", () => {
+    const session = createSession({
+      modelInfos: [
+        { value: "opus", displayName: "Opus", description: "", supportsAutoMode: true },
+        { value: "haiku", displayName: "Haiku", description: "" },
+      ],
+    });
+    const { manager } = createManager(session);
+    expect(manager.effectiveMode(session, "auto")).toBe("auto");
+    session.models.currentModelId = "haiku";
+    expect(manager.effectiveMode(session, "auto")).toBe("acceptEdits");
+    session.models.currentModelId = "unknown";
+    expect(manager.effectiveMode(session, "auto")).toBe("auto");
+  });
+
+  it("falls Auto back to Accept edits and warns only once per session", async () => {
+    const updates: SessionNotification[] = [];
+    const session = createSession({
+      models: { currentModelId: "haiku" },
+      modelInfos: [{ value: "haiku", displayName: "Haiku", description: "" }],
+    });
+    const { manager } = createManager(session, updates);
+
+    await expect(manager.selectMode(SESSION_ID, "auto")).resolves.toBe(AUTO_MODE_FALLBACK);
+    await manager.selectMode(SESSION_ID, "auto");
+
+    expect(session.query.setPermissionMode).toHaveBeenCalledTimes(2);
+    expect(session.query.setPermissionMode).toHaveBeenCalledWith("acceptEdits");
+    expect(
+      updates.filter((notification) => notification.update.sessionUpdate === "agent_message_chunk"),
+    ).toHaveLength(1);
+  });
+
+  it("handles setSessionMode and publishes the updated config option", async () => {
+    const updates: SessionNotification[] = [];
+    const session = createSession();
+    const { manager, notifications, updateConfigOption } = createManager(session, updates);
+
+    await manager.setSessionMode({ sessionId: SESSION_ID, modeId: "plan" });
+
+    expect(updateConfigOption).toHaveBeenCalledWith(SESSION_ID, "mode", "plan");
+    expect(notifications.sessionUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ sessionUpdate: "current_mode_update" }),
+      }),
+    );
+  });
+
+  it("rejects missing and closed sessions", async () => {
+    await expect(
+      createManager(undefined).manager.setSessionMode({ sessionId: SESSION_ID, modeId: "plan" }),
+    ).rejects.toThrow("Session not found");
+
+    await expect(
+      createManager(createSession({ queryClosed: true })).manager.setSessionMode({
+        sessionId: SESSION_ID,
+        modeId: "plan",
+      }),
+    ).rejects.toThrow("start a new session");
+  });
+
+  it("initializes the stable mode catalog and falls unsupported Auto back", async () => {
+    const setPermissionMode = vi.fn();
+    const { manager, notifications } = createManager(undefined);
+    const result = await manager.initialize({
+      query: { setPermissionMode },
+      requestedMode: "auto",
+      currentModelInfo: { value: "haiku", displayName: "Haiku", description: "" },
+      currentModelId: "haiku",
+    });
+
+    expect(result.modes.currentModeId).toBe("acceptEdits");
+    expect(result.modes.availableModes.map((mode) => mode.id)).toEqual(
+      expect.arrayContaining(["default", "acceptEdits", "plan", "auto"]),
+    );
+    expect(result.autoModeFallbackWarningPending).toBe(true);
+    expect(setPermissionMode).toHaveBeenCalledWith("acceptEdits");
+    expect(notifications.logError).toHaveBeenCalledWith(expect.stringContaining("falling back"));
+  });
+
+  it("keeps mode state and its config option synchronized", () => {
+    const session = {
+      ...createSession(),
+      configOptions: [SessionModeManager.configOption(createSession().modes)],
+    };
+    createManager(session).manager.syncConfig(session, "plan");
+
+    expect(session.modes.currentModeId).toBe("plan");
+    expect(session.configOptions[0].currentValue).toBe("plan");
+  });
+
+  it("reconciles Auto after a model switch", async () => {
+    const session = createSession();
+    session.modes.currentModeId = "auto";
+    const { manager } = createManager(session);
+
+    await expect(
+      manager.reconcileForModel(session, {
+        value: "haiku",
+        displayName: "Haiku",
+        description: "",
+      }),
+    ).resolves.toBe(true);
+    expect(session.modes.currentModeId).toBe("acceptEdits");
+    expect(session.query.setPermissionMode).toHaveBeenCalledWith("acceptEdits");
+  });
+});

--- a/src/tests/session-permission.test.ts
+++ b/src/tests/session-permission.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { ClaudeAcpAgent, type AcpClient } from "../acp-agent.js";
+import { makeMockQuery } from "./helpers.js";
+
+const SESSION_ID = "test-session-id";
+
+describe("session permission updates", () => {
+  let agent: ClaudeAcpAgent;
+  let capturedPermissionRequest: any;
+  let permissionResponse: any;
+  let sessionUpdates: SessionNotification[];
+
+  beforeEach(() => {
+    capturedPermissionRequest = null;
+    permissionResponse = { outcome: { outcome: "cancelled" } };
+    sessionUpdates = [];
+    const client = {
+      sessionUpdate: async (notification: SessionNotification) => {
+        sessionUpdates.push(notification);
+      },
+      requestPermission: async (params: any) => {
+        capturedPermissionRequest = params;
+        return permissionResponse;
+      },
+      readTextFile: async () => ({ content: "" }),
+      writeTextFile: async () => ({}),
+    } as unknown as AcpClient;
+    agent = new ClaudeAcpAgent(client);
+
+    agent.sessions[SESSION_ID] = {
+      query: makeMockQuery(),
+      cwd: process.cwd(),
+      modes: {
+        currentModeId: "plan",
+        availableModes: [
+          { id: "default", name: "Manual" },
+          { id: "acceptEdits", name: "Accept edits" },
+          { id: "plan", name: "Plan" },
+        ],
+      },
+      models: { currentModelId: "opus", availableModels: [] },
+      modelInfos: [],
+      configOptions: [],
+      emittedToolCalls: new Set(["toolu_1"]),
+      contextWindowSize: 200_000,
+      toolUseCache: {},
+    } as any;
+  });
+
+  it("maps an ExitPlanMode choice to the selected session mode effect", async () => {
+    permissionResponse = { outcome: { outcome: "selected", optionId: "exit-plan-default" } };
+
+    const result = await (agent as any).canUseTool(SESSION_ID)(
+      "ExitPlanMode",
+      { plan: "do stuff" },
+      { signal: new AbortController().signal, toolUseID: "toolu_1" },
+    );
+
+    expect(capturedPermissionRequest.options.map((option: any) => option.optionId)).toEqual([
+      "exit-plan-default",
+      "exit-plan-clear-accept-edits",
+      "exit-plan-accept-edits",
+      "reject",
+    ]);
+    expect(capturedPermissionRequest._meta).toEqual({
+      permission: { version: 1, title: "Ready to code?" },
+    });
+    expect(result.updatedPermissions).toEqual([
+      { type: "setMode", mode: "default", destination: "session" },
+    ]);
+    expect(agent.sessions[SESSION_ID].modes.currentModeId).toBe("plan");
+    expect(sessionUpdates).toHaveLength(0);
+  });
+
+  it("falls an Auto permission effect back when the current model cannot use Auto", async () => {
+    const session = agent.sessions[SESSION_ID];
+    session.modes.availableModes.push({ id: "auto", name: "Auto" });
+    session.models.currentModelId = "haiku";
+    session.modelInfos = [{ value: "haiku", displayName: "Haiku", description: "" }];
+    permissionResponse = { outcome: { outcome: "selected", optionId: "exit-plan-auto" } };
+
+    const result = await (agent as any).canUseTool(SESSION_ID)(
+      "ExitPlanMode",
+      { plan: "do stuff" },
+      { signal: new AbortController().signal, toolUseID: "toolu_1" },
+    );
+
+    expect(result.updatedPermissions).toEqual([
+      { type: "setMode", mode: "acceptEdits", destination: "session" },
+    ]);
+    expect(
+      sessionUpdates.filter(
+        (notification) => notification.update.sessionUpdate === "agent_message_chunk",
+      ),
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- expose semantic permission mode kinds through ACP mode metadata
- extract session mode policy and synchronization into a dedicated manager
- cover mode initialization, selection, fallback, and permission integration

## Tests

- `npm run check`
- `npm run build`
- `env -u ANTHROPIC_BASE_URL npm run test:run` (971 passed, 27 skipped)