### PR TITLE
feat: report async task readiness and CLI provenance

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -112,6 +112,11 @@ import {
 } from "./native-subagents.js";
 import { AIR_ASYNC_TASKS_CAPABILITY, withAirMeta } from "./air-extension.js";
 import {
+  asyncTaskCliSource,
+  type AsyncTaskReadiness,
+  type AsyncTaskReadinessMeta,
+} from "./async-task-readiness.js";
+import {
   AsyncTaskRuntime,
   backgroundBashTaskFromToolResult,
   clientSupportsAsyncTasks,
@@ -603,6 +608,10 @@ export type Session = {
   /** Last goal snapshot sent to the ACP client, used to roll back an
    *  optimistic `/goal` update when the command itself fails. */
   lastPublishedGoal?: GoalSnapshot | null;
+  /** Async task readiness for this session. Absent means `unconfirmed`; it
+   *  latches to `confirmed` on the first observed task lifecycle event and
+   *  never moves again, so the client is told exactly once. */
+  asyncTaskReadiness?: AsyncTaskReadiness;
   /** Count of result messages the consumer should treat as orphans and skip
    *  (not promote/attribute to the current head). When cancel() settles+removes
    *  a queued turn, that turn's user message was already pushed to the SDK, so
@@ -1960,6 +1969,14 @@ export class ClaudeAcpAgent {
           controlMethod: GOAL_CONTROL_METHOD,
           actions: [...GOAL_ACTIONS],
         } satisfies GoalCapability,
+        // Which binary `claudeCliPath()` resolves through is fixed for the
+        // adapter process, so async-task CLI provenance is reported once here
+        // rather than repeated on every session. A sibling of `steering` and
+        // `goal` rather than a member of the `air` object, which peers match
+        // as a closed shape.
+        asyncTaskReadiness: {
+          cli: { source: asyncTaskCliSource() },
+        } satisfies AsyncTaskReadinessMeta,
       },
     };
   }
@@ -2290,6 +2307,28 @@ export class ClaudeAcpAgent {
       update: {
         sessionUpdate: "session_info_update",
         _meta: { goal },
+      },
+    });
+  }
+
+  /** Latches async task readiness to `confirmed` on the first task lifecycle
+   *  event observed for the session, and publishes it once. Later events are
+   *  no-ops, so a session emits at most one readiness frame however much
+   *  background work it runs.
+   *
+   *  Sent directly rather than through a turn's `sendUpdate`, matching the
+   *  async-task and subagent runtimes: this is session state, so it must not
+   *  be routed to a subagent session or counted as answer delivery. */
+  private async confirmAsyncTaskReadiness(session: Session, sessionId: string): Promise<void> {
+    if (session.asyncTaskReadiness === "confirmed") return;
+    session.asyncTaskReadiness = "confirmed";
+    await this.client.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "session_info_update",
+        _meta: {
+          asyncTaskReadiness: { readiness: "confirmed" } satisfies AsyncTaskReadinessMeta,
+        },
       },
     });
   }
@@ -3821,6 +3860,20 @@ export class ClaudeAcpAgent {
                   parentToolUseId: message.tool_use_id,
                   isSubagent: !!message.subagent_type,
                 });
+                // Only for a client that negotiated the async task lifecycle:
+                // readiness describes that stream, so a client which opted out
+                // of it gains nothing from being told the stream is live.
+                //
+                // Published ahead of both runtimes on purpose. This is the
+                // session's one readiness frame, and emitting it before the
+                // handlers that stream a task's own updates keeps it out of the
+                // tail of the sequence, where consumers read a turn's outcome.
+                // It also has to run for subagent tasks, which
+                // `AsyncTaskRuntime` ignores: those prove the lifecycle is live
+                // while publishing nothing the client could infer it from.
+                if (asyncTasks.enabled) {
+                  await this.confirmAsyncTaskReadiness(session, params.sessionId);
+                }
                 await subagents.taskStarted(
                   {
                     taskId: message.task_id,

--- a/src/async-task-readiness.ts
+++ b/src/async-task-readiness.ts
@@ -1,0 +1,81 @@
+/**
+ * Readiness for the async task lifecycle.
+ *
+ * `AsyncTaskRuntime` publishes background work as `async_task_*` updates, but
+ * whether anything can reach that stream depends on the Claude binary the
+ * adapter spawned. `claudeCliPath()` resolves either an operator-configured
+ * `CLAUDE_CODE_EXECUTABLE` or the platform binary bundled with
+ * `@anthropic-ai/claude-agent-sdk`, and a binary that emits no task lifecycle
+ * produces an empty stream that a client cannot distinguish from a session in
+ * which no background task ever ran. Silence carries two meanings on one
+ * channel; this splits them apart.
+ *
+ * Two independent facts, at the altitudes they actually live at:
+ *
+ * - **Provenance** is connection-scoped. Which of the two resolution paths
+ *   `claudeCliPath()` takes is fixed for the adapter process, so it is
+ *   advertised once, on `initialize`. Only the *source* goes on the wire: the
+ *   resolved path is an operator's filesystem layout, and nothing else in this
+ *   adapter puts it in a protocol frame.
+ * - **Readiness** is session-scoped and monotone. It starts `unconfirmed` and
+ *   latches to `confirmed` the first time this adapter observes a task
+ *   lifecycle event for the session.
+ *
+ * The latch is worth sending because the adapter observes strictly more
+ * lifecycle than the client does: `AsyncTaskRuntime.taskStarted()` marks
+ * subagent tasks `ignored` and publishes nothing for them, so a session whose
+ * background work is entirely subagents proves the lifecycle is live to the
+ * adapter while the client's async-task stream stays empty for its whole
+ * lifetime. `confirmed` is the only way that client learns its silence is real.
+ *
+ * Deliberately not reported: a CLI version. It is knowable without spawning
+ * the binary only for the bundled case, and a field that is accurate for one
+ * source and a guess for the other is worse than its absence.
+ */
+
+/** Whether a task lifecycle event has been observed for a session yet. */
+export type AsyncTaskReadiness = "unconfirmed" | "confirmed";
+
+/** Which branch of `claudeCliPath()` this process resolves through. */
+export type AsyncTaskCliSource = "configured" | "bundled";
+
+export type AsyncTaskCliProvenance = { source: AsyncTaskCliSource };
+
+/** `initialize` carries provenance; `session_info_update` carries the latch. */
+export type AsyncTaskReadinessMeta = {
+  readiness?: AsyncTaskReadiness;
+  cli?: AsyncTaskCliProvenance;
+};
+
+/**
+ * Mirrors `claudeCliPath()`'s own branch exactly, including its truthiness
+ * test: an empty `CLAUDE_CODE_EXECUTABLE` falls through to the bundled binary
+ * there, so it must report `bundled` here. Resolution is deliberately not
+ * performed — reporting the source needs no filesystem lookup, so this cannot
+ * fail or slow `initialize` down.
+ */
+export function asyncTaskCliSource(): AsyncTaskCliSource {
+  return process.env.CLAUDE_CODE_EXECUTABLE ? "configured" : "bundled";
+}
+
+/**
+ * Fail-closed reader for clients: anything malformed returns null rather than
+ * a partly-trusted snapshot, so a garbled frame can never be read as proof
+ * that the lifecycle is live.
+ */
+export function normalizeAsyncTaskReadiness(value: unknown): AsyncTaskReadinessMeta | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const result: AsyncTaskReadinessMeta = {};
+  if (raw.readiness !== undefined) {
+    if (raw.readiness !== "unconfirmed" && raw.readiness !== "confirmed") return null;
+    result.readiness = raw.readiness;
+  }
+  if (raw.cli !== undefined) {
+    if (typeof raw.cli !== "object" || raw.cli === null || Array.isArray(raw.cli)) return null;
+    const source = (raw.cli as Record<string, unknown>).source;
+    if (source !== "configured" && source !== "bundled") return null;
+    result.cli = { source };
+  }
+  return result.readiness === undefined && result.cli === undefined ? null : result;
+}

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -17711,3 +17711,271 @@ describe("permission_denied", () => {
     expect(denials(updates)).toHaveLength(1);
   });
 });
+
+describe("async task readiness", () => {
+  /** Client that negotiated #1017's async task lifecycle, so `AsyncTaskRuntime`
+   *  is live and its silence for a task is a decision rather than a disabled
+   *  runtime. */
+  const asyncTaskClient = {
+    _meta: { jetbrains: { air: { version: 1, capabilities: ["asyncTasks"] } } },
+  };
+
+  function agentWithUpdates() {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (notification: AcpSessionNotification) => {
+          updates.push(notification);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    return { agent, updates };
+  }
+
+  function taskStarted(taskId: string, extra: Record<string, unknown> = {}) {
+    return {
+      type: "system",
+      subtype: "task_started",
+      task_id: taskId,
+      tool_use_id: `toolu_${taskId}`,
+      description: "Investigate",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      ...extra,
+    };
+  }
+
+  function settled() {
+    return {
+      type: "result" as const,
+      subtype: "success" as const,
+      stop_reason: null,
+      is_error: false,
+      result: "",
+      errors: [],
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+  }
+
+  /** Replays the prompt's user echo so the turn activates, then the given
+   *  messages, then settles the turn. */
+  function generator(messages: unknown[]) {
+    return async function* (input: Pushable<any>) {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage, done } = await iter.next();
+      if (!done && userMessage) yield userEcho(userMessage);
+      yield* messages as any;
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+    };
+  }
+
+  /** Indices of the readiness frames, in emission order. */
+  function readinessAt(updates: AcpSessionNotification[]): number[] {
+    return updates.flatMap((notification, index) =>
+      notification.update.sessionUpdate === "session_info_update" &&
+      (notification.update._meta as any)?.asyncTaskReadiness
+        ? [index]
+        : [],
+    );
+  }
+
+  function kinds(updates: AcpSessionNotification[]): string[] {
+    return updates.map((notification) => notification.update.sessionUpdate);
+  }
+
+  describe("CLI provenance at initialize", () => {
+    const provenance = async () => {
+      const { agent } = agentWithUpdates();
+      const response = await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+      return (response._meta as any)?.asyncTaskReadiness;
+    };
+
+    it("reports the bundled binary when CLAUDE_CODE_EXECUTABLE is unset", async () => {
+      vi.stubEnv("CLAUDE_CODE_EXECUTABLE", undefined as unknown as string);
+      expect(await provenance()).toEqual({ cli: { source: "bundled" } });
+      vi.unstubAllEnvs();
+    });
+
+    it("reports a configured binary when CLAUDE_CODE_EXECUTABLE is set", async () => {
+      vi.stubEnv("CLAUDE_CODE_EXECUTABLE", "/usr/local/bin/claude");
+      expect(await provenance()).toEqual({ cli: { source: "configured" } });
+      vi.unstubAllEnvs();
+    });
+
+    it("treats an empty CLAUDE_CODE_EXECUTABLE as bundled, as claudeCliPath does", async () => {
+      vi.stubEnv("CLAUDE_CODE_EXECUTABLE", "");
+      expect(await provenance()).toEqual({ cli: { source: "bundled" } });
+      vi.unstubAllEnvs();
+    });
+
+    it("never puts the resolved path on the wire", async () => {
+      vi.stubEnv("CLAUDE_CODE_EXECUTABLE", "/usr/local/bin/claude");
+      const { agent } = agentWithUpdates();
+      const response = await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+      expect(JSON.stringify(response)).not.toContain("/usr/local/bin/claude");
+      vi.unstubAllEnvs();
+    });
+
+    it("leaves the AIR capability object untouched", async () => {
+      const { agent } = agentWithUpdates();
+      const response = await agent.initialize({ protocolVersion: 1, clientCapabilities: {} });
+      expect(Object.keys((response._meta as any).jetbrains.air)).toEqual([
+        "version",
+        "capabilities",
+      ]);
+    });
+  });
+
+  it("leads the update sequence a subagent task_started produces", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { ...asyncTaskClient, subagents: {} } as any,
+    });
+    // Child output buffered ahead of the task_started, so the subagent's own
+    // updates are in play rather than the frame sitting alone in the stream.
+    const childChunk = {
+      type: "stream_event" as const,
+      parent_tool_use_id: "toolu_agent-42",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      event: {
+        type: "content_block_delta" as const,
+        index: 0,
+        delta: { type: "text_delta" as const, text: "buffered" },
+      },
+    };
+    injectGeneratorSession(
+      agent,
+      generator([childChunk, taskStarted("agent-42", { subagent_type: "Explore" }), settled()]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // A turn's tail is what consumers read for its outcome, so the session's
+    // one readiness frame belongs at the head. Note the ordering contract is
+    // only *observable* on the non-subagent path, where the async task runtime
+    // also publishes; `AsyncTaskRuntime` ignores subagent tasks, so nothing
+    // else is emitted in this window. The sensitive assertion is in
+    // "publishes readiness ahead of the async task updates ..." below.
+    const readiness = readinessAt(updates);
+    expect(readiness).toEqual([0]);
+    expect(kinds(updates).indexOf("subagent_spawned")).toBe(1);
+    expect(kinds(updates).at(-1)).toBe("subagent_state_update");
+  });
+
+  it("confirms readiness for a subagent task, which publishes no async task update", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { ...asyncTaskClient, subagents: {} } as any,
+    });
+    injectGeneratorSession(
+      agent,
+      generator([taskStarted("agent-42", { subagent_type: "Explore" }), settled()]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // The whole reason the latch is worth a frame: AsyncTaskRuntime ignores
+    // subagent tasks, so this client's async task stream stays empty for the
+    // session's lifetime even though the lifecycle demonstrably works.
+    expect(kinds(updates).filter((kind) => kind.startsWith("async_task_"))).toEqual([]);
+    expect(readinessAt(updates)).toHaveLength(1);
+    expect((updates[0].update._meta as any).asyncTaskReadiness).toEqual({
+      readiness: "confirmed",
+    });
+  });
+
+  it("publishes readiness ahead of the async task updates the same task_started produces", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: asyncTaskClient as any });
+    injectGeneratorSession(
+      agent,
+      generator([
+        taskStarted("shell-1", {
+          task_type: "local_bash",
+          description: "Build",
+          is_backgrounded: true,
+        }),
+        settled(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // The ordering contract, and the assertion that fails if readiness is
+    // published after the runtimes that stream a task's own updates.
+    expect(readinessAt(updates)).toEqual([0]);
+    expect(kinds(updates).indexOf("async_task_spawned")).toBe(1);
+    // Doubles as the positive control for the subagent case above: the runtime
+    // really is enabled on `asyncTaskClient`, so the empty async task stream
+    // asserted there is a decision about subagents rather than a disabled
+    // runtime satisfying the assertion vacuously.
+  });
+
+  it("latches: a second task_started publishes no further readiness frame", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: asyncTaskClient as any });
+    injectGeneratorSession(
+      agent,
+      generator([
+        taskStarted("shell-1", { task_type: "local_bash", is_backgrounded: true }),
+        taskStarted("shell-2", { task_type: "local_bash", is_backgrounded: true }),
+        settled(),
+      ]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(readinessAt(updates)).toEqual([0]);
+    // Control: both tasks really did reach the runtime, so the single frame is
+    // the latch holding rather than the second task never arriving.
+    expect(kinds(updates).filter((kind) => kind === "async_task_spawned")).toHaveLength(2);
+  });
+
+  it("publishes no readiness frame for a client that did not negotiate async tasks", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: { subagents: {} } as any,
+    });
+    injectGeneratorSession(
+      agent,
+      generator([taskStarted("agent-42", { subagent_type: "Explore" }), settled()]),
+    );
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    // Readiness describes the async task stream, so a client that opted out of
+    // that stream is not told about it.
+    expect(readinessAt(updates)).toEqual([]);
+    // Control: the task really did reach the handler, so the absent frame is
+    // the capability gate rather than a turn that never ran.
+    expect(kinds(updates)).toContain("subagent_state_update");
+  });
+
+  it("publishes no readiness frame for a session that runs no background work", async () => {
+    const { agent, updates } = agentWithUpdates();
+    await agent.initialize({ protocolVersion: 1, clientCapabilities: asyncTaskClient as any });
+    injectGeneratorSession(agent, generator([settled()]));
+
+    await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "go" }] });
+
+    expect(readinessAt(updates)).toEqual([]);
+  });
+});

--- a/src/tests/async-task-readiness.test.ts
+++ b/src/tests/async-task-readiness.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { asyncTaskCliSource, normalizeAsyncTaskReadiness } from "../async-task-readiness.js";
+
+describe("asyncTaskCliSource", () => {
+  it("reports a configured binary when CLAUDE_CODE_EXECUTABLE is set", () => {
+    vi.stubEnv("CLAUDE_CODE_EXECUTABLE", "/usr/local/bin/claude");
+    expect(asyncTaskCliSource()).toBe("configured");
+    vi.unstubAllEnvs();
+  });
+
+  it("reports the bundled binary when CLAUDE_CODE_EXECUTABLE is unset", () => {
+    vi.stubEnv("CLAUDE_CODE_EXECUTABLE", undefined as unknown as string);
+    expect(asyncTaskCliSource()).toBe("bundled");
+    vi.unstubAllEnvs();
+  });
+
+  it("reports the bundled binary for an empty CLAUDE_CODE_EXECUTABLE", () => {
+    // `claudeCliPath()` tests the same value for truthiness and falls through
+    // to the bundled binary on an empty string, so this must agree with it.
+    vi.stubEnv("CLAUDE_CODE_EXECUTABLE", "");
+    expect(asyncTaskCliSource()).toBe("bundled");
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("normalizeAsyncTaskReadiness", () => {
+  it("reads a readiness latch", () => {
+    expect(normalizeAsyncTaskReadiness({ readiness: "confirmed" })).toEqual({
+      readiness: "confirmed",
+    });
+  });
+
+  it("reads CLI provenance", () => {
+    expect(normalizeAsyncTaskReadiness({ cli: { source: "bundled" } })).toEqual({
+      cli: { source: "bundled" },
+    });
+  });
+
+  it("reads both together", () => {
+    expect(
+      normalizeAsyncTaskReadiness({ readiness: "unconfirmed", cli: { source: "configured" } }),
+    ).toEqual({ readiness: "unconfirmed", cli: { source: "configured" } });
+  });
+
+  it("drops unknown fields rather than passing them through", () => {
+    expect(normalizeAsyncTaskReadiness({ readiness: "confirmed", extra: 1 })).toEqual({
+      readiness: "confirmed",
+    });
+  });
+
+  it.each([
+    ["a non-object", "confirmed"],
+    ["null", null],
+    ["an array", [{ readiness: "confirmed" }]],
+    ["an empty object", {}],
+    ["an unknown readiness", { readiness: "armed" }],
+    ["a null readiness", { readiness: null }],
+    ["a non-object cli", { cli: "bundled" }],
+    ["a null cli", { cli: null }],
+    ["an unknown cli source", { cli: { source: "vendored" } }],
+    ["a cli with no source", { cli: {} }],
+    ["a valid latch beside a malformed cli", { readiness: "confirmed", cli: { source: 7 } }],
+  ])("fails closed on %s", (_label, value) => {
+    // A garbled frame must never read as proof that the lifecycle is live, so
+    // the whole payload is dropped rather than partly trusted.
+    expect(normalizeAsyncTaskReadiness(value)).toBeNull();
+  });
+});


### PR DESCRIPTION

This PR has been rewritten and force-pushed. It originally landed a
`backgroundTasks` extension with three parts: an init capability, a snapshot of
live background tasks, and a readiness/provenance signal. #1017 has since merged
and covers the first two properly, so those are gone. What is left is the third
part, rebased onto current `main` and layered on `AsyncTaskRuntime` rather than
sitting beside it.

### The gap

#1017 gives clients the async task lifecycle. Nothing tells them whether that
lifecycle can carry anything.

Whether any task event is emitted at all depends on the Claude binary the
adapter spawned, and the client is never told which one that is.
`claudeCliPath()` resolves either an operator-configured
`CLAUDE_CODE_EXECUTABLE` or the platform binary bundled with the SDK. A binary
that does not emit task lifecycle produces an empty stream, and an empty stream
is exactly what a session with no background work produces. Two meanings, one
channel, and no way for a client to tell them apart. A client that surfaces
background work has to choose between claiming "nothing is running" when it does
not know that, and never trusting the stream at all.

### What this adds

Two facts, reported at the altitudes they actually live at.

**CLI provenance is connection-scoped.** Which branch `claudeCliPath()` takes is
fixed for the adapter process, so `initialize` reports it once:

```jsonc
"_meta": {
  "asyncTaskReadiness": { "cli": { "source": "bundled" } }  // or "configured"
}
```

**Readiness is session-scoped and monotone.** It starts `unconfirmed` and
latches to `confirmed` the first time the adapter observes a task lifecycle
event for that session, published as a single `session_info_update`:

```jsonc
"_meta": { "asyncTaskReadiness": { "readiness": "confirmed" } }
```

At most one such frame per session, however much background work it runs.

### How it composes with #1017

The latch is worth sending because the adapter observes strictly more lifecycle
than the client does. `AsyncTaskRuntime.taskStarted()` marks subagent tasks
`ignored` and publishes nothing for them, so a session whose background work is
entirely subagents proves the lifecycle is live to the adapter while the
client's async task stream stays empty for the session's whole lifetime. A
client cannot derive `confirmed` for itself in that case; this frame is the only
way it learns that its silence is real. There is a test for exactly that case,
with a non-subagent control beside it so the empty-stream assertion cannot pass
against a disabled runtime.

### Deliberate omissions

- **No new capability name.** #1017 already advertises `asyncTasks`, and the
  presence of the `asyncTaskReadiness` object is self-describing. Advertising it
  again would only duplicate what `initialize` already says.
- **The resolved CLI path is not on the wire.** It is an operator's filesystem
  layout, and nothing else in this adapter puts it in a protocol frame.
  `source` is the part a client cannot determine for itself.
- **No CLI version.** It is knowable without spawning the binary only for the
  bundled case. A field that is accurate for one source and a guess for the
  other is worse than its absence.
- **`_meta.asyncTaskReadiness` is a top-level key**, a sibling of `steering` and
  `goal`, not a member of the `air` object. Peers match that object as a closed
  shape, including this repo's own tests, so adding a key inside it would be a
  breaking change for anyone doing the same.
- **The readiness frame is gated on the client having negotiated `asyncTasks`.**
  Readiness describes that stream, so a client which opted out of it gains
  nothing from being told the stream is live. Provenance at `initialize` is
  unconditional, matching the other advertisements there.

### Compatibility

Purely additive for a client that already speaks #1017's shape. It reads
`asyncTaskReadiness` or it does not; nothing existing changes shape, and no
existing field gains or loses a value.

The diff is purely additive: it changes no existing line, in source or in
tests.

One behavioural note worth stating plainly. A client that negotiated
`asyncTasks` and runs background work now sees one additional
`session_info_update` at the head of the sequence a `task_started` produces. It
is published ahead of the subagent and async task runtimes deliberately, so it
leads that sequence rather than displacing the tail a consumer reads for a
turn's outcome. `session_info_update` carrying only a `_meta` payload is already
how the `goal` and session-failure extensions report state, so the shape is
established rather than new, but a client that enumerates a turn's updates
exactly will see the extra frame. Clients that did not negotiate `asyncTasks`
see no change at all.

### Tests

`npm run test:run`, plus `npm run lint` and `npm run format:check`. The new
coverage is:

- CLI provenance at `initialize` for configured, unset, and empty
  `CLAUDE_CODE_EXECUTABLE` (empty falls through to the bundled binary, matching
  `claudeCliPath()`'s own truthiness test), that the resolved path never appears
  in the response, and that the `air` capability object is unchanged.
- The readiness frame leads the sequence a `task_started` produces. Note the
  ordering is only *observable* on the non-subagent path, where the async task
  runtime also publishes; `AsyncTaskRuntime` ignores subagent tasks, so nothing
  else is emitted in that window and position cannot be detected there. The
  test names say which case each one actually pins rather than implying a
  guarantee the fixture cannot see.
- A subagent-only session confirms readiness while publishing no `async_task_*`
  update, with a non-subagent control proving the runtime was enabled.
- The latch holds across a second `task_started`, with a control proving both
  tasks reached the runtime.
- A session with no background work, and a client that did not negotiate
  `asyncTasks`, each publish no readiness frame, both with controls proving the
  turn actually ran.
- Fail-closed parsing of the payload, so a garbled frame can never read as proof
  that the lifecycle is live.

Each absence assertion is paired with a control in the same test proving the
turn actually ran, so "no frame was published" cannot pass on a path that never
executed.
