### PR TITLE
fix: steered turn parks forever when the steer aborts a task-notification followup

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3322,6 +3322,30 @@ export class ClaudeAcpAgent {
                       session.owedTrailingIdles--;
                     }
                     settleDeferredIfDrained();
+                  } else if (
+                    isSteering(session.activeTurn) &&
+                    session.activeTurn.steeredEchoes.size === 0 &&
+                    session.activeTurn.steeredSettle !== undefined
+                  ) {
+                    // A READY steered settle — echo consumed, outcome
+                    // recorded — takes this idle ahead of the debt lane
+                    // below. When the steer aborted an autonomous followup
+                    // mid-write, that followup's result banked a trailer
+                    // (the "keep their own trailers" rule), but the abort
+                    // collapsed its trailing idle into this one spanning
+                    // idle: absorbing it as debt starves the settle, and
+                    // with the stream still open no teardown ever rescues
+                    // the prompt — it parks forever. A steer that is not
+                    // ready still falls through to the debt lane, so an
+                    // owed idle from an earlier turn can never settle a
+                    // steered cycle that is still running; a genuinely
+                    // separate owed trailer stays banked and absorbs the
+                    // next idle instead.
+                    const steered: Turn = session.activeTurn;
+                    steered.deferredSettle = steered.steeredSettle;
+                    steered.steeredEchoes = undefined;
+                    steered.steeredSettle = undefined;
+                    settleDeferredIfDrained();
                   } else if (session.owedTrailingIdles > 0) {
                     // Absorb a settled turn's trailing idle. Also covers a
                     // cancel that landed between a turn's counted result and
@@ -3334,25 +3358,12 @@ export class ClaudeAcpAgent {
                     // steered cycle is still running. Steered results owe none.
                     session.owedTrailingIdles--;
                   } else if (isSteering(session.activeTurn)) {
-                    // A steered turn settles here, not at a result: this idle is
-                    // the only signal spanning the interrupted and steered cycles
-                    // (see Turn.steeredEchoes). An idle before the steered echo,
-                    // or before any result was recorded, means the answer is
-                    // still ahead — swallow it, and never let it reach the #825
-                    // fail below, which would reject a prompt about to answer.
-                    //
-                    // Plain Turn so the fields can be cleared below; isSteering
-                    // narrows steeredEchoes to non-optional.
-                    const steered: Turn = session.activeTurn;
-                    if (steered.steeredEchoes?.size === 0 && steered.steeredSettle !== undefined) {
-                      // Via the subagent gate, not settleActive: a steered turn
-                      // can also have spawned background subagents, which own it
-                      // from here (settles now if none is live, holds otherwise).
-                      steered.deferredSettle = steered.steeredSettle;
-                      steered.steeredEchoes = undefined;
-                      steered.steeredSettle = undefined;
-                      settleDeferredIfDrained();
-                    }
+                    // A steered turn that is NOT ready yet (the ready case
+                    // settled above, before the debt lane): an idle before
+                    // the steered echo, or before any result was recorded,
+                    // means the answer is still ahead — swallow it, and
+                    // never let it reach the #825 fail below, which would
+                    // reject a prompt about to answer.
                   } else if (
                     !session.cancelled &&
                     session.activeTurn &&

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -12650,6 +12650,66 @@ describe("deferred settlement for live background subagents (issues #864/#866)",
     await agent.sessions["test-session"]?.consumer;
   });
 
+  it("settles a steered turn whose steer aborted the followup mid-write", async () => {
+    const { agent, events } = chunkCapturingAgent();
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const { value: userMessage } = await iter.next();
+        yield userEcho(userMessage);
+        yield running();
+        yield subagentStarted("agent-1");
+        // The user turn's terminal result: the subagent is live, so the
+        // prompt holds.
+        yield resultMessage();
+        // The CLI's immediate trailing idle, absorbed mid-hold.
+        yield idle();
+        // The subagent finishes and the followup starts streaming.
+        yield taskNotification("agent-1");
+        yield assistantText("relay begins");
+        // A message steered in mid-followup — the test gates the steer on
+        // the chunk above, so the turn is held and mid-relay, the live
+        // shape. The CLI aborts the followup cycle, which ends with ITS OWN
+        // result, task-notification origin. No trailing idle of its own
+        // ever comes: the abort collapsed it into the single spanning idle
+        // at the very end.
+        const steered = await iter.next();
+        yield resultMessage({ origin: { kind: "task-notification" } });
+        // The steered cycle: echo, answer, and the last-word result.
+        yield userEcho(steered.value);
+        yield assistantText("STEERED-ANSWER");
+        yield resultMessage();
+        // The one idle spanning the aborted followup and the steered cycle.
+        // The aborted followup's banked trailer must not swallow it, or the
+        // steered turn never settles and the prompt hangs forever.
+        yield idle();
+        // The real CLI keeps the stream open here — no end-of-stream
+        // teardown ever rescues a missed settle, so the test must not let
+        // one rescue it either.
+        await new Promise(() => {});
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "explore" }],
+    });
+    // Steer only once the followup is visibly streaming: mid-relay, held.
+    await waitFor(() => events.includes("chunk:relay begins"));
+    await expect(
+      agent.steer({
+        sessionId: "test-session",
+        prompt: [{ type: "text", text: "quick question" }],
+      }),
+    ).resolves.toEqual({ outcome: "injected" });
+
+    await expect(turn).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    // No consumer drain: the generator above deliberately never ends, the
+    // way the live stream stays open.
+  });
+
   it("falls back to settling at an idle when no followup comes", async () => {
     const agent = createMockAgent();
 


### PR DESCRIPTION
**Symptom.** A `session/steering` message injected while the model is streaming its task-notification followup (the relay after a background subagent finishes) leaves the held `session/prompt` unresolved forever. The steered answer's content still streams, every expected SDK frame arrives, but the turn never settles; only `session/cancel` or the next prompt releases it.

**Mechanism.** The steer aborts the followup cycle, whose result is autonomous-origin and therefore banks a trailing-idle debt ("autonomous results keep their own trailers"). But the abort collapses that cycle's trailing idle into the single idle spanning the interrupted and steered cycles — so the debt lane absorbs the one idle the steering lane was waiting for, and the ready steered settle is starved. With the stream still open, no teardown rescues it.

**Fix.** In the idle handler, a ready steered settle — echo consumed, outcome recorded — takes the idle ahead of debt absorption. A not-ready steer still falls through to the debt lane, preserving the guarantee that an earlier turn's owed idle can never settle a steered cycle still running; a genuinely separate owed trailer stays banked and absorbs the next idle.

**Evidence.** Live repro (background subagent holding the turn, steer during the followup stream): stock build, prompt unresolved after 240s, three runs; patched build, resolves in ~2s, same recipe. The regression test models the exact frame sequence with the mock stream held open, so the end-of-stream teardown can't mask a missed settle. Full suite: 1045 passing.
