### PR TITLE
fix: change min zod version to 4.x to avoid failing directory imports on 'v4'

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/claude-agent-sdk": "0.3.238",
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.120.0",


### PR DESCRIPTION
Currently, `package.json` allows zod version `3.x`. But `agentclientprotocol/sdk` and our code use explicit `zod/v4` imports. But `v4` became a proper ES module only in `4.x`. Before that, it was just a directory. So if a user has zod 3.x, running this ACP server will fail with `ERR_UNSUPPORTED_DIR_IMPORT`. 