### PR TITLE
fix: allow raw model ids in config option

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -5463,6 +5463,18 @@ export class ClaudeAcpAgent {
       }
     }
 
+    if (!validValue && params.configId === MODEL_CONFIG_ID) {
+      const rawModelId = params.value.trim();
+      if (rawModelId) {
+        // The picker is a convenience list, not the complete validation
+        // boundary for Anthropic model IDs. Accept a non-empty raw model id and
+        // let the SDK/API validate it on the next turn so valid-but-unlisted
+        // IDs (new launches, retired picker entries, custom gateways) remain
+        // reachable through the standard config option path.
+        validValue = { value: rawModelId, name: rawModelId };
+      }
+    }
+
     if (!validValue) {
       throw new Error(`Invalid value for config option ${params.configId}: ${params.value}`);
     }

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -324,14 +324,17 @@ describe("session config options", () => {
       expect(modelOption?.currentValue).toBe("claude-sonnet-4-6");
     });
 
-    it("throws for completely invalid model value", async () => {
-      await expect(
-        agent.setSessionConfigOption({
-          sessionId: SESSION_ID,
-          configId: "model",
-          value: "gpt-4",
-        }),
-      ).rejects.toThrow("Invalid value for config option model: gpt-4");
+    it("passes through out-of-picker model IDs to the SDK", async () => {
+      const response = await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "model",
+        value: "claude-opus-4-8",
+      });
+
+      expect(setModelSpy).toHaveBeenCalledWith("claude-opus-4-8");
+      expect(response.configOptions.find((o) => o.id === "model")?.currentValue).toBe(
+        "claude-opus-4-8",
+      );
     });
 
     it("returns full configOptions in the response", async () => {


### PR DESCRIPTION
## Summary

- allows the model config option to pass through a non-empty raw model ID when it is not present in the picker
- keeps alias/current-value resolution first, so picker entries still canonicalize to the SDK option value
- covers the regression with an out-of-picker `claude-opus-4-8` model ID

Closes #1033.

## Verification

- `npm run test:run -- src/tests/session-config-options.test.ts -t 'passes through out-of-picker model IDs'`
- `npm run test:run -- src/tests/session-config-options.test.ts src/tests/model-resolution.test.ts`
- `npm run build`
- `npm run check`
- `git diff --check`

I also ran `npm run test:run`. It completed with 963 passing tests, 27 skipped, and the same two root-environment `resolve-permission-mode` failures seen when running as root: `bypassPermissions` is intentionally downgraded to `default` in that environment. The changed model config tests passed.