### PR TITLE
feat: support message-specific ACP session forks

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -290,6 +290,12 @@ function forkPointMessageId(meta: unknown): string | undefined {
   return messageId || undefined;
 }
 
+function forkPointMessageIdCandidates(messageId: string): string[] {
+  // Older AIR builds sent their visible segment id. Prefer the exact id before its ACP source id.
+  const protocolMessageId = messageId.replace(/:segment:\d+$/, "");
+  return protocolMessageId === messageId ? [messageId] : [messageId, protocolMessageId];
+}
+
 /** Params of a {@link STEER_METHOD} request. Shaped like the relevant subset of
  *  a `PromptRequest` so the same `promptToClaude` conversion applies. Delivery
  *  priority is deliberately NOT exposed here — it's an internal detail the agent
@@ -1661,12 +1667,22 @@ export class ClaudeAcpAgent {
     if (this.providerUpdate) await this.providerUpdate;
     const messageId = forkPointMessageId(params._meta);
     if (messageId) {
-      const liveUuid = this.sessions[params.sessionId]?.messageIdToUuid.get(messageId);
+      const candidateIds = forkPointMessageIdCandidates(messageId);
+      const liveMappings = this.sessions[params.sessionId]?.messageIdToUuid;
+      const liveUuid = candidateIds
+        .map((candidateId) => liveMappings?.get(candidateId))
+        .find(Boolean);
+      const history = liveUuid
+        ? undefined
+        : await getSessionMessages(params.sessionId, { dir: params.cwd });
       const messageUuid =
         liveUuid ??
-        (await getSessionMessages(params.sessionId, { dir: params.cwd })).find(
-          (message) => messageIdForGrouping(message) === messageId,
-        )?.uuid;
+        candidateIds
+          .map(
+            (candidateId) =>
+              history?.find((message) => messageIdForGrouping(message) === candidateId)?.uuid,
+          )
+          .find(Boolean);
       if (!messageUuid) {
         throw RequestError.invalidParams(
           { messageId },

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -61,6 +61,7 @@ import {
   EffortLevel,
   FastModeDisabledReason,
   FastModeState,
+  forkSession as forkClaudeSession,
   getSessionMessages,
   listSessions,
   McpServerConfig,
@@ -269,6 +270,25 @@ type SteerMeta = {
     idleBehavior?: "promptRequired";
   };
 };
+
+type ForkSessionMeta = {
+  [key: string]: unknown;
+  jetbrains?: {
+    air?: {
+      fork?: {
+        version?: number;
+        messageId?: string;
+      };
+    };
+  };
+};
+
+function forkPointMessageId(meta: unknown): string | undefined {
+  const fork = (meta as ForkSessionMeta | null | undefined)?.jetbrains?.air?.fork;
+  if (fork?.version !== 1) return undefined;
+  const messageId = fork.messageId?.trim();
+  return messageId || undefined;
+}
 
 /** Params of a {@link STEER_METHOD} request. Shaped like the relevant subset of
  *  a `PromptRequest` so the same `promptToClaude` conversion applies. Delivery
@@ -1639,6 +1659,35 @@ export class ClaudeAcpAgent {
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
+    const messageId = forkPointMessageId(params._meta);
+    if (messageId) {
+      const liveUuid = this.sessions[params.sessionId]?.messageIdToUuid.get(messageId);
+      const messageUuid = liveUuid ?? (await getSessionMessages(params.sessionId, { dir: params.cwd }))
+        .find((message) => messageIdForGrouping(message) === messageId)?.uuid;
+      if (!messageUuid) {
+        throw RequestError.invalidParams(
+          { messageId },
+          `Fork point message ${messageId} was not found in session ${params.sessionId}`,
+        );
+      }
+      const forked = await forkClaudeSession(params.sessionId, {
+        dir: params.cwd,
+        upToMessageId: messageUuid,
+      });
+      const response = await this.createSession(
+        {
+          cwd: params.cwd,
+          mcpServers: params.mcpServers ?? [],
+          additionalDirectories: params.additionalDirectories,
+          _meta: params._meta,
+        },
+        { resume: forked.sessionId },
+      );
+      setTimeout(() => {
+        this.sendAvailableCommandsUpdate(response.sessionId);
+      }, 0);
+      return response;
+    }
     const response = await this.createSession(
       {
         cwd: params.cwd,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1662,8 +1662,11 @@ export class ClaudeAcpAgent {
     const messageId = forkPointMessageId(params._meta);
     if (messageId) {
       const liveUuid = this.sessions[params.sessionId]?.messageIdToUuid.get(messageId);
-      const messageUuid = liveUuid ?? (await getSessionMessages(params.sessionId, { dir: params.cwd }))
-        .find((message) => messageIdForGrouping(message) === messageId)?.uuid;
+      const messageUuid =
+        liveUuid ??
+        (await getSessionMessages(params.sessionId, { dir: params.cwd })).find(
+          (message) => messageIdForGrouping(message) === messageId,
+        )?.uuid;
       if (!messageUuid) {
         throw RequestError.invalidParams(
           { messageId },

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1693,37 +1693,10 @@ export class ClaudeAcpAgent {
         dir: params.cwd,
         upToMessageId: messageUuid,
       });
-      const response = await this.createSession(
-        {
-          cwd: params.cwd,
-          mcpServers: params.mcpServers ?? [],
-          additionalDirectories: params.additionalDirectories,
-          _meta: params._meta,
-        },
-        { resume: forked.sessionId },
-      );
-      setTimeout(() => {
-        this.sendAvailableCommandsUpdate(response.sessionId);
-      }, 0);
-      return response;
+      return { sessionId: forked.sessionId };
     }
-    const response = await this.createSession(
-      {
-        cwd: params.cwd,
-        mcpServers: params.mcpServers ?? [],
-        additionalDirectories: params.additionalDirectories,
-        _meta: params._meta,
-      },
-      {
-        resume: params.sessionId,
-        forkSession: true,
-      },
-    );
-    // Needs to happen after we return the session
-    setTimeout(() => {
-      this.sendAvailableCommandsUpdate(response.sessionId);
-    }, 0);
-    return response;
+    const forked = await forkClaudeSession(params.sessionId, { dir: params.cwd });
+    return { sessionId: forked.sessionId };
   }
 
   async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -61,7 +61,6 @@ import {
   EffortLevel,
   FastModeDisabledReason,
   FastModeState,
-  forkSession as forkClaudeSession,
   getSessionMessages,
   listSessions,
   McpServerConfig,
@@ -119,6 +118,7 @@ import {
   refusalFallbackResultFromResponse,
   refusalFallbackToCreateRequest,
 } from "./elicitation.js";
+import { forkSession } from "./fork-session.js";
 import { ALLOW_BYPASS, resolvePermissionMode } from "./permissions/modes.js";
 import { normalizeDurablePermissionChangeSet } from "./permissions/normalization.js";
 import { buildClaudePermissionOptions } from "./permissions/options.js";
@@ -270,31 +270,6 @@ type SteerMeta = {
     idleBehavior?: "promptRequired";
   };
 };
-
-type ForkSessionMeta = {
-  [key: string]: unknown;
-  jetbrains?: {
-    air?: {
-      fork?: {
-        version?: number;
-        messageId?: string;
-      };
-    };
-  };
-};
-
-function forkPointMessageId(meta: unknown): string | undefined {
-  const fork = (meta as ForkSessionMeta | null | undefined)?.jetbrains?.air?.fork;
-  if (fork?.version !== 1) return undefined;
-  const messageId = fork.messageId?.trim();
-  return messageId || undefined;
-}
-
-function forkPointMessageIdCandidates(messageId: string): string[] {
-  // Older AIR builds sent their visible segment id. Prefer the exact id before its ACP source id.
-  const protocolMessageId = messageId.replace(/:segment:\d+$/, "");
-  return protocolMessageId === messageId ? [messageId] : [messageId, protocolMessageId];
-}
 
 /** Params of a {@link STEER_METHOD} request. Shaped like the relevant subset of
  *  a `PromptRequest` so the same `promptToClaude` conversion applies. Delivery
@@ -1665,38 +1640,10 @@ export class ClaudeAcpAgent {
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
-    const messageId = forkPointMessageId(params._meta);
-    if (messageId) {
-      const candidateIds = forkPointMessageIdCandidates(messageId);
-      const liveMappings = this.sessions[params.sessionId]?.messageIdToUuid;
-      const liveUuid = candidateIds
-        .map((candidateId) => liveMappings?.get(candidateId))
-        .find(Boolean);
-      const history = liveUuid
-        ? undefined
-        : await getSessionMessages(params.sessionId, { dir: params.cwd });
-      const messageUuid =
-        liveUuid ??
-        candidateIds
-          .map(
-            (candidateId) =>
-              history?.find((message) => messageIdForGrouping(message) === candidateId)?.uuid,
-          )
-          .find(Boolean);
-      if (!messageUuid) {
-        throw RequestError.invalidParams(
-          { messageId },
-          `Fork point message ${messageId} was not found in session ${params.sessionId}`,
-        );
-      }
-      const forked = await forkClaudeSession(params.sessionId, {
-        dir: params.cwd,
-        upToMessageId: messageUuid,
-      });
-      return { sessionId: forked.sessionId };
-    }
-    const forked = await forkClaudeSession(params.sessionId, { dir: params.cwd });
-    return { sessionId: forked.sessionId };
+    return forkSession(params, {
+      liveMessageIdToUuid: this.sessions[params.sessionId]?.messageIdToUuid,
+      messageIdForGrouping,
+    });
   }
 
   async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {

--- a/src/fork-session.ts
+++ b/src/fork-session.ts
@@ -1,0 +1,80 @@
+import { ForkSessionRequest, ForkSessionResponse, RequestError } from "@agentclientprotocol/sdk";
+import {
+  forkSession as forkClaudeSession,
+  getSessionMessages,
+} from "@anthropic-ai/claude-agent-sdk";
+
+type ForkSessionMeta = {
+  [key: string]: unknown;
+  jetbrains?: {
+    air?: {
+      fork?: {
+        version?: number;
+        messageId?: string;
+      };
+    };
+  };
+};
+
+type ForkSessionDependencies = {
+  liveMessageIdToUuid?: ReadonlyMap<string, string>;
+  messageIdForGrouping: (message: {
+    type?: string;
+    uuid?: string | null;
+    message?: unknown;
+  }) => string | undefined;
+};
+
+function forkPointMessageId(meta: unknown): string | undefined {
+  const fork = (meta as ForkSessionMeta | null | undefined)?.jetbrains?.air?.fork;
+  if (fork?.version !== 1) return undefined;
+  const messageId = fork.messageId?.trim();
+  return messageId || undefined;
+}
+
+function forkPointMessageIdCandidates(messageId: string): string[] {
+  // Older AIR builds sent their visible segment id. Prefer the exact id before its ACP source id.
+  const protocolMessageId = messageId.replace(/:segment:\d+$/, "");
+  return protocolMessageId === messageId ? [messageId] : [messageId, protocolMessageId];
+}
+
+export async function forkSession(
+  params: ForkSessionRequest,
+  dependencies: ForkSessionDependencies,
+): Promise<ForkSessionResponse> {
+  const messageId = forkPointMessageId(params._meta);
+  if (!messageId) {
+    const forked = await forkClaudeSession(params.sessionId, { dir: params.cwd });
+    return { sessionId: forked.sessionId };
+  }
+
+  const candidateIds = forkPointMessageIdCandidates(messageId);
+  const liveUuid = candidateIds
+    .map((candidateId) => dependencies.liveMessageIdToUuid?.get(candidateId))
+    .find(Boolean);
+  const history = liveUuid
+    ? undefined
+    : await getSessionMessages(params.sessionId, { dir: params.cwd });
+  const messageUuid =
+    liveUuid ??
+    candidateIds
+      .map(
+        (candidateId) =>
+          history?.find((message) => dependencies.messageIdForGrouping(message) === candidateId)
+            ?.uuid,
+      )
+      .find(Boolean);
+
+  if (!messageUuid) {
+    throw RequestError.invalidParams(
+      { messageId },
+      `Fork point message ${messageId} was not found in session ${params.sessionId}`,
+    );
+  }
+
+  const forked = await forkClaudeSession(params.sessionId, {
+    dir: params.cwd,
+    upToMessageId: messageUuid,
+  });
+  return { sessionId: forked.sessionId };
+}

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -49,6 +49,7 @@ import { SessionTitles } from "../session-titles.js";
 import { Pushable } from "../utils.js";
 import {
   deleteSession,
+  forkSession,
   getSessionInfo,
   getSessionMessages,
   PermissionUpdate,
@@ -75,6 +76,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
   return {
     ...actual,
     deleteSession: vi.fn(),
+    forkSession: vi.fn(),
     getSessionInfo: vi.fn(),
     // Delegates to the real implementation so integration tests that read
     // actual transcripts keep working; unit tests override per-call with
@@ -6252,6 +6254,55 @@ describe("session/fork", () => {
         resume: "source-id",
         forkSession: true,
       },
+    );
+  });
+
+  it("forks at an AIR message id through the current SDK", async () => {
+    const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    const createSession = vi.spyOn(agent as any, "createSession").mockResolvedValue({
+      sessionId: "fork-id",
+      modes: { availableModes: [], currentModeId: "default" },
+      configOptions: [],
+    });
+    vi.spyOn(agent as any, "sendAvailableCommandsUpdate").mockImplementation(() => {});
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "assistant-uuid",
+        session_id: "source-id",
+        message: { id: "msg_123", role: "assistant", content: [] },
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+      },
+    ]);
+    vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "sdk-fork-id" });
+
+    const meta = {
+      jetbrains: { air: { fork: { version: 1, messageId: "msg_123" } } },
+    };
+    const response = await agent.unstable_forkSession({
+      sessionId: "source-id",
+      cwd: "/workspace",
+      additionalDirectories: ["/workspace/extra"],
+      mcpServers: [],
+      _meta: meta,
+    });
+
+    expect(response.sessionId).toBe("fork-id");
+    expect(getSessionMessages).toHaveBeenCalledWith("source-id", { dir: "/workspace" });
+    expect(forkSession).toHaveBeenCalledWith("source-id", {
+      dir: "/workspace",
+      upToMessageId: "assistant-uuid",
+    });
+    expect(createSession).toHaveBeenCalledWith(
+      {
+        cwd: "/workspace",
+        additionalDirectories: ["/workspace/extra"],
+        mcpServers: [],
+        _meta: meta,
+      },
+      { resume: "sdk-fork-id" },
     );
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6222,6 +6222,40 @@ describe("logout", () => {
   });
 });
 
+describe("session/fork", () => {
+  it("forks the latest turn in the requested workspace", async () => {
+    const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    const createSession = vi.spyOn(agent as any, "createSession").mockResolvedValue({
+      sessionId: "fork-id",
+      modes: { availableModes: [], currentModeId: "default" },
+      configOptions: [],
+    });
+    vi.spyOn(agent as any, "sendAvailableCommandsUpdate").mockImplementation(() => {});
+
+    const response = await agent.unstable_forkSession({
+      sessionId: "source-id",
+      cwd: "/workspace",
+      additionalDirectories: ["/workspace/extra"],
+      mcpServers: [],
+    });
+
+    expect(response.sessionId).toBe("fork-id");
+    expect(createSession).toHaveBeenCalledWith(
+      {
+        cwd: "/workspace",
+        additionalDirectories: ["/workspace/extra"],
+        mcpServers: [],
+        _meta: undefined,
+      },
+      {
+        resume: "source-id",
+        forkSession: true,
+      },
+    );
+  });
+});
+
 describe("session/close", () => {
   function createMockAgent() {
     const mockClient = {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6228,12 +6228,7 @@ describe("session/fork", () => {
   it("forks the latest turn in the requested workspace", async () => {
     const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
-    const createSession = vi.spyOn(agent as any, "createSession").mockResolvedValue({
-      sessionId: "fork-id",
-      modes: { availableModes: [], currentModeId: "default" },
-      configOptions: [],
-    });
-    vi.spyOn(agent as any, "sendAvailableCommandsUpdate").mockImplementation(() => {});
+    vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
 
     const response = await agent.unstable_forkSession({
       sessionId: "source-id",
@@ -6243,29 +6238,12 @@ describe("session/fork", () => {
     });
 
     expect(response.sessionId).toBe("fork-id");
-    expect(createSession).toHaveBeenCalledWith(
-      {
-        cwd: "/workspace",
-        additionalDirectories: ["/workspace/extra"],
-        mcpServers: [],
-        _meta: undefined,
-      },
-      {
-        resume: "source-id",
-        forkSession: true,
-      },
-    );
+    expect(forkSession).toHaveBeenCalledWith("source-id", { dir: "/workspace" });
   });
 
   it("forks at an AIR message id through the current SDK", async () => {
     const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
-    const createSession = vi.spyOn(agent as any, "createSession").mockResolvedValue({
-      sessionId: "fork-id",
-      modes: { availableModes: [], currentModeId: "default" },
-      configOptions: [],
-    });
-    vi.spyOn(agent as any, "sendAvailableCommandsUpdate").mockImplementation(() => {});
     vi.mocked(getSessionMessages).mockResolvedValueOnce([
       {
         type: "assistant",
@@ -6276,8 +6254,7 @@ describe("session/fork", () => {
         parent_agent_id: null,
       },
     ]);
-    vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "sdk-fork-id" });
-
+    vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
     const meta = {
       jetbrains: { air: { fork: { version: 1, messageId: "msg_123:segment:0" } } },
     };
@@ -6295,15 +6272,6 @@ describe("session/fork", () => {
       dir: "/workspace",
       upToMessageId: "assistant-uuid",
     });
-    expect(createSession).toHaveBeenCalledWith(
-      {
-        cwd: "/workspace",
-        additionalDirectories: ["/workspace/extra"],
-        mcpServers: [],
-        _meta: meta,
-      },
-      { resume: "sdk-fork-id" },
-    );
   });
 });
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6279,7 +6279,7 @@ describe("session/fork", () => {
     vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "sdk-fork-id" });
 
     const meta = {
-      jetbrains: { air: { fork: { version: 1, messageId: "msg_123" } } },
+      jetbrains: { air: { fork: { version: 1, messageId: "msg_123:segment:0" } } },
     };
     const response = await agent.unstable_forkSession({
       sessionId: "source-id",


### PR DESCRIPTION
## Summary

- keep the standard latest-turn ACP fork behavior
- accept an optional AIR fork point at `_meta.jetbrains.air.fork`
- translate the ACP `messageId` to the Claude transcript UUID
- use the current Agent SDK `forkSession(..., { upToMessageId })` API
- resume the new SDK session with the same working directory and additional directories

No Agent SDK dependency update is required. Version `0.3.238` already provides the required API.

## Tests

- `npm run build`
- `npm run lint`
- `env -u ANTHROPIC_BASE_URL npm run test:run` — 981 passed, 27 skipped
