### PR TITLE
feat: resolve cross-session ACP resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview#br
 This tool implements an ACP agent by using the official [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview), supporting:
 
 - Context @-mentions
+- [Cross-session references](docs/session-references.md) resolved through the Claude Agent SDK
 - Images
 - Tool calls (with permission requests)
 - Following

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview#br
 This tool implements an ACP agent by using the official [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview), supporting:
 
 - Context @-mentions
-- [Cross-session references](docs/session-references.md) resolved through the Claude Agent SDK
+- [Cross-session references](docs/session-references.md) to other Claude sessions
 - Images
 - Tool calls (with permission requests)
 - Following

--- a/docs/session-references.md
+++ b/docs/session-references.md
@@ -10,20 +10,33 @@ The client can include extra query parameters for its own navigation. The adapte
 
 This URI is an adapter convention inside the standard ACP `resource_link` block. It does not add an ACP method or schema field.
 
-Before a prompt or steering request starts, the adapter calls `getSessionMessages`.
-It uses the active working directory and sets `includeSystemMessages: true`.
-It replaces the link with an embedded JSON resource:
+## The reference becomes a one-line mention
 
-```json
-{
-  "type": "session_reference",
-  "sessionId": "source-session-id",
-  "title": "Source chat",
-  "messages": []
-}
+The adapter replaces the link with one markdown link, in the position the link occupied:
+
+```text
+[Claude session "Source chat"](claude://sessions/source-session)
 ```
 
-The adapter preserves the order of prompt blocks. It leaves resource links with other URI schemes unchanged.
+That is the whole resolution, and it is what lands in the stored transcript. `acp-session:` is the
+client's wire format and stops at the adapter boundary; the model sees a title and an id.
 
-The adapter rejects a reference to the active Claude session. A failed SDK read also fails the prompt request.
-The adapter sends the full message history and does not truncate or summarize it.
+There is no standard to follow here, so this is an adapter convention. ACP defines `resource_link`
+but no way to point at another agent session. Codex's `codex://threads/<id>` is a desktop deep link
+its app resolves, not a model affordance. The `prompt:` URI scheme
+([draft-boone-prompt-uri-scheme](https://datatracker.ietf.org/doc/draft-boone-prompt-uri-scheme/))
+is an individual Internet-Draft with no adoption. The mention above is therefore written for the
+model rather than for a URL handler: it says "session", carries the id, and fits on one line.
+
+The referenced transcript is not inlined, because a chat is usually far larger than the part that
+matters. The model opens the reference with the session-management tools when it needs to —
+`mcp__ccd_session_mgmt__list_events` for the turns, `get_session` for metadata,
+`search_session_transcripts` to find one part of it. The mention does not describe those tools;
+their own descriptions do.
+
+Resolution is local and synchronous: the adapter reads no session history itself, so a prompt
+carrying a reference cannot fail on a transcript read. If the session-management tools are not
+available in the host, the reference is a link the model cannot open.
+
+The adapter preserves the order of prompt blocks and leaves resource links with other URI schemes
+unchanged. It rejects a reference to the active Claude session.

--- a/docs/session-references.md
+++ b/docs/session-references.md
@@ -34,9 +34,12 @@ matters. The model opens the reference with the session-management tools when it
 `search_session_transcripts` to find one part of it. The mention does not describe those tools;
 their own descriptions do.
 
+The rewrite happens in `promptToClaude`, in the same `resource_link` branch that already turns
+`file://` and `zed://` links into `[@name](uri)` — a session link is just one more scheme handled
+there, not a separate pass over the prompt. A string compare on the URI decides it, so ordinary
+links cost nothing extra, and block order is preserved because nothing is reordered.
+
 Resolution is local and synchronous: the adapter reads no session history itself, so a prompt
 carrying a reference cannot fail on a transcript read. If the session-management tools are not
-available in the host, the reference is a link the model cannot open.
-
-The adapter preserves the order of prompt blocks and leaves resource links with other URI schemes
-unchanged. It rejects a reference to the active Claude session.
+available in the host, the reference is a link the model cannot open. A reference to the active
+Claude session is rejected with `invalid_params`.

--- a/docs/session-references.md
+++ b/docs/session-references.md
@@ -1,0 +1,29 @@
+# Cross-session references
+
+The adapter resolves an ACP `resource_link` as a Claude session reference when its URI has this form:
+
+```text
+acp-session://reference?sessionId=<Claude session id>
+```
+
+The client can include extra query parameters for its own navigation. The adapter reads only `sessionId`.
+
+This URI is an adapter convention inside the standard ACP `resource_link` block. It does not add an ACP method or schema field.
+
+Before a prompt or steering request starts, the adapter calls `getSessionMessages`.
+It uses the active working directory and sets `includeSystemMessages: true`.
+It replaces the link with an embedded JSON resource:
+
+```json
+{
+  "type": "session_reference",
+  "sessionId": "source-session-id",
+  "title": "Source chat",
+  "messages": []
+}
+```
+
+The adapter preserves the order of prompt blocks. It leaves resource links with other URI schemes unchanged.
+
+The adapter rejects a reference to the active Claude session. A failed SDK read also fails the prompt request.
+The adapter sends the full message history and does not truncate or summarize it.

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -97,6 +97,7 @@ import {
   toGoalSnapshot,
 } from "./goal-extension.js";
 import { sanitizeTitle, SessionTitles } from "./session-titles.js";
+import { resolveSessionResourceLinks } from "./session-references.js";
 import {
   AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
   AcpSessionNotification,
@@ -2207,7 +2208,8 @@ export class ClaudeAcpAgent {
       await this.publishTaskPlan(params.sessionId, session.taskState);
     }
 
-    const userMessage = promptToClaude(params);
+    const resolvedPrompt = await resolveSessionResourceLinks(params, session.cwd);
+    const userMessage = promptToClaude(resolvedPrompt);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
 
@@ -2406,7 +2408,8 @@ export class ClaudeAcpAgent {
       sessionId,
       prompt: params.prompt,
     };
-    const userMessage = promptToClaude(promptRequest);
+    const resolvedPrompt = await resolveSessionResourceLinks(promptRequest, session.cwd);
+    const userMessage = promptToClaude(resolvedPrompt);
     const steeredUuid = randomUUID();
     userMessage.uuid = steeredUuid;
     // Deliver into the running turn rather than queuing behind it as a fresh

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -97,7 +97,7 @@ import {
   toGoalSnapshot,
 } from "./goal-extension.js";
 import { sanitizeTitle, SessionTitles } from "./session-titles.js";
-import { resolveSessionResourceLinks } from "./session-references.js";
+import { sessionMentionForLink } from "./session-references.js";
 import {
   AIR_NATIVE_SUBAGENT_SESSIONS_CAPABILITY,
   AcpSessionNotification,
@@ -2208,8 +2208,7 @@ export class ClaudeAcpAgent {
       await this.publishTaskPlan(params.sessionId, session.taskState);
     }
 
-    const resolvedPrompt = resolveSessionResourceLinks(params);
-    const userMessage = promptToClaude(resolvedPrompt);
+    const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
 
@@ -2408,8 +2407,7 @@ export class ClaudeAcpAgent {
       sessionId,
       prompt: params.prompt,
     };
-    const resolvedPrompt = resolveSessionResourceLinks(promptRequest);
-    const userMessage = promptToClaude(resolvedPrompt);
+    const userMessage = promptToClaude(promptRequest);
     const steeredUuid = randomUUID();
     userMessage.uuid = steeredUuid;
     // Deliver into the running turn rather than queuing behind it as a fresh
@@ -8697,10 +8695,12 @@ export function promptToClaude(prompt: PromptRequest): SDKUserMessage {
         break;
       }
       case "resource_link": {
-        const formattedUri = formatUriAsLink(chunk.uri);
+        // A reference to another Claude session becomes a mention the model can
+        // act on; every other link keeps its usual `[@name](uri)` rendering.
+        const mention = sessionMentionForLink(chunk.uri, chunk.name, prompt.sessionId);
         content.push({
           type: "text",
-          text: formattedUri,
+          text: mention ?? formatUriAsLink(chunk.uri),
         });
         break;
       }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2208,7 +2208,7 @@ export class ClaudeAcpAgent {
       await this.publishTaskPlan(params.sessionId, session.taskState);
     }
 
-    const resolvedPrompt = await resolveSessionResourceLinks(params, session.cwd);
+    const resolvedPrompt = resolveSessionResourceLinks(params);
     const userMessage = promptToClaude(resolvedPrompt);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -2408,7 +2408,7 @@ export class ClaudeAcpAgent {
       sessionId,
       prompt: params.prompt,
     };
-    const resolvedPrompt = await resolveSessionResourceLinks(promptRequest, session.cwd);
+    const resolvedPrompt = resolveSessionResourceLinks(promptRequest);
     const userMessage = promptToClaude(resolvedPrompt);
     const steeredUuid = randomUUID();
     userMessage.uuid = steeredUuid;

--- a/src/acp-subagents.ts
+++ b/src/acp-subagents.ts
@@ -49,7 +49,7 @@ export type AsyncTaskSpawnedUpdate = {
   asyncTaskId: string;
   name: string;
   taskType: string;
-  description: string;
+  description?: string;
   showInTranscript: boolean;
   canStop: boolean;
   outputFilePath?: string;

--- a/src/async-tasks.ts
+++ b/src/async-tasks.ts
@@ -460,7 +460,7 @@ export class AsyncTaskRuntime {
         asyncTaskId: task.id,
         name: task.name,
         taskType: task.taskType,
-        description: task.description,
+        ...(task.description !== task.name ? { description: task.description } : {}),
         showInTranscript: task.showInTranscript,
         canStop: true,
         ...(task.outputFilePath ? { outputFilePath: task.outputFilePath } : {}),

--- a/src/session-references.ts
+++ b/src/session-references.ts
@@ -1,10 +1,24 @@
 import { type PromptRequest, RequestError } from "@agentclientprotocol/sdk";
-import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
 
-export async function resolveSessionResourceLinks(
-  prompt: PromptRequest,
-  cwd: string,
-): Promise<PromptRequest> {
+/**
+ * Rewrites `acp-session://reference?sessionId=…` resource links into a short,
+ * self-describing session mention.
+ *
+ * There is no standard to follow here. ACP defines `resource_link` but no
+ * convention for pointing at another agent session; Codex's `codex://threads/<id>`
+ * is a desktop deep link the app resolves, not something a model is expected to
+ * act on; and the `prompt:` URI scheme (draft-boone-prompt-uri-scheme) is an
+ * individual Internet-Draft with no adoption. So this is our own convention, and
+ * it is aimed at the model rather than at a URL handler: say "session", give the
+ * id, keep it to one line.
+ *
+ * The referenced transcript is deliberately *not* inlined -- a chat is usually far
+ * larger than the part that matters, and the session-management tools read it on
+ * demand. The mention does not explain those tools either; their own descriptions
+ * do. And `acp-session:` is the client's wire format, which means nothing to the
+ * model, so it stops at this boundary.
+ */
+export function resolveSessionResourceLinks(prompt: PromptRequest): PromptRequest {
   const resolved: PromptRequest["prompt"] = [];
   for (const block of prompt.prompt) {
     if (block.type !== "resource_link") {
@@ -19,25 +33,18 @@ export async function resolveSessionResourceLinks(
     if (sessionId === prompt.sessionId) {
       throw RequestError.invalidParams(undefined, "A session cannot reference itself");
     }
-    const messages = await getSessionMessages(sessionId, {
-      dir: cwd,
-      includeSystemMessages: true,
-    });
     resolved.push({
-      type: "resource",
-      resource: {
-        uri: block.uri,
-        mimeType: "application/json",
-        text: JSON.stringify({
-          type: "session_reference",
-          sessionId,
-          title: block.name,
-          messages,
-        }),
-      },
+      type: "text",
+      text: sessionMention(sessionId, block.name),
     });
   }
   return { ...prompt, prompt: resolved };
+}
+
+/** One line, in the position the link occupied. */
+function sessionMention(sessionId: string, title: string): string {
+  const label = title ? `Claude session "${title}"` : "Claude session";
+  return `[${label}](claude://sessions/${encodeURIComponent(sessionId)})`;
 }
 
 function acpSessionId(uri: string): string | null {

--- a/src/session-references.ts
+++ b/src/session-references.ts
@@ -1,0 +1,51 @@
+import { type PromptRequest, RequestError } from "@agentclientprotocol/sdk";
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
+
+export async function resolveSessionResourceLinks(
+  prompt: PromptRequest,
+  cwd: string,
+): Promise<PromptRequest> {
+  const resolved: PromptRequest["prompt"] = [];
+  for (const block of prompt.prompt) {
+    if (block.type !== "resource_link") {
+      resolved.push(block);
+      continue;
+    }
+    const sessionId = acpSessionId(block.uri);
+    if (sessionId === null) {
+      resolved.push(block);
+      continue;
+    }
+    if (sessionId === prompt.sessionId) {
+      throw RequestError.invalidParams(undefined, "A session cannot reference itself");
+    }
+    const messages = await getSessionMessages(sessionId, {
+      dir: cwd,
+      includeSystemMessages: true,
+    });
+    resolved.push({
+      type: "resource",
+      resource: {
+        uri: block.uri,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          type: "session_reference",
+          sessionId,
+          title: block.name,
+          messages,
+        }),
+      },
+    });
+  }
+  return { ...prompt, prompt: resolved };
+}
+
+function acpSessionId(uri: string): string | null {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol !== "acp-session:" || parsed.hostname !== "reference") return null;
+    return parsed.searchParams.get("sessionId")?.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/session-references.ts
+++ b/src/session-references.ts
@@ -1,8 +1,9 @@
-import { type PromptRequest, RequestError } from "@agentclientprotocol/sdk";
+import { RequestError } from "@agentclientprotocol/sdk";
 
 /**
- * Rewrites `acp-session://reference?sessionId=…` resource links into a short,
- * self-describing session mention.
+ * Rewrites an `acp-session://reference?sessionId=…` resource link into a short,
+ * self-describing session mention. Returns `null` for any other link, so the
+ * caller falls through to its normal resource-link handling.
  *
  * There is no standard to follow here. ACP defines `resource_link` but no
  * convention for pointing at another agent session; Codex's `codex://threads/<id>`
@@ -18,32 +19,19 @@ import { type PromptRequest, RequestError } from "@agentclientprotocol/sdk";
  * do. And `acp-session:` is the client's wire format, which means nothing to the
  * model, so it stops at this boundary.
  */
-export function resolveSessionResourceLinks(prompt: PromptRequest): PromptRequest {
-  const resolved: PromptRequest["prompt"] = [];
-  for (const block of prompt.prompt) {
-    if (block.type !== "resource_link") {
-      resolved.push(block);
-      continue;
-    }
-    const sessionId = acpSessionId(block.uri);
-    if (sessionId === null) {
-      resolved.push(block);
-      continue;
-    }
-    if (sessionId === prompt.sessionId) {
-      throw RequestError.invalidParams(undefined, "A session cannot reference itself");
-    }
-    resolved.push({
-      type: "text",
-      text: sessionMention(sessionId, block.name),
-    });
+export function sessionMentionForLink(
+  uri: string,
+  name: string,
+  activeSessionId: string,
+): string | null {
+  // A string compare first, so ordinary `file://` links never reach the parser.
+  if (!uri.startsWith("acp-session:")) return null;
+  const sessionId = acpSessionId(uri);
+  if (sessionId === null) return null;
+  if (sessionId === activeSessionId) {
+    throw RequestError.invalidParams(undefined, "A session cannot reference itself");
   }
-  return { ...prompt, prompt: resolved };
-}
-
-/** One line, in the position the link occupied. */
-function sessionMention(sessionId: string, title: string): string {
-  const label = title ? `Claude session "${title}"` : "Claude session";
+  const label = name ? `Claude session "${name}"` : "Claude session";
   return `[${label}](claude://sessions/${encodeURIComponent(sessionId)})`;
 }
 

--- a/src/tests/async-tasks.test.ts
+++ b/src/tests/async-tasks.test.ts
@@ -56,12 +56,12 @@ describe("AsyncTaskRuntime", () => {
       asyncTaskId: "bpux8xmfg",
       name: "npm run build",
       taskType: "shell",
-      description: "npm run build",
       showInTranscript: true,
       canStop: true,
       outputFilePath: "/private/tmp/claude/tasks/bpux8xmfg.output",
       toolCallId: "bash-tool",
     });
+    expect(updates[0].update).not.toHaveProperty("description");
   });
 
   it("publishes a stopped terminal after a task-specific stop", async () => {
@@ -339,6 +339,7 @@ describe("AsyncTaskRuntime", () => {
       asyncTaskId: "task-1",
       name: "assets",
       taskType: "workflow",
+      description: "Build generated assets",
       showInTranscript: true,
     });
     expect(published[1]?.update).toMatchObject({
@@ -453,9 +454,10 @@ describe("AsyncTaskRuntime", () => {
       "async_task_state_update",
     ]);
     expect(published[0]?.update).toMatchObject({
-      description: "Fast build",
+      name: "Fast build",
       outputFilePath: "/tmp/tasks/fast-shell.output",
     });
+    expect(published[0]?.update).not.toHaveProperty("description");
     expect(published[1]?.update).toMatchObject({
       state: "completed",
       summary: "Already done",
@@ -630,9 +632,9 @@ describe("AsyncTaskRuntime", () => {
       sessionUpdate: "async_task_spawned",
       asyncTaskId: "lost-start",
       taskType: "shell",
-      description: "Build",
       showInTranscript: false,
     });
+    expect(published[0]?.update).not.toHaveProperty("description");
   });
 
   it("keeps level-only recovery panel-only when task_started arrives late", async () => {

--- a/src/tests/session-references.test.ts
+++ b/src/tests/session-references.test.ts
@@ -1,49 +1,45 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionResourceLinks } from "../session-references.js";
+import { promptToClaude } from "../acp-agent.js";
+import { sessionMentionForLink } from "../session-references.js";
 
 describe("session references", () => {
-  it("rewrites an ACP session link into a session mention in place", () => {
-    const resolved = resolveSessionResourceLinks({
-      sessionId: "current-session",
+  it("mentions a referenced session by title and id", () => {
+    expect(
+      sessionMentionForLink("acp-session://reference?sessionId=source", "Source chat", "current"),
+    ).toBe('[Claude session "Source chat"](claude://sessions/source)');
+  });
+
+  it("passes over links with other URI schemes", () => {
+    expect(sessionMentionForLink("file:///workspace/main.ts", "main.ts", "current")).toBeNull();
+    expect(
+      sessionMentionForLink("acp-session://other?sessionId=source", "x", "current"),
+    ).toBeNull();
+  });
+
+  it("rejects a reference to the active Claude session", () => {
+    expect(() =>
+      sessionMentionForLink("acp-session://reference?sessionId=current", "Current chat", "current"),
+    ).toThrow("A session cannot reference itself");
+  });
+
+  it("renders session links and file links side by side in one prompt", () => {
+    const message = promptToClaude({
+      sessionId: "current",
       prompt: [
         { type: "text", text: "compare with" },
         {
           type: "resource_link",
           name: "Source chat",
-          uri: "acp-session://reference?sessionId=source-session",
+          uri: "acp-session://reference?sessionId=source",
         },
+        { type: "resource_link", name: "main.ts", uri: "file:///workspace/main.ts" },
       ],
     });
 
-    expect(resolved.prompt[0]).toEqual({ type: "text", text: "compare with" });
-    expect(resolved.prompt[1]).toEqual({
-      type: "text",
-      text: '[Claude session "Source chat"](claude://sessions/source-session)',
-    });
-  });
-
-  it("leaves other resource links untouched", () => {
-    const link = {
-      type: "resource_link" as const,
-      name: "file",
-      uri: "file:///workspace/main.ts",
-    };
-    const resolved = resolveSessionResourceLinks({ sessionId: "current-session", prompt: [link] });
-    expect(resolved.prompt).toEqual([link]);
-  });
-
-  it("rejects a link to the active Claude session", () => {
-    expect(() =>
-      resolveSessionResourceLinks({
-        sessionId: "current-session",
-        prompt: [
-          {
-            type: "resource_link",
-            name: "Current chat",
-            uri: "acp-session://reference?sessionId=current-session",
-          },
-        ],
-      }),
-    ).toThrow("A session cannot reference itself");
+    expect(message.message.content).toEqual([
+      { type: "text", text: "compare with" },
+      { type: "text", text: '[Claude session "Source chat"](claude://sessions/source)' },
+      { type: "text", text: "[@main.ts](file:///workspace/main.ts)" },
+    ]);
   });
 });

--- a/src/tests/session-references.test.ts
+++ b/src/tests/session-references.test.ts
@@ -1,0 +1,75 @@
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionResourceLinks } from "../session-references.js";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
+  return {
+    ...actual,
+    getSessionMessages: vi.fn(actual.getSessionMessages),
+  };
+});
+
+describe("session references", () => {
+  beforeEach(() => {
+    vi.mocked(getSessionMessages).mockReset();
+  });
+
+  it("resolves an ACP session link through Claude session history", async () => {
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "answer",
+        session_id: "source-session",
+        message: { role: "assistant", content: [{ type: "text", text: "Resolved answer" }] },
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+      },
+    ]);
+
+    const resolved = await resolveSessionResourceLinks(
+      {
+        sessionId: "current-session",
+        prompt: [
+          {
+            type: "resource_link",
+            name: "Source chat",
+            uri: "acp-session://reference?sessionId=source-session",
+          },
+        ],
+      },
+      "/workspace",
+    );
+
+    expect(getSessionMessages).toHaveBeenCalledWith("source-session", {
+      dir: "/workspace",
+      includeSystemMessages: true,
+    });
+    expect(resolved.prompt).toEqual([
+      expect.objectContaining({
+        type: "resource",
+        resource: expect.objectContaining({ text: expect.stringContaining("Resolved answer") }),
+      }),
+    ]);
+  });
+
+  it("rejects a link to the active Claude session", async () => {
+    await expect(
+      resolveSessionResourceLinks(
+        {
+          sessionId: "current-session",
+          prompt: [
+            {
+              type: "resource_link",
+              name: "Current chat",
+              uri: "acp-session://reference?sessionId=current-session",
+            },
+          ],
+        },
+        "/workspace",
+      ),
+    ).rejects.toThrow("A session cannot reference itself");
+
+    expect(getSessionMessages).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/session-references.test.ts
+++ b/src/tests/session-references.test.ts
@@ -1,75 +1,49 @@
-import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveSessionResourceLinks } from "../session-references.js";
 
-vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
-  return {
-    ...actual,
-    getSessionMessages: vi.fn(actual.getSessionMessages),
-  };
-});
-
 describe("session references", () => {
-  beforeEach(() => {
-    vi.mocked(getSessionMessages).mockReset();
+  it("rewrites an ACP session link into a session mention in place", () => {
+    const resolved = resolveSessionResourceLinks({
+      sessionId: "current-session",
+      prompt: [
+        { type: "text", text: "compare with" },
+        {
+          type: "resource_link",
+          name: "Source chat",
+          uri: "acp-session://reference?sessionId=source-session",
+        },
+      ],
+    });
+
+    expect(resolved.prompt[0]).toEqual({ type: "text", text: "compare with" });
+    expect(resolved.prompt[1]).toEqual({
+      type: "text",
+      text: '[Claude session "Source chat"](claude://sessions/source-session)',
+    });
   });
 
-  it("resolves an ACP session link through Claude session history", async () => {
-    vi.mocked(getSessionMessages).mockResolvedValueOnce([
-      {
-        type: "assistant",
-        uuid: "answer",
-        session_id: "source-session",
-        message: { role: "assistant", content: [{ type: "text", text: "Resolved answer" }] },
-        parent_tool_use_id: null,
-        parent_agent_id: null,
-      },
-    ]);
+  it("leaves other resource links untouched", () => {
+    const link = {
+      type: "resource_link" as const,
+      name: "file",
+      uri: "file:///workspace/main.ts",
+    };
+    const resolved = resolveSessionResourceLinks({ sessionId: "current-session", prompt: [link] });
+    expect(resolved.prompt).toEqual([link]);
+  });
 
-    const resolved = await resolveSessionResourceLinks(
-      {
+  it("rejects a link to the active Claude session", () => {
+    expect(() =>
+      resolveSessionResourceLinks({
         sessionId: "current-session",
         prompt: [
           {
             type: "resource_link",
-            name: "Source chat",
-            uri: "acp-session://reference?sessionId=source-session",
+            name: "Current chat",
+            uri: "acp-session://reference?sessionId=current-session",
           },
         ],
-      },
-      "/workspace",
-    );
-
-    expect(getSessionMessages).toHaveBeenCalledWith("source-session", {
-      dir: "/workspace",
-      includeSystemMessages: true,
-    });
-    expect(resolved.prompt).toEqual([
-      expect.objectContaining({
-        type: "resource",
-        resource: expect.objectContaining({ text: expect.stringContaining("Resolved answer") }),
       }),
-    ]);
-  });
-
-  it("rejects a link to the active Claude session", async () => {
-    await expect(
-      resolveSessionResourceLinks(
-        {
-          sessionId: "current-session",
-          prompt: [
-            {
-              type: "resource_link",
-              name: "Current chat",
-              uri: "acp-session://reference?sessionId=current-session",
-            },
-          ],
-        },
-        "/workspace",
-      ),
-    ).rejects.toThrow("A session cannot reference itself");
-
-    expect(getSessionMessages).not.toHaveBeenCalled();
+    ).toThrow("A session cannot reference itself");
   });
 });


### PR DESCRIPTION
## Summary

- Resolve ACP session resource links through the Claude adapter.
- Mention referenced sessions without copying their full transcript into the prompt.
- Omit async task descriptions when they repeat the task name.

## Validation

- `npm run check`
- `npm run build`
- `env -u ANTHROPIC_BASE_URL npm run test:run` (1071 passed, 27 skipped)