### PR TITLE
fix: strip injected system reminders from replayed prompts

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1167,6 +1167,19 @@ const LOCAL_COMMAND_MARKERS = [
   "local-command-stderr",
 ].map((tag) => ({ open: `<${tag}>`, close: `</${tag}>` }));
 
+// Context the CLI injects into a user turn to steer the model, appended to
+// whatever the user typed. Nobody wrote it and no client sees it live — the
+// prompt loop's user-message skip covers the whole message — but it is
+// persisted alongside that prose, so replay would hand the client a prompt
+// with instructions in it the user never gave.
+const INJECTED_CONTEXT_MARKERS = ["system-reminder"].map((tag) => ({
+  open: `<${tag}>`,
+  close: `</${tag}>`,
+}));
+
+// Everything a replayed user message may be wrapped in that is not speech.
+const TRANSCRIPT_MARKERS = [...LOCAL_COMMAND_MARKERS, ...INJECTED_CONTEXT_MARKERS];
+
 // Single-pass scanner that removes each `<tag>…</tag>` marker (matching the
 // nearest closing tag of the same name, like a lazy regex would).
 function stripMarkerTags(text: string): string {
@@ -1176,7 +1189,7 @@ function stripMarkerTags(text: string): string {
   let i = 0;
   while (i < text.length) {
     if (text[i] === "<") {
-      const marker = LOCAL_COMMAND_MARKERS.find(
+      const marker = TRANSCRIPT_MARKERS.find(
         (m) => !dead.has(m.open) && text.startsWith(m.open, i),
       );
       if (marker) {
@@ -1198,10 +1211,11 @@ function stripMarkerTags(text: string): string {
 }
 
 /**
- * Return user-message content with local-command marker tags removed, or
- * `null` if nothing meaningful remains (caller should skip the message).
- * Preserves real prose that's mixed in alongside the markers — e.g. a
- * message like `<command-name>…</command-name>hi` becomes `hi`.
+ * Return user-message content with local-command and injected-context marker
+ * tags removed, or `null` if nothing meaningful remains (caller should skip
+ * the message). Preserves real prose that's mixed in alongside the markers —
+ * e.g. a message like `<command-name>…</command-name>hi` becomes `hi`, and
+ * `hi<system-reminder>…</system-reminder>` becomes `hi`.
  */
 export function stripLocalCommandMetadata(content: unknown): unknown | null {
   if (typeof content === "string") {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1594,6 +1594,26 @@ describe("stripLocalCommandMetadata", () => {
     expect((stripped as string).trimEnd()).toMatch(/hi$/);
   });
 
+  // A reminder the CLI appends to the user's own turn: never typed, never
+  // shown live, but persisted next to the prose it was appended to.
+  it("strips injected system reminders, keeping what the user typed", () => {
+    expect(
+      stripLocalCommandMetadata("is that right?<system-reminder>be nice</system-reminder>"),
+    ).toBe("is that right?");
+    expect(
+      stripLocalCommandMetadata("<system-reminder>do not mention this</system-reminder>"),
+    ).toBeNull();
+  });
+
+  it("drops reminder-only blocks from mixed arrays, keeping real blocks", () => {
+    expect(
+      stripLocalCommandMetadata([
+        { type: "text", text: "is that right?" },
+        { type: "text", text: "<system-reminder>be nice</system-reminder>" },
+      ]),
+    ).toEqual([{ type: "text", text: "is that right?" }]);
+  });
+
   it("drops marker-only blocks from mixed arrays, keeping real blocks", () => {
     const result = stripLocalCommandMetadata([
       { type: "text", text: "<command-name>/model</command-name>" },
@@ -1698,6 +1718,47 @@ describe("synthetic login message (issue #863)", () => {
     ).toBe(false);
     expect(isSyntheticLoginMessage(undefined)).toBe(false);
     expect(isSyntheticLoginMessage("Not logged in · Please run /login")).toBe(false);
+  });
+
+  it("loadSession replay hands the client the prompt without the reminder appended to it", async () => {
+    const updates: SessionNotification[] = [];
+    const client = {
+      sessionUpdate: async (u: SessionNotification) => {
+        updates.push(u);
+      },
+    } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "user",
+        uuid: "u1",
+        session_id: "s1",
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        message: {
+          role: "user",
+          content:
+            "is that right?<system-reminder>Do not mention this reminder to the user.</system-reminder>",
+        },
+      },
+    ] as Awaited<ReturnType<typeof getSessionMessages>>);
+
+    await (
+      agent as unknown as { replaySessionHistory(sessionId: string): Promise<void> }
+    ).replaySessionHistory("s1");
+
+    // What the user typed still replays…
+    expect(
+      updates.some(
+        (u) =>
+          u.update.sessionUpdate === "user_message_chunk" &&
+          u.update.content.type === "text" &&
+          u.update.content.text === "is that right?",
+      ),
+    ).toBe(true);
+    // …without the instruction the CLI appended to it.
+    expect(JSON.stringify(updates)).not.toContain("system-reminder");
   });
 
   it("loadSession replay skips the synthetic login message but keeps the rest", async () => {


### PR DESCRIPTION
## Summary

- strip `<system-reminder>` blocks from replayed user messages, through the marker scanner that already handles the local-command tags
- what the user actually typed is preserved; a reminder-only message strips to nothing and is skipped
- regression coverage for the string shape, the content-array shape, and `replaySessionHistory` end to end

## Why

`stripLocalCommandMetadata` exists for a stated reason: *"The live prompt loop drops them; replay must strip them too or they leak into the UI on session/load."* Injected reminders are the same class of leak and are not covered by it.

The CLI appends `<system-reminder>` blocks to a user turn to steer the model — a worktree that was deleted, a background task that started elsewhere. They are persisted in the same text block as the prose the user typed, and they are not `isMeta`, so `getSessionMessages` returns them. Live, nothing reaches the client: the prompt loop's user-message skip covers the whole message. On `session/load` the block is replayed verbatim, so a client renders a paragraph of instructions the user never wrote, followed by their one-line prompt.

Reproduced against `main` with a real transcript: a reminder about a deleted worktree, followed by a five-word prompt, arrives as a single `user_message_chunk` containing both. With this change the chunk is the five words.

## Not included, deliberately

- **`<task-notification>` envelopes.** They still replay as user messages, but #1028 is already doing that properly, keyed on the SDK-provided `origin.kind` rather than the text — the better trust boundary, since a user can type the tag themselves.
- **`[Request interrupted by user]`.** Also still replayed as a user message. It is untagged prose and it is the only trace a cancelled turn leaves, so whether it should be dropped, typed, or marked in `_meta` reads as your product call rather than a bug fix. Happy to open a follow-up if you want it handled.

The exported name `stripLocalCommandMetadata` is left alone — it is part of `lib.ts` — so only the shared marker list and the doc comment grew.

## The one false positive

A user who literally types `<system-reminder>…</system-reminder>` in a prompt loses that span on replay, while seeing it live. It is the same trade already accepted for `<command-name>`, the surrounding prose still survives, and text is the only signal available here — unlike task notifications, reminders carry no `origin` to key on. Flagging it rather than leaving it for review to find.

## Verification

- `npm run build`
- `npm run check`
- `env -u ANTHROPIC_BASE_URL npm run test:run` — 974 passed, 27 skipped
- the three new tests fail on `main` and pass with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
