### PR TITLE
test: tolerate minute-aligned scheduled wakeups

### DIFF
--- a/src/tests/live-capability-events-audit.test.ts
+++ b/src/tests/live-capability-events-audit.test.ts
@@ -24,6 +24,11 @@ type LiveHarness = {
 const enabled = process.env.RUN_LIVE_CAPABILITY_AUDIT === "true";
 const exec = promisify(execCallback);
 
+// ScheduleWakeup stores a minute-aligned cron entry. A 60-second delay can
+// therefore take almost two minutes to fire when scheduling crosses a minute
+// boundary, plus a little time for the autonomous model turn to finish.
+const SCHEDULED_WAKEUP_TIMEOUT_MS = 135_000;
+
 function object(value: unknown): JsonObject | undefined {
   return value !== null && typeof value === "object" ? (value as JsonObject) : undefined;
 }
@@ -220,7 +225,7 @@ describe.skipIf(!enabled)("live Claude SDK to ACP capability audit", () => {
               const origin = object(message.origin);
               return origin?.kind === "auto-continuation" || origin?.kind === "task-notification";
             }) || transcriptText(harness.updates).includes("LIVE_WAKE_OK"),
-          75_000,
+          SCHEDULED_WAKEUP_TIMEOUT_MS,
         );
       } catch (error) {
         printResult("scheduled-wakeup-timeout", {
@@ -246,7 +251,7 @@ describe.skipIf(!enabled)("live Claude SDK to ACP capability audit", () => {
     } finally {
       await harness.dispose();
     }
-  }, 110_000);
+  }, 170_000);
 
   it("records whether a real refusal produces retraction or fallback messages", async () => {
     const harness = await createHarness();


### PR DESCRIPTION
## Summary

- allow the scheduled-wakeup live audit to wait through the full minute-alignment window
- keep a small buffer for the autonomous model turn to complete
- raise the Vitest case timeout accordingly

`ScheduleWakeup(delaySeconds=60)` is persisted as a minute-aligned cron entry. Depending on where scheduling lands within a minute, delivery can take close to two minutes. The previous 75-second predicate timeout can therefore fail even though the idle ACP stream delivers the wakeup correctly. I reproduced both outcomes against current `main`: one run timed out at 75 seconds, while a second run delivered `LIVE_WAKE_OK` through the idle ACP stream.

Related: #838

## Verification

- `npm run check`
- `npm run build`
- `npm run test:run` (971 passed, 27 skipped)
- live SDK/ACP probe on Agent SDK 0.3.238 observed `SCHEDULED` followed by autonomous `LIVE_WAKE_OK` while idle
