### PR TITLE
fix: defer steering while user input is pending

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -251,11 +251,11 @@ const STEER_METHOD = "_session/steering";
 
 /** How urgently the SDK delivers a steered message relative to the running
  *  turn — an internal Claude implementation detail, not part of the wire
- *  contract. `now` pre-empts the current generation and handles the message
- *  immediately (interrupting a single-shot response, or slotting in between a
- *  multi-step turn's tool calls). Maps to `SDKUserMessage.priority`; injected
- *  steering always uses `now` so the running turn adapts as soon as possible. */
-const STEER_PRIORITY = "now" as const;
+ *  contract. `now` pre-empts the current generation, while `later` waits for a
+ *  pending permission/elicitation callback to settle instead of cancelling its
+ *  ACP request and hiding the client's user-input card (IJAI-1191). */
+const STEER_PRIORITY_NOW = "now" as const;
+const STEER_PRIORITY_LATER = "later" as const;
 
 /** Request-level steering options. `promptRequired` is opt-in so existing Hosts
  *  keep the established idle fallback behavior. */
@@ -416,7 +416,7 @@ type Turn = {
   deferredSettle?: PromptResponse;
   /** Uuids of `steer()`-injected messages the SDK has not replayed back yet.
    *
-   *  A steer is delivered at {@link STEER_PRIORITY} (`now`), so the CLI ABORTS
+   *  A steer is normally delivered at priority `now`, so the CLI ABORTS
    *  the running cycle: it emits its own human-origin `result` —
    *  indistinguishable from a turn's terminal one — and the steered message runs
    *  as a SECOND cycle. Settling at that result would answer `session/prompt`
@@ -585,6 +585,11 @@ export type Session = {
   /** Whether nested subagent text/thinking is forwarded to the ACP client.
    *  Enabled by either the ACP capability or the pre-existing SDK option. */
   forwardSubagentText: boolean;
+  /** Number of ACP permission/elicitation requests currently awaiting user
+   *  input. This is a counter rather than a boolean because parallel subagents
+   *  can ask concurrently; steering must remain non-interrupting until the last
+   *  request settles. */
+  pendingUserInputCount?: number;
   /** Context window size of the session's current model, carried across
    *  prompts so mid-stream usage_update notifications report a correct `size`
    *  before the turn's first result message arrives. Seeded synchronously at
@@ -1999,11 +2004,13 @@ export class ClaudeAcpAgent {
    *  an `SDKUserMessage` onto the same streaming input, which the SDK routes
    *  into the in-flight turn. The injected message's echo carries a uuid that
    *  matches no queued turn, so the consumer drops it as an unrelated replay
-   *  without promoting/settling anything. It is delivered at {@link
-   *  STEER_PRIORITY} (`now`) so it pre-empts the current generation (interrupting
-   *  a single-shot response, or slotting in between a multi-step turn's tool
-   *  calls). The steered message's own output streams via `session/update`, not
-   *  this response.
+   *  without promoting/settling anything. It is normally delivered at priority
+   *  `now` so it pre-empts the current generation (interrupting a single-shot
+   *  response, or slotting in between a multi-step turn's tool calls). While a
+   *  permission or elicitation is awaiting user input it uses `later`, because
+   *  interrupting that SDK callback cancels the ACP request and can strand the
+   *  prompt (IJAI-1191). The steered message's own output streams via
+   *  `session/update`, not this response.
    *
    *  Pre-empting means ABORTING: the interrupted cycle emits a `result` of its
    *  own and the steered message runs as a second one, so the turn is marked
@@ -2058,7 +2065,8 @@ export class ClaudeAcpAgent {
     userMessage.uuid = steeredUuid;
     // Deliver into the running turn rather than queuing behind it as a fresh
     // prompt would.
-    userMessage.priority = STEER_PRIORITY;
+    userMessage.priority =
+      (session.pendingUserInputCount ?? 0) > 0 ? STEER_PRIORITY_LATER : STEER_PRIORITY_NOW;
     // Mark before the push and in the same synchronous section as the in-flight
     // check: the interrupt can have the CLI finalizing the aborted cycle by the
     // time the consumer next runs, and an unmarked result would settle the turn
@@ -5236,6 +5244,21 @@ export class ClaudeAcpAgent {
     return response;
   }
 
+  /** Mark a client request as blocking on user input for exactly the lifetime
+   *  of its promise. Steering consults this session-local count synchronously,
+   *  so a message arriving while any permission/elicitation card is open uses
+   *  non-interrupting SDK delivery. */
+  private async withPendingUserInput<T>(sessionId: string, request: () => Promise<T>): Promise<T> {
+    const session = this.sessions[sessionId];
+    if (!session) return request();
+    session.pendingUserInputCount = (session.pendingUserInputCount ?? 0) + 1;
+    try {
+      return await request();
+    } finally {
+      session.pendingUserInputCount = Math.max(0, (session.pendingUserInputCount ?? 1) - 1);
+    }
+  }
+
   /** Forward a permission request to the client, wiring the tool call's
    *  `signal` through as a `cancellationSignal`. When the turn is cancelled
    *  while the client's prompt is still open the signal aborts, the SDK sends
@@ -5269,7 +5292,9 @@ export class ClaudeAcpAgent {
     // cancellation signal. The local race guarantees that Claude's tool call
     // is released even when an older or broken client ignores $/cancel_request.
     try {
-      return await raceWithAbort(this.client.requestPermission(params, signal), signal);
+      return await this.withPendingUserInput(params.sessionId, () =>
+        raceWithAbort(this.client.requestPermission(params, signal), signal),
+      );
     } catch (error) {
       if (signal.aborted) {
         throw new Error("Tool use aborted", { cause: error });
@@ -5538,7 +5563,9 @@ export class ClaudeAcpAgent {
       }
 
       try {
-        const response = await this.client.unstable_createElicitation(createRequest, signal);
+        const response = await this.withPendingUserInput(sessionId, () =>
+          this.client.unstable_createElicitation(createRequest, signal),
+        );
         if (signal.aborted) {
           return { action: "cancel" };
         }
@@ -5574,7 +5601,9 @@ export class ClaudeAcpAgent {
     const createRequest = askUserQuestionsToCreateRequest(questions, sessionId, toolUseID);
     let response;
     try {
-      response = await this.client.unstable_createElicitation(createRequest, signal);
+      response = await this.withPendingUserInput(sessionId, () =>
+        this.client.unstable_createElicitation(createRequest, signal),
+      );
     } catch (error) {
       // A cancellation we requested (signal aborted) settles as an aborted tool
       // use, matching the post-response check below.
@@ -5617,9 +5646,11 @@ export class ClaudeAcpAgent {
       }
       let response: CreateElicitationResponse;
       try {
-        response = await this.client.unstable_createElicitation(
-          refusalFallbackToCreateRequest(prompt, sessionId),
-          signal,
+        response = await this.withPendingUserInput(sessionId, () =>
+          this.client.unstable_createElicitation(
+            refusalFallbackToCreateRequest(prompt, sessionId),
+            signal,
+          ),
         );
       } catch (error) {
         // A cancellation we requested (signal aborted) is expected teardown;

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -12614,6 +12614,111 @@ describe("turn steering (_session/steering)", () => {
     expect(JSON.stringify(injected.message.content)).toContain("also handle X");
   });
 
+  it.each([
+    {
+      name: "a permission request",
+      start: (agent: ClaudeAcpAgent, signal: AbortSignal) =>
+        agent.canUseTool("test-session")("Bash", { command: "npm test" }, {
+          signal,
+          suggestions: [],
+          toolUseID: "tool-permission",
+        } as any),
+      response: { outcome: { outcome: "selected", optionId: "allow-once" } },
+    },
+    {
+      name: "an AskUserQuestion elicitation",
+      start: (agent: ClaudeAcpAgent, signal: AbortSignal) => {
+        (agent as any).clientCapabilities = { elicitation: { form: true, url: true } };
+        return agent.canUseTool("test-session")(
+          "AskUserQuestion",
+          {
+            questions: [
+              {
+                question: "Pick a color",
+                header: "Color",
+                options: [{ label: "Blue", description: "Use blue" }],
+                multiSelect: false,
+              },
+            ],
+          },
+          { signal, suggestions: [], toolUseID: "tool-question" } as any,
+        );
+      },
+      response: { action: "accept", content: { question_0: "Blue" } },
+    },
+    {
+      name: "an MCP elicitation",
+      start: (agent: ClaudeAcpAgent, signal: AbortSignal) =>
+        (agent as any).handleMcpElicitation("test-session", { form: true, url: true })(
+          {
+            mode: "form",
+            message: "Choose",
+            requestedSchema: { type: "object", properties: {} },
+          },
+          { signal },
+        ),
+      response: { action: "accept", content: {} },
+    },
+    {
+      name: "a refusal-fallback user dialog",
+      start: (agent: ClaudeAcpAgent, signal: AbortSignal) =>
+        (agent as any).handleUserDialog("test-session")(
+          {
+            dialogKind: "refusal_fallback_prompt",
+            payload: {
+              originalModel: "claude-fable-5",
+              fallbackModel: "claude-opus-4-8",
+              apiRefusalCategory: "cyber",
+            },
+          },
+          { signal },
+        ),
+      response: { action: "accept", content: { choice: "retry_fallback" } },
+    },
+  ])("uses priority:'later' while $name is pending", async ({ start, response }) => {
+    let resolveUserInput!: (response: any) => void;
+    const userInputResponse = new Promise<any>((resolve) => (resolveUserInput = resolve));
+    const userInputRequest = vi.fn(() => userInputResponse);
+    const input = new Pushable<any>();
+    const inputPush = vi.spyOn(input, "push");
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async () => {},
+        requestPermission: userInputRequest,
+        unstable_createElicitation: userInputRequest,
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    agent.sessions["test-session"] = mockSessionState({
+      input,
+      turnQueue: [
+        {
+          promptUuid: "running",
+          isLocalOnlyCommand: false,
+          settled: false,
+          resolve: () => {},
+          reject: () => {},
+        },
+      ],
+    });
+
+    const pending = start(agent, new AbortController().signal);
+    await waitFor(() => userInputRequest.mock.calls.length === 1);
+
+    await expect(
+      agent.steer({
+        sessionId: "test-session",
+        prompt: [{ type: "text", text: "also handle this" }],
+      }),
+    ).resolves.toEqual({ outcome: "injected" });
+    expect(inputPush).toHaveBeenCalledTimes(1);
+    expect(inputPush.mock.calls[0][0].priority).toBe("later");
+
+    resolveUserInput(response);
+    await pending;
+    expect(agent.sessions["test-session"].pendingUserInputCount).toBe(0);
+  });
+
   it("publishes an optimistic goal update for a steered goal replacement", async () => {
     const updates: any[] = [];
     const agent = new ClaudeAcpAgent(


### PR DESCRIPTION
## Problem

The ACP steering extension injects follow-up user messages into a running Claude SDK turn. Until now, every injected message used priority `now`. That is normally desirable because it makes Claude react immediately, but `now` is interrupting delivery: the SDK aborts the currently running cycle before processing the new message.

This becomes unsafe while the SDK is blocked in a user-input callback, such as a permission request or elicitation. Interrupting that cycle makes the SDK send `$/cancel_request` for the pending ACP request. The client then removes the permission/elicitation card before the user can answer it. Depending on timing, the original ACP prompt can remain pending because the callback and interrupted cycle no longer complete through their normal lifecycle.

The failure sequence was:

1. Claude requests permission or opens an elicitation.
2. The ACP client displays a user-input card and waits for an answer.
3. The user sends a steering message while that card is still open.
4. The adapter injects the message with priority `now`.
5. The Claude SDK interrupts the cycle and emits `$/cancel_request` for the open card.
6. The card disappears, and the original prompt may be left waiting indefinitely.

## Fix

Track the number of permission/elicitation requests currently awaiting user input for each session. Steering now selects its internal SDK delivery priority as follows:

- `later` while at least one user-input request is pending, so the steering message is queued without interrupting or cancelling the open request;
- `now` at all other times, preserving the existing immediate steering behavior.

The state is a counter rather than a boolean because multiple background subagents can have concurrent permission requests. The `finally` cleanup keeps the count correct for accepted, declined, cancelled, aborted, and failed requests.

All ACP-backed user-input paths are covered:

- regular tool permission requests;
- the built-in `AskUserQuestion` form elicitation;
- MCP form/URL elicitations;
- refusal-fallback user dialogs.

## Regression coverage

Added parameterized tests that hold each user-input path open, inject a steering message, and verify that the SDK message uses priority `later`. The existing steering regression test continues to verify priority `now` when no user input is pending. The tests also verify that the pending-user-input state is cleared after the request settles.

Fixes IJAI-1191.

## Validation

- `npm run check`
- `npm run build`
- `env -u ANTHROPIC_BASE_URL npm run test:run` — 975 passed, 27 skipped

`ANTHROPIC_BASE_URL` was removed only for the test command because the Codex environment injects a local proxy URL, while four provider tests intentionally assert the native `https://api.anthropic.com` default.