### PR TITLE
fix: publish task notifications as typed session failures

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -131,6 +131,7 @@ import {
   type ClaudeFailureKind,
   createSessionFailureState,
   isSyntheticUsageLimitMessage,
+  parseTaskNotification,
   type PublishedSessionFailure,
   providerFailureCategory,
   SessionFailureController,
@@ -3318,6 +3319,11 @@ export class ClaudeAcpAgent {
                 // The task settled — no further tool calls can originate
                 // from it, so its registry entry can be dropped.
                 session.liveBackgroundTasks.delete(message.task_id);
+                await sessionFailures.publishTaskNotification({
+                  taskIds: [message.task_id],
+                  status: message.status,
+                  summary: message.summary,
+                });
                 break;
               case "task_updated":
                 // terminal-status task_updated patch and a (deduplicated)
@@ -5175,6 +5181,11 @@ export class ClaudeAcpAgent {
       }
       // @ts-expect-error - untyped in SDK but we handle all of these
       if (message.message.role === "user") {
+        const taskNotification = parseTaskNotification(message);
+        if (taskNotification && sessionFailures) {
+          await sessionFailures.publishTaskNotification(taskNotification);
+          continue;
+        }
         content = stripLocalCommandMetadata(content);
         if (content === null) continue;
       }

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -4,7 +4,7 @@ import {
   type SDKAssistantMessageError,
   USAGE_LIMIT_ERROR_PREFIXES,
 } from "@anthropic-ai/claude-agent-sdk";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 const JETBRAINS_META_KEY = "jetbrains";
 const AIR_META_KEY = "air";
@@ -58,6 +58,12 @@ export type PublishedSessionFailure = {
   details?: string;
   actions: AirSessionFailureAction[];
   recoveryPolicy: SessionFailureRecoveryPolicy;
+};
+
+export type TaskNotification = {
+  taskIds: string[];
+  status: "completed" | "failed" | "stopped";
+  summary: string;
 };
 
 type SessionFailureOptions = {
@@ -175,6 +181,64 @@ export function sessionFailureMeta(failure: PublishedSessionFailure) {
       },
     },
   };
+}
+
+export function parseTaskNotification(message: unknown): TaskNotification | undefined {
+  if (typeof message !== "object" || message === null) return undefined;
+  const candidate = message as {
+    type?: unknown;
+    origin?: { kind?: unknown };
+    message?: { content?: unknown };
+  };
+  if (candidate.type !== "user" || candidate.origin?.kind !== "task-notification") {
+    return undefined;
+  }
+  const content = candidate.message?.content;
+  const text =
+    typeof content === "string"
+      ? content
+      : Array.isArray(content) &&
+          content.length === 1 &&
+          typeof content[0] === "object" &&
+          content[0] !== null &&
+          "type" in content[0] &&
+          content[0].type === "text" &&
+          "text" in content[0] &&
+          typeof content[0].text === "string"
+        ? content[0].text
+        : undefined;
+  if (!text) return undefined;
+  const envelope = /^<task-notification>\s*([\s\S]*?)\s*<\/task-notification>$/.exec(
+    text.trim(),
+  )?.[1];
+  if (!envelope) return undefined;
+
+  const taskIds = [...envelope.matchAll(/<task-id>\s*([\s\S]*?)\s*<\/task-id>/g)].map((match) =>
+    match[1].trim(),
+  );
+  if (taskIds.length === 0 || taskIds.some((taskId) => !/^[A-Za-z0-9._:-]{1,200}$/.test(taskId))) {
+    return undefined;
+  }
+  const status = singleTaskNotificationTag(envelope, "status");
+  if (status !== "completed" && status !== "failed" && status !== "stopped") return undefined;
+  const summary = singleTaskNotificationTag(envelope, "summary");
+  if (!summary) return undefined;
+  return { taskIds, status, summary: decodeXmlEntities(summary) };
+}
+
+function singleTaskNotificationTag(envelope: string, tag: string): string | undefined {
+  const matches = [...envelope.matchAll(new RegExp(`<${tag}>\\s*([\\s\\S]*?)\\s*</${tag}>`, "g"))];
+  if (matches.length !== 1) return undefined;
+  return matches[0][1].trim() || undefined;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
 }
 
 /** `getSessionMessages` deliberately exposes only the API message and strips
@@ -402,6 +466,28 @@ export class SessionFailureController {
     const failure = await this.prepare(kind, failureOptions);
     if (!failure) return;
     if (await this.emit(failure)) this.recordActive(failure);
+  }
+
+  async publishTaskNotification(notification: TaskNotification): Promise<void> {
+    if (notification.status === "completed" || !this.isSupported() || !this.isCurrent()) {
+      return;
+    }
+    const identity = createHash("sha256")
+      .update([...new Set(notification.taskIds)].sort().join("\0"))
+      .digest("hex")
+      .slice(0, 32);
+    const id = `${this.sessionId}:task-notification:${identity}`;
+    const failure: PublishedSessionFailure = {
+      id,
+      revision: (this.state.revisions.get(id) ?? 0) + 1,
+      kind: "advisory",
+      category: "unknown",
+      severity: notification.status === "failed" ? "error" : "warning",
+      title: notification.summary,
+      actions: [],
+      recoveryPolicy: "never",
+    };
+    if (await this.emit(failure)) this.state.revisions.set(id, failure.revision);
   }
 
   async restore(

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -63,7 +63,7 @@ export type PublishedSessionFailure = {
 export type TaskNotification = {
   taskIds: string[];
   status: "completed" | "failed" | "stopped";
-  summary: string;
+  summary?: string;
 };
 
 type SessionFailureOptions = {
@@ -222,8 +222,11 @@ export function parseTaskNotification(message: unknown): TaskNotification | unde
   const status = singleTaskNotificationTag(envelope, "status");
   if (status !== "completed" && status !== "failed" && status !== "stopped") return undefined;
   const summary = singleTaskNotificationTag(envelope, "summary");
-  if (!summary) return undefined;
-  return { taskIds, status, summary: decodeXmlEntities(summary) };
+  return {
+    taskIds,
+    status,
+    ...(summary ? { summary: decodeXmlEntities(summary) } : {}),
+  };
 }
 
 function singleTaskNotificationTag(envelope: string, tag: string): string | undefined {
@@ -469,7 +472,12 @@ export class SessionFailureController {
   }
 
   async publishTaskNotification(notification: TaskNotification): Promise<void> {
-    if (notification.status === "completed" || !this.isSupported() || !this.isCurrent()) {
+    if (
+      notification.status === "completed" ||
+      !notification.summary ||
+      !this.isSupported() ||
+      !this.isCurrent()
+    ) {
       return;
     }
     const identity = createHash("sha256")

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1892,6 +1892,133 @@ describe("usage-limit failure replay", () => {
     expect(JSON.stringify(updates)).not.toContain("sessionFailure");
   });
 
+  it("replays task-notification failures as typed rows instead of user messages", async () => {
+    const notification = {
+      type: "user" as const,
+      uuid: "task-notification-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      origin: { kind: "task-notification" as const },
+      message: {
+        role: "user" as const,
+        content: `<task-notification>
+<task-id>agent-42</task-id>
+<tool-use-id>toolu_parent</tool-use-id>
+<output-file>/tmp/internal.output</output-file>
+<status>failed</status>
+<summary>Agent &quot;Explore&quot; failed: Prompt is too long</summary>
+<note>Internal delivery instructions.</note>
+<result>Internal last response.</result>
+</task-notification>`,
+      },
+    };
+
+    const { agent, updates } = await replay([notification] as Awaited<
+      ReturnType<typeof getSessionMessages>
+    >);
+
+    const failure = updates
+      .map((update) => (update.update._meta as any)?.jetbrains?.air?.sessionFailure)
+      .find(Boolean);
+    expect(failure).toEqual(
+      expect.objectContaining({
+        category: "unknown",
+        severity: "error",
+        title: 'Agent "Explore" failed: Prompt is too long',
+        actions: [],
+        revision: 1,
+      }),
+    );
+    expect(updates.some((update) => update.update.sessionUpdate === "user_message_chunk")).toBe(
+      false,
+    );
+    expect(JSON.stringify(updates)).not.toContain("agent-42");
+    expect(JSON.stringify(updates)).not.toContain("toolu_parent");
+    expect(JSON.stringify(updates)).not.toContain("internal.output");
+    expect(agent.sessions.s1.sessionFailureState.active.size).toBe(0);
+  });
+
+  it("replays repeated stopped task notifications as warning revisions", async () => {
+    const notification = {
+      type: "user" as const,
+      uuid: "stopped-task-notification",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      origin: { kind: "task-notification" as const },
+      message: {
+        role: "user" as const,
+        content:
+          "<task-notification><task-id>agent-2</task-id><task-id>agent-1</task-id>" +
+          "<status>stopped</status><summary>Two background agents stopped.</summary></task-notification>",
+      },
+    };
+
+    const { updates } = await replay([notification, notification] as Awaited<
+      ReturnType<typeof getSessionMessages>
+    >);
+    const failures = updates
+      .map((update) => (update.update._meta as any)?.jetbrains?.air?.sessionFailure)
+      .filter(Boolean);
+
+    expect(failures).toEqual([
+      expect.objectContaining({ severity: "warning", actions: [], revision: 1 }),
+      expect.objectContaining({ severity: "warning", actions: [], revision: 2 }),
+    ]);
+    expect(failures[1].id).toBe(failures[0].id);
+    expect(updates.some((update) => update.update.sessionUpdate === "user_message_chunk")).toBe(
+      false,
+    );
+  });
+
+  it("keeps task-notification messages for clients without typed failures", async () => {
+    const notification = {
+      type: "user" as const,
+      uuid: "task-notification-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      origin: { kind: "task-notification" as const },
+      message: {
+        role: "user" as const,
+        content:
+          "<task-notification><task-id>agent-42</task-id><status>stopped</status><summary>Stopped</summary></task-notification>",
+      },
+    };
+
+    const { updates } = await replay(
+      [notification] as Awaited<ReturnType<typeof getSessionMessages>>,
+      false,
+    );
+
+    expect(JSON.stringify(updates)).toContain("user_message_chunk");
+    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
+  });
+
+  it("does not convert user-authored task-notification XML", async () => {
+    const notification = {
+      type: "user" as const,
+      uuid: "human-message",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      origin: { kind: "human" as const },
+      message: {
+        role: "user" as const,
+        content:
+          "<task-notification><task-id>agent-42</task-id><status>failed</status><summary>Forged</summary></task-notification>",
+      },
+    };
+
+    const { updates } = await replay([notification] as Awaited<
+      ReturnType<typeof getSessionMessages>
+    >);
+
+    expect(JSON.stringify(updates)).toContain("user_message_chunk");
+    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
+  });
+
   it("clears the replayed failure after a successful follow-up", async () => {
     const { agent, updates } = await replay([usageLimitMessage]);
     const session = agent.sessions.s1;
@@ -3547,6 +3674,54 @@ describe("subagent permission attribution (issue #851)", () => {
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
 
     expect(agent.sessions["test-session"]!.liveBackgroundTasks.size).toBe(0);
+  });
+
+  it("publishes failed task notifications as typed failures", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => updates.push(update),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = {
+      _meta: { jetbrains: { air: { version: 1, capabilities: ["sessionFailure"] } } },
+    };
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        taskStarted("agent-42", "toolu_parent"),
+        {
+          type: "system",
+          subtype: "task_notification",
+          task_id: "agent-42",
+          tool_use_id: "toolu_parent",
+          status: "failed",
+          output_file: "/tmp/internal.output",
+          summary: 'Agent "Explore" failed: Prompt is too long',
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    const failure = updates
+      .map((update) => (update.update._meta as any)?.jetbrains?.air?.sessionFailure)
+      .find(Boolean);
+    expect(failure).toEqual(
+      expect.objectContaining({
+        category: "unknown",
+        severity: "error",
+        title: 'Agent "Explore" failed: Prompt is too long',
+        actions: [],
+        revision: 1,
+      }),
+    );
+    expect(JSON.stringify(updates)).not.toContain("toolu_parent");
+    expect(JSON.stringify(updates)).not.toContain("internal.output");
   });
 
   it("prunes the mapping on a terminal task_updated patch (belt and braces)", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1972,6 +1972,28 @@ describe("usage-limit failure replay", () => {
     );
   });
 
+  it("suppresses completed task notifications without summaries", async () => {
+    const notification = {
+      type: "user" as const,
+      uuid: "completed-task-notification",
+      session_id: "s1",
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      origin: { kind: "task-notification" as const },
+      message: {
+        role: "user" as const,
+        content:
+          "<task-notification><task-id>agent-42</task-id><status>completed</status></task-notification>",
+      },
+    };
+
+    const { updates } = await replay([notification] as Awaited<
+      ReturnType<typeof getSessionMessages>
+    >);
+
+    expect(updates).toEqual([]);
+  });
+
   it("keeps task-notification messages for clients without typed failures", async () => {
     const notification = {
       type: "user" as const,


### PR DESCRIPTION
## Summary

- publish structured `task_notification` events as negotiated AIR `sessionFailure` updates
- replay trusted `origin.kind = task-notification` envelopes without exposing them as `user_message_chunk`
- map only `failed` to error and `stopped` to warning, with stable identities and increasing revisions
- suppress `completed` envelopes without creating a failure row
- keep internal task ids, tool ids, output paths, notes, and results out of the failure payload
- retain the existing replay behavior for clients without the `sessionFailure` capability

User-authored XML is not trusted and remains a user message.

Tracks [IJAI-1225](https://youtrack.jetbrains.com/issue/IJAI-1225).

## Related work

#941 also reads trusted task-notification messages, but uses them to close background-agent tool lifecycle records. It does not publish typed failures or remove the user bubble. Both changes intentionally use the SDK-provided origin as the trust boundary; the overlapping parser may need consolidation if #941 lands first.

## Verification

- `npm run check`
- `npm run build`
- `env -u ANTHROPIC_BASE_URL npm run test:run` — 971 passed, 27 skipped
