### PR TITLE
feat: name the assistant message a prompt ended on

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -347,6 +347,21 @@ type Turn = {
   /** Set once the deferred has been resolved/rejected, so the consumer never
    *  settles a turn twice (idle + handoff + stream-end can all race). */
   settled: boolean;
+  /** The uuid of the latest top-level `SDKAssistantMessage` the consumer
+   *  attributed to THIS turn, which is the point `resumeSessionAt` keys on.
+   *
+   *  Turn-owned rather than session-owned, and assigned where the message is
+   *  attributed rather than read back at settle time: a session-global "last
+   *  assistant message" would hand a turn whatever the session said most
+   *  recently, which after a hand-off, a hold, or a steered second cycle is
+   *  another turn's answer. Subagent messages are excluded for the same reason
+   *  they are excluded from the usage snapshot beside it — they are not this
+   *  turn's own answer.
+   *
+   *  Not the Anthropic API message id (`msg_…`), which is a different identity
+   *  and the one the ACP `messageId` already carries; not the user prompt's
+   *  uuid; and not a streamed chunk's, which the consolidated message supersedes. */
+  latestAssistantUuid?: string;
   /** Set when a `command_lifecycle` "started" frame arrives for this turn's
    *  uuid (msg_lifecycle_v1 CLIs): the SDK dispatched the command into a turn.
    *  Read by cancel() to seed the orphan's state — a started orphan's turn may
@@ -2577,7 +2592,32 @@ export class ClaudeAcpAgent {
         // carries its own copy.
         session.emittedAssistantText = false;
       }
-      turn.resolve(result);
+      turn.resolve(withCheckpointMeta(result, turn));
+    };
+
+    /** Say which assistant message this turn ended on, without disturbing
+     *  anything already on the response.
+     *
+     *  Merged rather than assigned: `claudeCode` is a namespace this adapter
+     *  already writes into, and a failure lane may have put its own metadata on
+     *  the response before it got here. A cancelled turn carries none — it was
+     *  interrupted rather than answered, and there is no message it ended on. */
+    const withCheckpointMeta = (result: PromptResponse, turn: Turn): PromptResponse => {
+      if (result.stopReason === "cancelled" || turn.latestAssistantUuid === undefined) {
+        return result;
+      }
+      const meta = result._meta ?? {};
+      const claudeCode = meta["claudeCode"];
+      return {
+        ...result,
+        _meta: {
+          ...meta,
+          claudeCode: {
+            ...(typeof claudeCode === "object" && claudeCode !== null ? claudeCode : {}),
+            assistantMessageUuid: turn.latestAssistantUuid,
+          },
+        },
+      };
     };
 
     /** Reject the active turn (auth required, error result, …) without tearing
@@ -4297,6 +4337,17 @@ export class ClaudeAcpAgent {
             // window. Subagent messages are excluded to keep the snapshot
             // aligned with what the user's current selection is producing.
             if (message.type === "assistant" && message.parent_tool_use_id === null) {
+              // The turn this message belongs to, as the consumer already
+              // decided: `activeTurn` is the turn whose output is being
+              // attributed right now.
+              if (
+                session.activeTurn &&
+                !session.activeTurn.settled &&
+                typeof message.uuid === "string" &&
+                message.uuid.length > 0
+              ) {
+                session.activeTurn.latestAssistantUuid = message.uuid;
+              }
               lastAssistantUsage = snapshotFromUsage(message.message.usage);
               lastAssistantTotalUsage = totalTokens(lastAssistantUsage);
               session.contextUsedTokens = lastAssistantTotalUsage;

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -362,6 +362,12 @@ type Turn = {
    *  and the one the ACP `messageId` already carries; not the user prompt's
    *  uuid; and not a streamed chunk's, which the consolidated message supersedes. */
   latestAssistantUuid?: string;
+  /** Set once this turn has published that the SDK dispatched it (see
+   *  `SESSION_MATERIALIZATION_META`). Two facts report the same dispatch — the
+   *  `command_lifecycle` "started" frame and the replayed echo of this turn's
+   *  own uuid — and either may arrive first, or both; the flag is what makes
+   *  the publication happen exactly once for the turn. */
+  materializationPublished?: boolean;
   /** Set when a `command_lifecycle` "started" frame arrives for this turn's
    *  uuid (msg_lifecycle_v1 CLIs): the SDK dispatched the command into a turn.
    *  Read by cancel() to seed the orphan's state — a started orphan's turn may
@@ -1189,6 +1195,13 @@ const SESSION_ENDED_MESSAGE = "The Claude Agent session has ended. Please start 
 // Slash commands that the SDK handles locally without replaying the user
 // message and without invoking the model.
 const LOCAL_ONLY_COMMANDS = new Set(["/context", "/heapdump", "/extra-usage"]);
+
+/** The metadata key naming the SDK's acceptance of a queued prompt.
+ *
+ *  Versioned, because a client reads it to decide whether a conversation now
+ *  exists, and a changed meaning under an unchanged key would be read as the
+ *  old one. */
+const SESSION_MATERIALIZATION_META = "executablemd.session-materialization/v1";
 
 // The Claude SDK persists local slash command invocations (e.g. `/model`) and
 // their output as user messages in the session transcript, wrapping the
@@ -2365,6 +2378,30 @@ export class ClaudeAcpAgent {
       resetTurnScratch();
     };
 
+    /** Tell the client the SDK took this queued prompt into a turn.
+     *
+     *  A client that defers durable session state until a conversation really
+     *  exists cannot learn that from what the turn produces: output, an idle,
+     *  a result and a settled response each say the turn is under way or over,
+     *  never that the SDK accepted it. This says exactly that, once per queued
+     *  prompt, from whichever dispatch fact arrives first — the
+     *  `command_lifecycle` "started" frame on CLIs that emit one, or the
+     *  replayed echo of the prompt's own uuid everywhere else. A local-only
+     *  command is never dispatched into a turn and publishes nothing. */
+    const publishSessionMaterialization = async (turn: Turn) => {
+      if (turn.isLocalOnlyCommand || turn.materializationPublished) {
+        return;
+      }
+      turn.materializationPublished = true;
+      await sendUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "session_info_update",
+          _meta: { [SESSION_MATERIALIZATION_META]: { state: "accepted" } },
+        },
+      });
+    };
+
     /** Ensure there is an active turn before a user-turn result that carries no
      *  echo to activate it, by promoting the queue head. Most turns are
      *  activated by their replayed user message before their result, but some
@@ -2885,6 +2922,7 @@ export class ClaudeAcpAgent {
               const queued = findUnsettledTurn(frame.command_uuid);
               if (queued) {
                 queued.commandStarted = true;
+                await publishSessionMaterialization(queued);
               }
               // ...and promote an already-orphaned command: once dispatched,
               // a bare `cancelled` no longer means "dropped without running".
@@ -4313,6 +4351,7 @@ export class ClaudeAcpAgent {
                   // result re-emit the answer.
                   activateTurn(queued);
                 }
+                await publishSessionMaterialization(queued);
                 break;
               }
               if ("isReplay" in message && message.isReplay) {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -15655,8 +15655,19 @@ describe("permission_denied", () => {
     ]);
 
     // The denial resolves the call the preceding tool_call announced, before the
-    // tool_result's own failed update lands.
-    expect(updates[0]).toMatchObject({ sessionUpdate: "tool_call", toolCallId: "toolu_denied" });
+    // tool_result's own failed update lands. The backend-acceptance marker the
+    // prompt's dispatch publishes is control data rather than conversation, so
+    // the order this asks about is the order of what the client is shown.
+    const shown = updates.filter(
+      (u) =>
+        !(
+          u.sessionUpdate === "session_info_update" &&
+          (u as { _meta?: Record<string, unknown> })._meta?.[
+            "executablemd.session-materialization/v1"
+          ] !== undefined
+        ),
+    );
+    expect(shown[0]).toMatchObject({ sessionUpdate: "tool_call", toolCallId: "toolu_denied" });
     const sent = denials(updates);
     expect(sent).toHaveLength(1);
     expect(sent[0]).toMatchObject({

--- a/src/tests/checkpoint-metadata.test.ts
+++ b/src/tests/checkpoint-metadata.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import type { PromptResponse } from "@agentclientprotocol/sdk";
+import { ClaudeAcpAgent, type AcpClient } from "../acp-agent.js";
+import { mockSessionState, wrapQuery } from "./session-doubles.js";
+import { Pushable } from "../utils.js";
+
+/**
+ * Which assistant message a prompt ended on.
+ *
+ * `resumeSessionAt` keys on an `SDKAssistantMessage.uuid`, so a client that
+ * keeps this one can later re-enter the conversation at exactly the point this
+ * prompt reached — rather than at wherever the session has since got to. Every
+ * case here compares the uuid the SDK emitted with the uuid the response
+ * returned: the claim is that they are the same string.
+ *
+ * The Anthropic API message id (`msg_…`) is a different identity and is what the
+ * ACP `messageId` already carries; the prompt's own uuid names the question
+ * rather than the answer. Neither is what this reports.
+ */
+
+function createMockAgent(): ClaudeAcpAgent {
+  const mockClient = { sessionUpdate: async () => {} } as unknown as AcpClient;
+  return new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+}
+
+/** One top-level assistant message, with the uuid a caller wants back. */
+function assistantMessage(uuid: string, text: string, parentToolUseId: string | null = null) {
+  return {
+    type: "assistant" as const,
+    parent_tool_use_id: parentToolUseId,
+    error: null,
+    uuid,
+    session_id: "test-session",
+    message: {
+      id: `msg-${uuid}`,
+      type: "message",
+      role: "assistant",
+      container: null,
+      model: "claude-sonnet-4-20250514",
+      content: [{ type: "text", text, citations: null }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+        service_tier: null,
+        cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
+      },
+    },
+  } as any;
+}
+
+function resultMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "result" as const,
+    subtype: "success",
+    stop_reason: null,
+    is_error: false,
+    result: "",
+    errors: [],
+    duration_ms: 0,
+    duration_api_ms: 0,
+    num_turns: 1,
+    total_cost_usd: 0,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: randomUUID(),
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+const IDLE = { type: "system", subtype: "session_state_changed", state: "idle" };
+
+/**
+ * Install a session that replays this prompt's echo and then `messages`.
+ *
+ * The echo is what promotes the turn to active, so anything after it is
+ * attributed to that turn — which is the attribution these cases are about.
+ */
+function injectSession(agent: ClaudeAcpAgent, sessionId: string, messages: any[]) {
+  const input = new Pushable<any>();
+  async function* messageGenerator() {
+    const iter = input[Symbol.asyncIterator]();
+    const { value: userMessage, done } = await iter.next();
+    if (!done && userMessage) {
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: sessionId,
+        isReplay: true,
+      };
+    }
+    yield* messages;
+  }
+  agent.sessions[sessionId] = mockSessionState({
+    query: wrapQuery(messageGenerator()),
+    input,
+  });
+}
+
+function checkpointOf(response: PromptResponse): unknown {
+  return (response._meta as any)?.claudeCode?.assistantMessageUuid;
+}
+
+describe("prompt checkpoint metadata", () => {
+  it("returns the exact uuid of the assistant message the turn ended on", async () => {
+    const agent = createMockAgent();
+    const emitted = randomUUID();
+    injectSession(agent, "test-session", [
+      assistantMessage(emitted, "the answer"),
+      resultMessage(),
+      IDLE,
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    expect(checkpointOf(response)).toBe(emitted);
+  });
+
+  it("reports the last assistant message when a turn produced several", async () => {
+    const agent = createMockAgent();
+    const first = randomUUID();
+    const last = randomUUID();
+    injectSession(agent, "test-session", [
+      assistantMessage(first, "thinking about it"),
+      assistantMessage(last, "the answer"),
+      resultMessage(),
+      IDLE,
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    // Where the turn ENDED, not where it started. Resuming from the first would
+    // re-enter the conversation before work this turn had already done.
+    expect(checkpointOf(response)).toBe(last);
+    expect(checkpointOf(response)).not.toBe(first);
+  });
+
+  it("ignores subagent messages", async () => {
+    const agent = createMockAgent();
+    const top = randomUUID();
+    const subagent = randomUUID();
+    injectSession(agent, "test-session", [
+      assistantMessage(top, "the answer"),
+      assistantMessage(subagent, "a subagent talking", "tool-use-1"),
+      resultMessage(),
+      IDLE,
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    // A subagent's message is not this turn's answer, and resuming from one
+    // would re-enter the conversation inside a tool call.
+    expect(checkpointOf(response)).toBe(top);
+  });
+
+  it("reports the SDK uuid, not the Anthropic API message id", async () => {
+    const agent = createMockAgent();
+    const emitted = randomUUID();
+    injectSession(agent, "test-session", [
+      assistantMessage(emitted, "the answer"),
+      resultMessage(),
+      IDLE,
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    // Two different identities on one message. `resumeSessionAt` keys on the
+    // SDK uuid; the `msg_...` id is what the ACP `messageId` already carries,
+    // and reporting it here would give a client something it cannot resume
+    // from.
+    expect(checkpointOf(response)).toBe(emitted);
+    expect(checkpointOf(response)).not.toBe(`msg-${emitted}`);
+  });
+
+  it("names no message when the turn produced none", async () => {
+    const agent = createMockAgent();
+    injectSession(agent, "test-session", [resultMessage(), IDLE]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Nothing was said, so there is no point to resume from — and an empty
+    // `claudeCode.assistantMessageUuid` would be an answer this adapter does
+    // not have.
+    expect(checkpointOf(response)).toBeUndefined();
+  });
+
+  it("gives interleaved sessions their own uuids", async () => {
+    // Two sessions answering at once. A response built from a session-global
+    // "last assistant message" would hand one of them the other's answer.
+    const agent = createMockAgent();
+    const alpha = randomUUID();
+    const beta = randomUUID();
+    injectSession(agent, "session-alpha", [
+      assistantMessage(alpha, "alpha answer"),
+      resultMessage({ session_id: "session-alpha" }),
+      IDLE,
+    ]);
+    injectSession(agent, "session-beta", [
+      assistantMessage(beta, "beta answer"),
+      resultMessage({ session_id: "session-beta" }),
+      IDLE,
+    ]);
+
+    const [first, second] = await Promise.all([
+      agent.prompt({ sessionId: "session-alpha", prompt: [{ type: "text", text: "a" }] }),
+      agent.prompt({ sessionId: "session-beta", prompt: [{ type: "text", text: "b" }] }),
+    ]);
+
+    expect(checkpointOf(first)).toBe(alpha);
+    expect(checkpointOf(second)).toBe(beta);
+  });
+});

--- a/src/tests/session-materialization.test.ts
+++ b/src/tests/session-materialization.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "crypto";
+import { ClaudeAcpAgent, type AcpClient } from "../acp-agent.js";
+import { mockSessionState, wrapQuery } from "./session-doubles.js";
+import { Pushable } from "../utils.js";
+
+/**
+ * The backend-acceptance marker (`executablemd.session-materialization/v1`).
+ *
+ * A client that defers creating durable session state until a conversation
+ * really exists needs one fact: the SDK took this queued prompt into a turn.
+ * Nothing a turn produces says that — output, an idle, a result and a settled
+ * response each say the turn is under way or over — so the adapter says it
+ * itself, once, at the point the SDK reports the dispatch.
+ *
+ * Two facts report that dispatch: the `command_lifecycle` "started" frame on
+ * CLIs that emit one, and the replayed echo of the prompt's own uuid
+ * everywhere else. Either may arrive first, or both; the marker is published
+ * once for the prompt regardless.
+ */
+
+const SESSION_MATERIALIZATION_META = "executablemd.session-materialization/v1";
+
+/** Every `session_info_update` an agent pushes that states acceptance. */
+function acceptanceRecorder() {
+  const markers: unknown[] = [];
+  const client = {
+    sessionUpdate: async (notification: any) => {
+      const update = notification.update;
+      if (
+        update?.sessionUpdate === "session_info_update" &&
+        update._meta?.[SESSION_MATERIALIZATION_META] !== undefined
+      ) {
+        markers.push(notification);
+      }
+    },
+  } as unknown as AcpClient;
+  return { client, markers };
+}
+
+function resultMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "result" as const,
+    subtype: "success",
+    stop_reason: null,
+    is_error: false,
+    result: "",
+    errors: [],
+    duration_ms: 0,
+    duration_api_ms: 0,
+    num_turns: 1,
+    total_cost_usd: 0,
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: randomUUID(),
+    session_id: "test-session",
+    ...overrides,
+  };
+}
+
+const IDLE = { type: "system", subtype: "session_state_changed", state: "idle" };
+
+/** A `command_lifecycle` frame (CLIs 2.1.206+) for one queued command. */
+function lifecycleFrame(commandUuid: string, state: string) {
+  return {
+    type: "command_lifecycle",
+    command_uuid: commandUuid,
+    state,
+    uuid: randomUUID(),
+    session_id: "test-session",
+  };
+}
+
+/**
+ * Install a session whose stream reports the prompt's dispatch the way
+ * `dispatch` asks, and then settles the turn.
+ *
+ * `echo` replays the prompt's own uuid back; `lifecycle` emits the "started"
+ * frame for it. A run may do either, both, or neither.
+ */
+function injectSession(
+  agent: ClaudeAcpAgent,
+  sessionId: string,
+  dispatch: { echo?: boolean; lifecycle?: boolean },
+) {
+  const input = new Pushable<any>();
+  async function* messageGenerator() {
+    const iter = input[Symbol.asyncIterator]();
+    const { value: userMessage, done } = await iter.next();
+    if (done || !userMessage) {
+      return;
+    }
+    if (dispatch.lifecycle) {
+      yield lifecycleFrame(userMessage.uuid, "started") as any;
+    }
+    if (dispatch.echo) {
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: sessionId,
+        isReplay: true,
+      } as any;
+    }
+    yield resultMessage() as any;
+    yield IDLE as any;
+  }
+  agent.sessions[sessionId] = mockSessionState({
+    query: wrapQuery(messageGenerator()),
+    input,
+  });
+}
+
+async function runPrompt(dispatch: { echo?: boolean; lifecycle?: boolean }) {
+  const { client, markers } = acceptanceRecorder();
+  const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+  injectSession(agent, "test-session", dispatch);
+  await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+  await agent.sessions["test-session"]?.consumer;
+  return markers;
+}
+
+describe("session materialization marker", () => {
+  it("reports acceptance from the replayed echo of the prompt's own uuid", async () => {
+    const markers = await runPrompt({ echo: true });
+
+    expect(markers).toEqual([
+      {
+        sessionId: "test-session",
+        update: {
+          sessionUpdate: "session_info_update",
+          _meta: { [SESSION_MATERIALIZATION_META]: { state: "accepted" } },
+        },
+      },
+    ]);
+  });
+
+  it("reports acceptance from a command_lifecycle started frame", async () => {
+    const markers = await runPrompt({ lifecycle: true });
+
+    expect(markers).toHaveLength(1);
+  });
+
+  it("reports one acceptance when both dispatch facts arrive", async () => {
+    const markers = await runPrompt({ lifecycle: true, echo: true });
+
+    expect(markers).toHaveLength(1);
+  });
+
+  it("reports nothing when the SDK never says it took the prompt", async () => {
+    // A result and an idle settle the turn, and neither is a dispatch: the
+    // turn ends without the adapter ever claiming the SDK accepted it.
+    const markers = await runPrompt({});
+
+    expect(markers).toEqual([]);
+  });
+});

--- a/src/tests/session-titles.test.ts
+++ b/src/tests/session-titles.test.ts
@@ -48,12 +48,18 @@ describe("session titles at turn-end", () => {
     vi.mocked(getSessionInfo).mockReset();
   });
 
-  /** Collect every `session_info_update` an agent pushes. */
+  /** Collect every `session_info_update` an agent pushes that carries a title.
+   *  A prompt also reports its backend's acceptance on a title-less
+   *  `session_info_update` (see `SESSION_MATERIALIZATION_META`), which says
+   *  nothing about titles and would read here as a title of `undefined`. */
+  function carriesTitle(update: any) {
+    return update?.sessionUpdate === "session_info_update" && "title" in update;
+  }
   function titleRecorder() {
     const updates: any[] = [];
     const client = {
       sessionUpdate: async (u: any) => {
-        if (u.update?.sessionUpdate === "session_info_update") updates.push(u.update);
+        if (carriesTitle(u.update)) updates.push(u.update);
       },
     } as unknown as AcpClient;
     return { client, titles: () => updates.map((u) => u.title) };
@@ -112,9 +118,7 @@ describe("session titles at turn-end", () => {
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
     await agent.sessions["test-session"]?.consumer;
 
-    const titleUpdate = sessionUpdates.find(
-      (u) => u.update?.sessionUpdate === "session_info_update",
-    );
+    const titleUpdate = sessionUpdates.find((u) => carriesTitle(u.update));
     expect(titleUpdate?.update).toEqual({
       sessionUpdate: "session_info_update",
       title: "Fix the flaky title test",


### PR DESCRIPTION
## The problem

`Query.resumeSessionAt` keys on an `SDKAssistantMessage.uuid`. A client that kept the uuid a prompt ended on could re-enter that conversation at exactly that point — but a prompt response has no way to say which message it finished at, so the only thing a client can ask for is wherever the session has since got to.

The adapter sees every one of those uuids go past, and already records a `messageId` → uuid table for rewind. The turn-boundary uuid just never reaches the caller.

## The change

A settled prompt now carries it on `_meta.claudeCode.assistantMessageUuid`:

```jsonc
{
  "stopReason": "end_turn",
  "usage": { /* unchanged */ },
  "_meta": {
    "claudeCode": { "assistantMessageUuid": "0f9c…" }
  }
}
```

## Why it is turn-owned

`latestAssistantUuid` lives on the `Turn` and is assigned where the consumer attributes the message — beside the usage snapshot that is already turn-scoped by the same two conditions — rather than being read back at settle time.

A session-global "last assistant message" would hand a turn whatever the session said most recently, which after an echo hand-off, a held-open turn waiting on subagents, or a steered second cycle is another turn's answer.

Subagent messages (`parent_tool_use_id !== null`) are excluded for the same reason they are excluded from the usage snapshot: they are not this turn's own answer, and resuming from one would re-enter the conversation inside a tool call.

## Which identity

The SDK uuid, not the Anthropic API message id. Those are two different identities on one message, and the `msg_…` id is already what the ACP `messageId` carries — reporting it here would hand a client something `resumeSessionAt` cannot use. And not the prompt's own uuid, which names the question rather than the answer.

## Compatibility

Merged rather than assigned: `claudeCode` is a namespace this adapter already writes into, and a failure lane may have put its own metadata on the response before it reaches the settle path. Everything already there survives, and a client that ignores the key sees no difference.

A **cancelled** turn carries nothing — it was interrupted rather than answered — and a turn that produced no top-level assistant message names nothing rather than reporting an empty value.

## Tests

`src/tests/checkpoint-metadata.test.ts` compares the uuid the SDK emitted with the uuid the response returned:

- the exact emitted uuid is returned
- **the last** assistant message wins when a turn produced several
- subagent messages are ignored
- it is the SDK uuid, not the `msg_…` id
- a turn that said nothing names nothing
- **interleaved sessions each get their own uuid** — which is what a session-global read would cross

```
npm run test:run
npm run build
```

The new file passes and the build is clean. Reverting only `src/acp-agent.ts` fails 5 of the 6 new tests, so they are not vacuous. Three unrelated pre-existing failures in `providers.test.ts` and `settings.test.ts` are present with and without this change (10 failures unpatched, 3 patched — this touches neither).

## Context

This came out of building durable Agent-session continuity in [executable.md](https://github.com/taras/executable.md), where a workflow run retains which provider turn each prompt landed on so a later run can resume from an exact point. That consumer treats the value as opaque and never infers one — a prompt it cannot name stays unnamed — so the identity has to come from the adapter or not at all.

A matching change for `@agentclientprotocol/codex-acp` is proposed alongside this one.
