### PR TITLE
fix: preserve selected AskUserQuestion option

### DIFF
--- a/src/elicitation.ts
+++ b/src/elicitation.ts
@@ -271,23 +271,24 @@ export function applyAskElicitationResponse(
   // stay in sync with what the built-in tool's call() expects to read back.
   const answers: AskUserQuestionOutput["answers"] = {};
   questions.forEach((question, index) => {
-    // A typed custom answer wins over the selection: the user chose to write
-    // their own answer for this question instead of picking an option.
+    const value = content[questionFieldKey(index)];
+    const selectedText = Array.isArray(value)
+      ? value.join(", ")
+      : value == null
+        ? ""
+        : String(value);
+
     const custom = content[questionCustomFieldKey(index)];
     if (typeof custom === "string" && custom.trim() !== "") {
-      answers[question.question] = custom.trim();
+      const details = custom.trim();
+      answers[question.question] = selectedText ? `${selectedText}\n\n${details}` : details;
       return;
     }
 
-    const value = content[questionFieldKey(index)];
-    if (value === undefined || value === null) {
+    if (selectedText === "") {
       return;
     }
-    const text = Array.isArray(value) ? value.join(", ") : String(value);
-    if (text === "") {
-      return;
-    }
-    answers[question.question] = text;
+    answers[question.question] = selectedText;
   });
 
   return { action: "answered", updatedInput: { ...toolInput, answers } };

--- a/src/tests/elicitation.test.ts
+++ b/src/tests/elicitation.test.ts
@@ -350,7 +350,7 @@ describe("applyAskElicitationResponse", () => {
     });
   });
 
-  it("prefers a question's custom answer over its selection", () => {
+  it("keeps the selected option when follow-up text is also supplied", () => {
     const response = {
       action: "accept",
       content: { question_0: "A", question_0_custom: "  my own take  " },
@@ -361,7 +361,7 @@ describe("applyAskElicitationResponse", () => {
       updatedInput: {
         questions,
         metadata: { source: "test" },
-        answers: { "Single?": "my own take" },
+        answers: { "Single?": "A\n\nmy own take" },
       },
     });
   });


### PR DESCRIPTION
## Summary
- Preserve the selected AskUserQuestion option when clients also return follow-up text
- Keep free-form-only answers working when no option is selected
- Add a regression test for the option + follow-up text case

Closes #1050

## Test plan
- npm run test:run -- src/tests/elicitation.test.ts
- npm run build
- npm run check
- git diff --check

Full `npm run test:run` was also attempted; it reached 1042 passed / 27 skipped and failed only the existing root-environment `resolvePermissionMode` bypassPermissions expectations.
