### PR TITLE
fix: match WSL session list cwd casing

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1202,6 +1202,11 @@ const SUPPORTED_PROTOCOLS: LlmProtocol[] = ["anthropic", "bedrock", "vertex"];
 const PROVIDER_ID = "main";
 const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com";
 
+function normalizeSessionListDir(dir: string | undefined): string | undefined {
+  if (dir === undefined) return undefined;
+  return /^\/mnt\/[a-z](?:\/|$)/i.test(dir) ? dir.toLowerCase() : dir;
+}
+
 /**
  * Vertex needs project + region that the standard `providers/set` payload
  * (`apiType`/`baseUrl`/`headers`) does not model, so clients pass them through
@@ -2168,7 +2173,9 @@ export class ClaudeAcpAgent {
   }
 
   async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
-    const sdk_sessions = await listSessions({ dir: params.cwd ?? undefined });
+    const sdk_sessions = await listSessions({
+      dir: normalizeSessionListDir(params.cwd ?? undefined),
+    });
     const sessions = [];
 
     for (const session of sdk_sessions) {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -57,6 +57,7 @@ import {
   getSessionInfo,
   getSessionMessages,
   importSessionToStore,
+  listSessions,
   PermissionUpdate,
   query,
   SDKAssistantMessage,
@@ -85,6 +86,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
     forkSession: vi.fn(),
     getSessionInfo: vi.fn(),
     importSessionToStore: vi.fn(actual.importSessionToStore),
+    listSessions: vi.fn(actual.listSessions),
     // Delegates to the real implementation so integration tests that read
     // actual transcripts keep working; unit tests override per-call with
     // `mockResolvedValueOnce`.
@@ -8405,6 +8407,53 @@ describe("logout", () => {
         "asyncTasks",
       ],
     });
+  });
+});
+
+describe("session/list", () => {
+  function createMockAgent() {
+    const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
+    return new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+  }
+
+  beforeEach(() => {
+    vi.mocked(listSessions).mockReset();
+  });
+
+  it("normalizes WSL drive cwd casing before querying stored sessions", async () => {
+    const agent = createMockAgent();
+    vi.mocked(listSessions).mockResolvedValueOnce([
+      {
+        sessionId: "session-1",
+        cwd: "/mnt/c/Users/Me/Notes/MyVault",
+        summary: "Project work",
+        lastModified: 1_725_000_000_000,
+      },
+    ] as Awaited<ReturnType<typeof listSessions>>);
+
+    const response = await agent.listSessions({
+      cwd: "/mnt/c/Users/Me/Notes/MyVault",
+      cursor: null,
+    });
+
+    expect(listSessions).toHaveBeenCalledWith({ dir: "/mnt/c/users/me/notes/myvault" });
+    expect(response.sessions).toEqual([
+      {
+        sessionId: "session-1",
+        cwd: "/mnt/c/Users/Me/Notes/MyVault",
+        title: "Project work",
+        updatedAt: new Date(1_725_000_000_000).toISOString(),
+      },
+    ]);
+  });
+
+  it("leaves non-WSL cwd filters case-preserving", async () => {
+    const agent = createMockAgent();
+    vi.mocked(listSessions).mockResolvedValueOnce([]);
+
+    await agent.listSessions({ cwd: "/Work/Project", cursor: null });
+
+    expect(listSessions).toHaveBeenCalledWith({ dir: "/Work/Project" });
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize `/mnt/<drive>/...` cwd filters before calling the Claude SDK session index
- keep non-WSL paths case-preserving
- add `session/list` coverage for the WSL drive-path case

Fixes #1041

## Verification
- `npm run test:run -- src/tests/acp-agent.test.ts -t 'session/list'`
- `npm run test:run -- src/tests/acp-agent.test.ts`
- `npm run build`
- `npm run check`
- `git diff --check`

I also ran `npm run test:run`; it reached `1044 passed, 27 skipped` and failed only the two existing root-environment `resolvePermissionMode` expectations where `bypassPermissions` is downgraded to `default` when tests run as root.
