### PR TITLE
Fix replay of forked session history

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -150,7 +150,12 @@ import {
   isFileChangeAuditTool,
   supportsAgentFileChangeReport,
 } from "./file-change-audit.js";
-import { ForkHistoryStore, forkedSessionHistory, forkResumeTarget } from "./fork-history.js";
+import {
+  ForkHistoryStore,
+  forkedSessionHistory,
+  forkPointResumeTarget,
+  forkResumeTarget,
+} from "./fork-history.js";
 import {
   applyTaskCreate,
   applyTaskList,
@@ -755,8 +760,9 @@ type Session = {
    *  naturally yields the turn-boundary uuid when one `msg_…` spans several
    *  content-block messages.
    *
-   *  NOT READ YET — recorded now so the mapping exists if/when we wire up
-   *  fork/rewind. */
+   *  Point forks also need to identify the persisted session that owns an
+   *  inherited message, so they use the durable fork lineage rather than this
+   *  per-process cache. */
   messageIdToUuid: Map<string, string>;
   /** Durable-for-this-consumer failure state shared with session/load replay.
    *  Keeping it on the Session lets replay seed a failure that the persistent
@@ -1735,21 +1741,36 @@ export class ClaudeAcpAgent {
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
-    const branchPoint = forkBranchPoint(params);
+    // Keep the ACP message id as the durable display boundary. Claude's SDK
+    // accepts only its own message uuid in resumeSessionAt, so resolve that
+    // separately (and through inherited fork history when necessary).
+    const displayBranchPoint = forkBranchPoint(params);
     const resumeTarget = await forkResumeTarget(
       params.sessionId,
       this.forkHistory,
       getSessionMessages,
     );
+    const requestedPoint = displayBranchPoint ?? resumeTarget.branchPoint;
+    const pointResumeTarget = requestedPoint
+      ? await forkPointResumeTarget(
+          params.sessionId,
+          requestedPoint,
+          this.forkHistory,
+          getSessionMessages,
+          messageIdForGrouping,
+          (message) =>
+            typeof message.uuid === "string" && message.uuid.length > 0 ? message.uuid : undefined,
+        )
+      : undefined;
     const response = await this.createSession(
       {
         cwd: params.cwd,
         mcpServers: params.mcpServers ?? [],
         additionalDirectories: params.additionalDirectories,
-        _meta: forkMeta(params, branchPoint ?? resumeTarget.branchPoint),
+        _meta: forkMeta(params, pointResumeTarget?.messageUuid),
       },
       {
-        resume: resumeTarget.sessionId,
+        resume: pointResumeTarget?.sessionId ?? resumeTarget.sessionId,
         forkSession: true,
       },
     );
@@ -1757,7 +1778,7 @@ export class ClaudeAcpAgent {
       await this.forkHistory.record({
         sessionId: response.sessionId,
         parentSessionId: params.sessionId,
-        branchPoint,
+        branchPoint: displayBranchPoint,
       });
     } catch (error) {
       // A fork without its lineage would execute with the right model context but

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -150,6 +150,7 @@ import {
   isFileChangeAuditTool,
   supportsAgentFileChangeReport,
 } from "./file-change-audit.js";
+import { ForkHistoryStore, forkedSessionHistory } from "./fork-history.js";
 import {
   applyTaskCreate,
   applyTaskList,
@@ -172,6 +173,8 @@ import { nodeToWebReadable, nodeToWebWritable, Pushable, unreachable } from "./u
 
 export const CLAUDE_CONFIG_DIR =
   process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
+
+const FORK_HISTORY_DIRECTORY = path.join(CLAUDE_CONFIG_DIR, "acp-forks");
 
 const execFileAsync = promisify(execFile);
 
@@ -866,6 +869,12 @@ export type NewSessionMeta = {
   additionalRoots?: string[];
 };
 
+function forkBranchPoint(params: ForkSessionRequest): string | undefined {
+  const branchPoint = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options
+    ?.resumeSessionAt;
+  return typeof branchPoint === "string" && branchPoint.length > 0 ? branchPoint : undefined;
+}
+
 /**
  * Extra metadata for 'gateway' authentication requests.
  */
@@ -1511,6 +1520,8 @@ export class ClaudeAcpAgent {
   providerConfig?: ProviderConfig;
   /** Serializes provider changes while every open query is recreated between turns. */
   private providerUpdate: Promise<void> | null = null;
+  /** Durable fork-to-parent links used to reconstruct forked transcripts on load. */
+  private readonly forkHistory = new ForkHistoryStore(FORK_HISTORY_DIRECTORY);
   /** Grace period before a `session/cancel` forces a wedged prompt loop to
    *  return "cancelled". See {@link DEFAULT_FORCE_CANCEL_GRACE_MS}. Mutable so
    *  tests can shrink it. */
@@ -1718,6 +1729,20 @@ export class ClaudeAcpAgent {
         forkSession: true,
       },
     );
+    try {
+      await this.forkHistory.record({
+        sessionId: response.sessionId,
+        parentSessionId: params.sessionId,
+        branchPoint: forkBranchPoint(params),
+      });
+    } catch (error) {
+      // A fork without its lineage would execute with the right model context but
+      // reopen as an empty transcript. Do not return a session we cannot reload
+      // faithfully; clean up the newly-created SDK session before surfacing the error.
+      await this.teardownSession(response.sessionId);
+      await deleteSession(response.sessionId).catch(() => {});
+      throw error;
+    }
     // Needs to happen after we return the session
     setTimeout(() => {
       this.sendAvailableCommandsUpdate(response.sessionId);
@@ -5000,6 +5025,7 @@ export class ClaudeAcpAgent {
       await this.teardownSession(params.sessionId);
     }
     await deleteSession(params.sessionId);
+    await this.forkHistory.remove(params.sessionId);
     return {};
   }
 
@@ -5160,7 +5186,12 @@ export class ClaudeAcpAgent {
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
     const toolUseCache: ToolUseCache = {};
-    const messages = await getSessionMessages(sessionId);
+    const messages = await forkedSessionHistory(
+      sessionId,
+      this.forkHistory,
+      getSessionMessages,
+      messageIdForGrouping,
+    );
     const session = this.sessions[sessionId];
     const forwardSubagentText =
       session?.forwardSubagentText ?? supportsSubagentTranscript(this.clientCapabilities);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -150,7 +150,7 @@ import {
   isFileChangeAuditTool,
   supportsAgentFileChangeReport,
 } from "./file-change-audit.js";
-import { ForkHistoryStore, forkedSessionHistory } from "./fork-history.js";
+import { ForkHistoryStore, forkedSessionHistory, forkResumeTarget } from "./fork-history.js";
 import {
   applyTaskCreate,
   applyTaskList,
@@ -873,6 +873,24 @@ function forkBranchPoint(params: ForkSessionRequest): string | undefined {
   const branchPoint = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options
     ?.resumeSessionAt;
   return typeof branchPoint === "string" && branchPoint.length > 0 ? branchPoint : undefined;
+}
+
+function forkMeta(
+  params: ForkSessionRequest,
+  branchPoint: string | undefined,
+): ForkSessionRequest["_meta"] {
+  if (!branchPoint) return params._meta;
+  const meta = params._meta as NewSessionMeta | undefined;
+  return {
+    ...meta,
+    claudeCode: {
+      ...meta?.claudeCode,
+      options: {
+        ...meta?.claudeCode?.options,
+        resumeSessionAt: branchPoint,
+      },
+    },
+  };
 }
 
 /**
@@ -1717,15 +1735,21 @@ export class ClaudeAcpAgent {
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
+    const branchPoint = forkBranchPoint(params);
+    const resumeTarget = await forkResumeTarget(
+      params.sessionId,
+      this.forkHistory,
+      getSessionMessages,
+    );
     const response = await this.createSession(
       {
         cwd: params.cwd,
         mcpServers: params.mcpServers ?? [],
         additionalDirectories: params.additionalDirectories,
-        _meta: params._meta,
+        _meta: forkMeta(params, branchPoint ?? resumeTarget.branchPoint),
       },
       {
-        resume: params.sessionId,
+        resume: resumeTarget.sessionId,
         forkSession: true,
       },
     );
@@ -1733,7 +1757,7 @@ export class ClaudeAcpAgent {
       await this.forkHistory.record({
         sessionId: response.sessionId,
         parentSessionId: params.sessionId,
-        branchPoint: forkBranchPoint(params),
+        branchPoint,
       });
     } catch (error) {
       // A fork without its lineage would execute with the right model context but

--- a/src/fork-history.ts
+++ b/src/fork-history.ts
@@ -21,6 +21,16 @@ export type ForkResumeTarget = {
 };
 
 /**
+ * The persisted Claude session and SDK message uuid to use for a point fork.
+ * `branchPoint` itself remains the client-visible message id so the display
+ * transcript can still be reconstructed independently of Claude's SDK ids.
+ */
+export type ForkPointResumeTarget = {
+  sessionId: string;
+  messageUuid: string;
+};
+
+/**
  * Stores one file per fork. Separate files make concurrent ACP processes safe:
  * a new fork never needs to rewrite another process's lineage record.
  */
@@ -100,6 +110,31 @@ export async function forkResumeTarget<Message>(
   return resumeTargetFor(sessionId, store, readMessages, new Set());
 }
 
+/**
+ * Resolves a client-visible fork boundary to the session which owns it and to
+ * the SDK uuid Claude expects in `resumeSessionAt`. A visible fork transcript
+ * can contain inherited messages, so looking only in the immediate session is
+ * insufficient: Claude cannot resume that session at a parent message id.
+ */
+export async function forkPointResumeTarget<Message>(
+  sessionId: string,
+  branchPoint: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+  messageId: (message: Message) => string | undefined,
+  messageUuid: (message: Message) => string | undefined,
+): Promise<ForkPointResumeTarget> {
+  return pointResumeTargetFor(
+    sessionId,
+    branchPoint,
+    store,
+    readMessages,
+    messageId,
+    messageUuid,
+    new Set(),
+  );
+}
+
 async function historyFor<Message>(
   sessionId: string,
   store: ForkHistoryStore,
@@ -154,6 +189,61 @@ async function resumeTargetFor<Message>(
 
     const inherited = await resumeTargetFor(lineage.parentSessionId, store, readMessages, visiting);
     return lineage.branchPoint ? { ...inherited, branchPoint: lineage.branchPoint } : inherited;
+  } finally {
+    visiting.delete(sessionId);
+  }
+}
+
+async function pointResumeTargetFor<Message>(
+  sessionId: string,
+  branchPoint: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+  messageId: (message: Message) => string | undefined,
+  messageUuid: (message: Message) => string | undefined,
+  visiting: Set<string>,
+): Promise<ForkPointResumeTarget> {
+  if (visiting.has(sessionId)) {
+    throw new Error(`Fork lineage contains a cycle at session ${sessionId}`);
+  }
+  visiting.add(sessionId);
+  try {
+    const [lineage, ownMessages] = await Promise.all([
+      store.read(sessionId),
+      readMessages(sessionId),
+    ]);
+
+    // A single Claude turn can yield several persisted records with the same
+    // ACP grouping id. Last-write-wins matches the adapter's live/replay map
+    // and selects the final, resumable record for that turn.
+    let matchingMessage: Message | undefined;
+    for (const message of ownMessages) {
+      if (messageId(message) === branchPoint) matchingMessage = message;
+    }
+    if (matchingMessage) {
+      const uuid = messageUuid(matchingMessage);
+      if (!uuid) {
+        throw new Error(
+          `Fork boundary ${branchPoint} in session ${sessionId} has no SDK message uuid`,
+        );
+      }
+      return { sessionId, messageUuid: uuid };
+    }
+
+    if (!lineage) {
+      throw new Error(
+        `Fork boundary ${branchPoint} is absent from session ${sessionId} and its ancestors`,
+      );
+    }
+    return pointResumeTargetFor(
+      lineage.parentSessionId,
+      branchPoint,
+      store,
+      readMessages,
+      messageId,
+      messageUuid,
+      visiting,
+    );
   } finally {
     visiting.delete(sessionId);
   }

--- a/src/fork-history.ts
+++ b/src/fork-history.ts
@@ -12,6 +12,15 @@ export type ForkLineage = {
 };
 
 /**
+ * The Claude session to resume when creating a fork. A newborn fork has no
+ * Claude transcript of its own yet, so its id cannot be resumed directly.
+ */
+export type ForkResumeTarget = {
+  sessionId: string;
+  branchPoint?: string;
+};
+
+/**
  * Stores one file per fork. Separate files make concurrent ACP processes safe:
  * a new fork never needs to rewrite another process's lineage record.
  */
@@ -78,6 +87,19 @@ export async function forkedSessionHistory<Message>(
   return historyFor(sessionId, store, readMessages, messageId, new Set());
 }
 
+/**
+ * Resolves an empty fork back to the closest session Claude can actually
+ * resume. The returned boundary keeps the model context identical to the
+ * inherited display transcript, including through several empty forks.
+ */
+export async function forkResumeTarget<Message>(
+  sessionId: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+): Promise<ForkResumeTarget> {
+  return resumeTargetFor(sessionId, store, readMessages, new Set());
+}
+
 async function historyFor<Message>(
   sessionId: string,
   store: ForkHistoryStore,
@@ -107,6 +129,31 @@ async function historyFor<Message>(
       ? inheritedThrough(inherited, lineage.branchPoint, messageId, sessionId)
       : inherited;
     return [...prefix, ...ownMessages];
+  } finally {
+    visiting.delete(sessionId);
+  }
+}
+
+async function resumeTargetFor<Message>(
+  sessionId: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+  visiting: Set<string>,
+): Promise<ForkResumeTarget> {
+  if (visiting.has(sessionId)) {
+    throw new Error(`Fork lineage contains a cycle at session ${sessionId}`);
+  }
+  visiting.add(sessionId);
+  try {
+    const [lineage, ownMessages] = await Promise.all([
+      store.read(sessionId),
+      readMessages(sessionId),
+    ]);
+
+    if (!lineage || ownMessages.length > 0) return { sessionId };
+
+    const inherited = await resumeTargetFor(lineage.parentSessionId, store, readMessages, visiting);
+    return lineage.branchPoint ? { ...inherited, branchPoint: lineage.branchPoint } : inherited;
   } finally {
     visiting.delete(sessionId);
   }

--- a/src/fork-history.ts
+++ b/src/fork-history.ts
@@ -1,0 +1,143 @@
+import { createHash, randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/** The durable relationship between a fork and the transcript it inherited. */
+export type ForkLineage = {
+  version: 1;
+  sessionId: string;
+  parentSessionId: string;
+  /** The final inherited transcript entry, if the fork has a branch point. */
+  branchPoint?: string;
+};
+
+/**
+ * Stores one file per fork. Separate files make concurrent ACP processes safe:
+ * a new fork never needs to rewrite another process's lineage record.
+ */
+export class ForkHistoryStore {
+  constructor(private readonly directory: string) {}
+
+  async record(lineage: Omit<ForkLineage, "version">): Promise<void> {
+    await fs.mkdir(this.directory, { recursive: true });
+    const destination = this.fileFor(lineage.sessionId);
+    const temporary = path.join(
+      this.directory,
+      `.${path.basename(destination)}.${randomUUID()}.tmp`,
+    );
+    const contents = JSON.stringify({ version: 1, ...lineage } satisfies ForkLineage) + "\n";
+
+    try {
+      await fs.writeFile(temporary, contents, { encoding: "utf8", mode: 0o600 });
+      await fs.rename(temporary, destination);
+    } finally {
+      await fs.rm(temporary, { force: true }).catch(() => {});
+    }
+  }
+
+  async read(sessionId: string): Promise<ForkLineage | undefined> {
+    let contents: string;
+    try {
+      contents = await fs.readFile(this.fileFor(sessionId), "utf8");
+    } catch (error) {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contents);
+    } catch {
+      return undefined;
+    }
+    if (!isForkLineage(parsed) || parsed.sessionId !== sessionId) return undefined;
+    return parsed;
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    await fs.rm(this.fileFor(sessionId), { force: true });
+  }
+
+  private fileFor(sessionId: string): string {
+    const digest = createHash("sha256").update(sessionId).digest("hex");
+    return path.join(this.directory, `${digest}.json`);
+  }
+}
+
+/**
+ * Reconstructs the display transcript of a fork. Claude keeps only the new
+ * branch's entries under the new session id, so a reload must prepend the
+ * inherited prefix itself. The result is also correct for nested forks.
+ */
+export async function forkedSessionHistory<Message>(
+  sessionId: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+  messageId: (message: Message) => string | undefined,
+): Promise<Message[]> {
+  return historyFor(sessionId, store, readMessages, messageId, new Set());
+}
+
+async function historyFor<Message>(
+  sessionId: string,
+  store: ForkHistoryStore,
+  readMessages: (sessionId: string) => Promise<Message[]>,
+  messageId: (message: Message) => string | undefined,
+  visiting: Set<string>,
+): Promise<Message[]> {
+  if (visiting.has(sessionId)) {
+    throw new Error(`Fork lineage contains a cycle at session ${sessionId}`);
+  }
+  visiting.add(sessionId);
+  try {
+    const [lineage, ownMessages] = await Promise.all([
+      store.read(sessionId),
+      readMessages(sessionId),
+    ]);
+    if (!lineage) return ownMessages;
+
+    const inherited = await historyFor(
+      lineage.parentSessionId,
+      store,
+      readMessages,
+      messageId,
+      visiting,
+    );
+    const prefix = lineage.branchPoint
+      ? inheritedThrough(inherited, lineage.branchPoint, messageId, sessionId)
+      : inherited;
+    return [...prefix, ...ownMessages];
+  } finally {
+    visiting.delete(sessionId);
+  }
+}
+
+function inheritedThrough<Message>(
+  messages: Message[],
+  branchPoint: string,
+  messageId: (message: Message) => string | undefined,
+  sessionId: string,
+): Message[] {
+  const boundary = messages.findIndex((message) => messageId(message) === branchPoint);
+  if (boundary < 0) {
+    throw new Error(
+      `Fork ${sessionId} refers to message ${branchPoint}, which is absent from its parent history`,
+    );
+  }
+  return messages.slice(0, boundary + 1);
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function isForkLineage(value: unknown): value is ForkLineage {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.version === 1 &&
+    typeof record.sessionId === "string" &&
+    typeof record.parentSessionId === "string" &&
+    (record.branchPoint === undefined || typeof record.branchPoint === "string")
+  );
+}

--- a/src/fork-history.ts
+++ b/src/fork-history.ts
@@ -255,7 +255,14 @@ function inheritedThrough<Message>(
   messageId: (message: Message) => string | undefined,
   sessionId: string,
 ): Message[] {
-  const boundary = messages.findIndex((message) => messageId(message) === branchPoint);
+  // One completed assistant turn can be persisted as several records sharing
+  // its ACP grouping id (thinking, tool calls, then its final text). The fork
+  // boundary is after that turn, so retain every matching record rather than
+  // stopping at the first one.
+  let boundary = -1;
+  for (let index = 0; index < messages.length; index += 1) {
+    if (messageId(messages[index]) === branchPoint) boundary = index;
+  }
   if (boundary < 0) {
     throw new Error(
       `Fork ${sessionId} refers to message ${branchPoint}, which is absent from its parent history`,

--- a/src/tests/fork-history.test.ts
+++ b/src/tests/fork-history.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ForkHistoryStore, forkedSessionHistory } from "../fork-history.js";
+
+type Message = { id: string; text: string };
+
+const temporaryDirectories: string[] = [];
+
+async function store(): Promise<ForkHistoryStore> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "claude-acp-fork-history-"));
+  temporaryDirectories.push(directory);
+  return new ForkHistoryStore(directory);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function history(
+  sessionId: string,
+  lineages: ForkHistoryStore,
+  transcripts: Record<string, Message[]>,
+): Promise<Message[]> {
+  return forkedSessionHistory(
+    sessionId,
+    lineages,
+    async (id) => transcripts[id] ?? [],
+    (message) => message.id,
+  );
+}
+
+describe("fork history", () => {
+  it("prepends a full parent transcript and keeps the fork's later messages", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "fork", parentSessionId: "parent" });
+
+    await expect(
+      history("fork", lineages, {
+        parent: [
+          { id: "u1", text: "first" },
+          { id: "a1", text: "first answer" },
+        ],
+        fork: [{ id: "u2", text: "new branch prompt" }],
+      }),
+    ).resolves.toEqual([
+      { id: "u1", text: "first" },
+      { id: "a1", text: "first answer" },
+      { id: "u2", text: "new branch prompt" },
+    ]);
+  });
+
+  it("stops a point fork at the selected inherited message", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "fork", parentSessionId: "parent", branchPoint: "u2" });
+
+    await expect(
+      history("fork", lineages, {
+        parent: [
+          { id: "u1", text: "first" },
+          { id: "a1", text: "first answer" },
+          { id: "u2", text: "try another approach" },
+          { id: "a2", text: "old answer that is not inherited" },
+        ],
+        fork: [{ id: "a3", text: "new branch answer" }],
+      }),
+    ).resolves.toEqual([
+      { id: "u1", text: "first" },
+      { id: "a1", text: "first answer" },
+      { id: "u2", text: "try another approach" },
+      { id: "a3", text: "new branch answer" },
+    ]);
+  });
+
+  it("resolves a point fork from a previously forked session", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "first-fork", parentSessionId: "root" });
+    await lineages.record({
+      sessionId: "second-fork",
+      parentSessionId: "first-fork",
+      branchPoint: "u2",
+    });
+
+    await expect(
+      history("second-fork", lineages, {
+        root: [{ id: "u1", text: "root prompt" }],
+        "first-fork": [
+          { id: "a1", text: "root answer" },
+          { id: "u2", text: "fork prompt" },
+          { id: "a2", text: "fork answer not inherited" },
+        ],
+        "second-fork": [{ id: "a3", text: "second fork answer" }],
+      }),
+    ).resolves.toEqual([
+      { id: "u1", text: "root prompt" },
+      { id: "a1", text: "root answer" },
+      { id: "u2", text: "fork prompt" },
+      { id: "a3", text: "second fork answer" },
+    ]);
+  });
+
+  it("persists the lineage across agent processes", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "claude-acp-fork-history-"));
+    temporaryDirectories.push(directory);
+    const forkId = randomUUID();
+    await new ForkHistoryStore(directory).record({
+      sessionId: forkId,
+      parentSessionId: "parent",
+      branchPoint: "u1",
+    });
+
+    await expect(new ForkHistoryStore(directory).read(forkId)).resolves.toEqual({
+      version: 1,
+      sessionId: forkId,
+      parentSessionId: "parent",
+      branchPoint: "u1",
+    });
+  });
+
+  it("removes the lineage when its forked session is deleted", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "fork", parentSessionId: "parent" });
+    await expect(lineages.read("fork")).resolves.toEqual({
+      version: 1,
+      sessionId: "fork",
+      parentSessionId: "parent",
+    });
+    await lineages.remove("fork");
+    await expect(lineages.read("fork")).resolves.toBeUndefined();
+  });
+});

--- a/src/tests/fork-history.test.ts
+++ b/src/tests/fork-history.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ForkHistoryStore, forkedSessionHistory } from "../fork-history.js";
+import { ForkHistoryStore, forkedSessionHistory, forkResumeTarget } from "../fork-history.js";
 
 type Message = { id: string; text: string };
 
@@ -34,6 +34,14 @@ async function history(
     async (id) => transcripts[id] ?? [],
     (message) => message.id,
   );
+}
+
+async function resumeTarget(
+  sessionId: string,
+  lineages: ForkHistoryStore,
+  transcripts: Record<string, Message[]>,
+) {
+  return forkResumeTarget(sessionId, lineages, async (id) => transcripts[id] ?? []);
 }
 
 describe("fork history", () => {
@@ -103,6 +111,54 @@ describe("fork history", () => {
       { id: "u2", text: "fork prompt" },
       { id: "a3", text: "second fork answer" },
     ]);
+  });
+
+  it("resumes an empty nested fork through its nearest persisted ancestor", async () => {
+    const lineages = await store();
+    await lineages.record({
+      sessionId: "first-fork",
+      parentSessionId: "root",
+      branchPoint: "a1",
+    });
+    await lineages.record({ sessionId: "second-fork", parentSessionId: "first-fork" });
+
+    await expect(
+      resumeTarget("second-fork", lineages, {
+        root: [
+          { id: "u1", text: "root prompt" },
+          { id: "a1", text: "root answer" },
+        ],
+        "first-fork": [],
+        "second-fork": [],
+      }),
+    ).resolves.toEqual({ sessionId: "root", branchPoint: "a1" });
+  });
+
+  it("uses a new nested point instead of the inherited boundary", async () => {
+    const lineages = await store();
+    await lineages.record({
+      sessionId: "first-fork",
+      parentSessionId: "root",
+      branchPoint: "a2",
+    });
+    await lineages.record({
+      sessionId: "second-fork",
+      parentSessionId: "first-fork",
+      branchPoint: "a1",
+    });
+
+    await expect(
+      resumeTarget("second-fork", lineages, {
+        root: [
+          { id: "u1", text: "root prompt" },
+          { id: "a1", text: "first answer" },
+          { id: "u2", text: "second prompt" },
+          { id: "a2", text: "second answer" },
+        ],
+        "first-fork": [],
+        "second-fork": [],
+      }),
+    ).resolves.toEqual({ sessionId: "root", branchPoint: "a1" });
   });
 
   it("persists the lineage across agent processes", async () => {

--- a/src/tests/fork-history.test.ts
+++ b/src/tests/fork-history.test.ts
@@ -3,9 +3,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { ForkHistoryStore, forkedSessionHistory, forkResumeTarget } from "../fork-history.js";
+import {
+  ForkHistoryStore,
+  forkedSessionHistory,
+  forkPointResumeTarget,
+  forkResumeTarget,
+} from "../fork-history.js";
 
-type Message = { id: string; text: string };
+type Message = { id: string; text: string; uuid?: string };
 
 const temporaryDirectories: string[] = [];
 
@@ -42,6 +47,22 @@ async function resumeTarget(
   transcripts: Record<string, Message[]>,
 ) {
   return forkResumeTarget(sessionId, lineages, async (id) => transcripts[id] ?? []);
+}
+
+async function pointResumeTarget(
+  sessionId: string,
+  branchPoint: string,
+  lineages: ForkHistoryStore,
+  transcripts: Record<string, Message[]>,
+) {
+  return forkPointResumeTarget(
+    sessionId,
+    branchPoint,
+    lineages,
+    async (id) => transcripts[id] ?? [],
+    (message) => message.id,
+    (message) => message.uuid,
+  );
 }
 
 describe("fork history", () => {
@@ -159,6 +180,61 @@ describe("fork history", () => {
         "second-fork": [],
       }),
     ).resolves.toEqual({ sessionId: "root", branchPoint: "a1" });
+  });
+
+  it("resolves an ACP assistant id to the final SDK uuid in its owning session", async () => {
+    const lineages = await store();
+
+    await expect(
+      pointResumeTarget("parent", "msg_answer", lineages, {
+        parent: [
+          { id: "msg_answer", uuid: "thinking-uuid", text: "thinking" },
+          { id: "msg_answer", uuid: "answer-uuid", text: "answer" },
+        ],
+      }),
+    ).resolves.toEqual({ sessionId: "parent", messageUuid: "answer-uuid" });
+  });
+
+  it("finds the owning parent when point-forking an inherited response", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "fork", parentSessionId: "parent" });
+
+    await expect(
+      pointResumeTarget("fork", "msg_parent_answer", lineages, {
+        parent: [{ id: "msg_parent_answer", uuid: "parent-answer-uuid", text: "answer" }],
+        fork: [{ id: "msg_fork_answer", uuid: "fork-answer-uuid", text: "new answer" }],
+      }),
+    ).resolves.toEqual({ sessionId: "parent", messageUuid: "parent-answer-uuid" });
+  });
+
+  it("finds an inherited boundary through empty nested forks", async () => {
+    const lineages = await store();
+    await lineages.record({
+      sessionId: "first-fork",
+      parentSessionId: "root",
+      branchPoint: "msg_root_answer",
+    });
+    await lineages.record({ sessionId: "second-fork", parentSessionId: "first-fork" });
+
+    await expect(
+      pointResumeTarget("second-fork", "msg_root_answer", lineages, {
+        root: [{ id: "msg_root_answer", uuid: "root-answer-uuid", text: "root answer" }],
+        "first-fork": [],
+        "second-fork": [],
+      }),
+    ).resolves.toEqual({ sessionId: "root", messageUuid: "root-answer-uuid" });
+  });
+
+  it("rejects a point absent from the complete fork lineage", async () => {
+    const lineages = await store();
+    await lineages.record({ sessionId: "fork", parentSessionId: "parent" });
+
+    await expect(
+      pointResumeTarget("fork", "msg_missing", lineages, {
+        parent: [{ id: "msg_parent", uuid: "parent-uuid", text: "answer" }],
+        fork: [],
+      }),
+    ).rejects.toThrow("Fork boundary msg_missing is absent from session parent and its ancestors");
   });
 
   it("persists the lineage across agent processes", async () => {

--- a/src/tests/fork-history.test.ts
+++ b/src/tests/fork-history.test.ts
@@ -107,6 +107,32 @@ describe("fork history", () => {
     ]);
   });
 
+  it("keeps every persisted record belonging to the selected assistant turn", async () => {
+    const lineages = await store();
+    await lineages.record({
+      sessionId: "fork",
+      parentSessionId: "parent",
+      branchPoint: "msg_answer",
+    });
+
+    await expect(
+      history("fork", lineages, {
+        parent: [
+          { id: "u1", text: "question" },
+          { id: "msg_answer", text: "tool call" },
+          { id: "msg_answer", text: "final answer" },
+          { id: "u2", text: "later prompt not inherited" },
+        ],
+        fork: [{ id: "u3", text: "alternative prompt" }],
+      }),
+    ).resolves.toEqual([
+      { id: "u1", text: "question" },
+      { id: "msg_answer", text: "tool call" },
+      { id: "msg_answer", text: "final answer" },
+      { id: "u3", text: "alternative prompt" },
+    ]);
+  });
+
   it("resolves a point fork from a previously forked session", async () => {
     const lineages = await store();
     await lineages.record({ sessionId: "first-fork", parentSessionId: "root" });


### PR DESCRIPTION
## Summary
- persist fork lineage separately from Claude session transcripts
- replay inherited history for full and point forks, including nested forks
- resume an empty nested fork from its nearest persisted source session
- remove a fork lineage record with its session

Claude keeps a new fork’s subsequent messages under the new session ID but does not materialize the inherited transcript there. Loading that ID therefore produced an empty ACP transcript even though the model retained the parent context. A nested fork of a newborn fork also cannot resume that unborn Claude session ID, so the adapter now follows lineage to the nearest resumable ancestor and preserves the inherited branch point.

## Tests
- `npm run check`
- `npm run build`
- `npm run test:run -- src/tests/fork-history.test.ts src/tests/acp-agent.test.ts`

`npm test` has one pre-existing failing context-window test on the clean `v0.70.0` tag as well: `session/load seeds the window from the resumed session’s getContextUsage report` expects `888000` but receives `200000`.