### PR TITLE
fix: Adopt per-model effort settings and user_message_uuid result attribution

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -80,6 +80,7 @@ import {
   SDKMessageOrigin,
   SDKPartialAssistantMessage,
   SDKUserMessage,
+  Settings,
   SlashCommand,
   ThinkingConfig,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -705,6 +706,14 @@ export type Session = {
    *  user's intent so it persists across model switches; the Fast mode config
    *  option is only surfaced while the selected model supports it. */
   fastModeEnabled: boolean;
+  /** Whether the user picked a non-default effort through the ACP picker this
+   *  session. A pin lives at the SDK's flag layer, which overrides the CLI's
+   *  persisted effort (including the per-model `modelSettings` entries), so it
+   *  follows the session across model switches; without one, the CLI resolves
+   *  effort itself and the Effort option is display-only. Cleared when the
+   *  user picks "Default" (the flag layer is cleared with it) or when a model
+   *  switch clamps the pin away. */
+  effortPinnedByUser?: boolean;
   /** Why the SDK currently can't serve Fast mode, when the reason is one worth
    *  telling the user about (see {@link FAST_MODE_UNAVAILABLE_EXPLANATIONS} —
    *  routine states like the SDK's own opt-in requirement normalize to
@@ -2767,12 +2776,20 @@ export class ClaudeAcpAgent {
      *
      *  But an echo-less result can also be an ORPHAN: cancel() settles+removes a
      *  queued turn whose user message was already pushed, so the SDK still runs
-     *  it and emits a result with no uuid to match. Promoting the head for an
+     *  it and emits a result with no echo to match. Promoting the head for an
      *  orphan would misattribute its stop reason/usage to an unrelated later
      *  prompt. `session.pendingOrphanResults` counts exactly how many such
      *  orphans are still expected (FIFO, they arrive before any live turn's
-     *  result), so we skip those and only promote once the count is drained. */
-    const ensureActiveTurn = () => {
+     *  result), so we skip those and only promote once the count is drained.
+     *
+     *  `resultUserMessageUuid` is the result's own join key (SDK 0.3.246+
+     *  echoes the triggering send's client uuid on results; absent on older
+     *  CLIs, synthetic/meta turns, and session-scoped failures). When present
+     *  it upgrades the map lane from positional heuristics to an exact match:
+     *  a stamp naming an orphaned command consumes the result outright, and a
+     *  stamp naming anything else positively refutes "this is a dead turn's
+     *  result", so the dup-over-loss one-skip must not eat it. */
+    const ensureActiveTurn = (resultUserMessageUuid?: string) => {
       if (session.activeTurn) {
         if (!isHeldOpen(session.activeTurn)) {
           return;
@@ -2824,8 +2841,13 @@ export class ClaudeAcpAgent {
       // double-consume it. The unexpected-transition logging in the frame
       // handler is the tripwire for that class of drift.
       if (session.orphanCommands?.size) {
+        const stampedOrphan =
+          resultUserMessageUuid !== undefined && session.orphanCommands.has(resultUserMessageUuid);
         let consumedOrphanResult = false;
         let oldestPending: string | undefined;
+        // The started/zombie drain applies regardless of the stamp: commands
+        // folded into the turn that emitted this result share it, and zombies'
+        // late results have already passed (or never existed).
         for (const [uuid, state] of session.orphanCommands) {
           if (state === "started" || state === "zombie") {
             consumedOrphanResult = true;
@@ -2834,17 +2856,32 @@ export class ClaudeAcpAgent {
             oldestPending ??= uuid;
           }
         }
-        if (consumedOrphanResult) {
+        if (stampedOrphan) {
+          // Exact join: the result names an orphaned command. Delete the
+          // matched entry even when it is still "pending" (its dispatch frame
+          // was lost) and consume the result — no promotion.
+          session.orphanCommands.delete(resultUserMessageUuid!);
           return;
         }
-        if (oldestPending !== undefined) {
-          // No dispatch was seen before this result, so it is very likely a
-          // live turn's — but a lost "started" frame would mean it IS the
-          // orphan's (dup-over-loss: prefer one wrong skip over
-          // misattributing a dead turn's outcome to a live prompt). Grant
-          // each pending entry exactly one skip, like the count lane did.
-          session.orphanCommands.delete(oldestPending);
-          return;
+        if (resultUserMessageUuid !== undefined) {
+          // The stamp names a send that is NOT in the orphan map, so this is
+          // a live turn's result: skip both the consumed-return (its folded
+          // orphans were drained above, but the result itself still needs a
+          // turn) and the dup-over-loss one-skip the stamp refutes, and fall
+          // through to promote the head.
+        } else {
+          if (consumedOrphanResult) {
+            return;
+          }
+          if (oldestPending !== undefined) {
+            // No dispatch was seen before this result, so it is very likely a
+            // live turn's — but a lost "started" frame would mean it IS the
+            // orphan's (dup-over-loss: prefer one wrong skip over
+            // misattributing a dead turn's outcome to a live prompt). Grant
+            // each pending entry exactly one skip, like the count lane did.
+            session.orphanCommands.delete(oldestPending);
+            return;
+          }
         }
       }
       const head = firstUnsettledQueuedTurn();
@@ -4065,7 +4102,7 @@ export class ClaudeAcpAgent {
               // the map in that case).
               if (!isAutonomousResult) {
                 recordResultForOrphanCommands();
-                ensureActiveTurn();
+                ensureActiveTurn(message.user_message_uuid);
                 // Once the submitted goal command has produced its own result,
                 // no older runtime update can still precede it in the ordered
                 // SDK stream. Stop suppressing updates even when this runtime
@@ -4289,13 +4326,28 @@ export class ClaudeAcpAgent {
                 isEmptyUserInterruptionDiagnostic(message) &&
                 (session.pendingEmptyInterruptionDiagnosticCommands?.size ?? 0) > 0
               ) {
-                const commandUuid = session
-                  .pendingEmptyInterruptionDiagnosticCommands!.values()
-                  .next().value;
-                if (commandUuid) {
-                  session.pendingEmptyInterruptionDiagnosticCommands!.delete(commandUuid);
+                const pending = session.pendingEmptyInterruptionDiagnosticCommands!;
+                const stamped = message.user_message_uuid;
+                if (stamped === undefined) {
+                  // Older producer: no join key on the result, so consume an
+                  // arbitrary hand-off token like before.
+                  const commandUuid = pending.values().next().value;
+                  if (commandUuid) {
+                    pending.delete(commandUuid);
+                  }
+                  break;
                 }
-                break;
+                if (pending.delete(stamped)) {
+                  // Exact join (SDK 0.3.246+ echoes the triggering send's
+                  // uuid on error results): the diagnostic names a cancelled
+                  // command we handed a token for — swallow it.
+                  break;
+                }
+                // Stamped but unmatched: this diagnostic belongs to a send we
+                // did NOT cancel — a live turn's real failure. Don't let a
+                // stale token eat it; fall through to the ordinary failure
+                // lanes (the clear below retires the stale tokens, same as
+                // every other non-diagnostic result path).
               }
 
               // Some CLI versions omit the cancelled cycle's diagnostic. Do
@@ -5287,8 +5339,10 @@ export class ClaudeAcpAgent {
       }
       // Each removed queued turn's user message was already pushed to the SDK,
       // which processes input FIFO and will still emit a result for it with no
-      // uuid to match. Track those so the consumer skips them (see
-      // ensureActiveTurn) rather than misattributing them to the head.
+      // user echo to match (0.3.246+ CLIs do stamp results with the
+      // triggering send's user_message_uuid, which ensureActiveTurn uses as
+      // an exact join when present). Track those so the consumer skips them
+      // (see ensureActiveTurn) rather than misattributing them to the head.
       // msg_lifecycle_v1 CLIs get per-uuid tracking drained by the command's
       // own terminal lifecycle frame — exact under command coalescing, where
       // N queued commands fold into ONE turn emitting one result and a plain
@@ -6553,15 +6607,26 @@ export class ClaudeAcpAgent {
         session.fastModeDisabledReason = undefined;
       }
 
-      // Rebuild config options since effort levels depend on the selected model
+      // Rebuild config options since effort levels depend on the selected
+      // model. The effort seed depends on who owns the choice: a user pin
+      // made through the ACP picker this session lives at the SDK's flag
+      // layer and follows the session across switches, so carry it forward.
+      // Otherwise the CLI resolves effort itself from the persisted settings
+      // — the NEW model's `modelSettings` entry first (the CLI persists
+      // /effort per model), then the legacy top-level value — so display
+      // what it will actually run instead of dragging the old model's value
+      // along.
       const effortOpt = session.configOptions.find((o) => o.id === EFFORT_CONFIG_ID);
       const currentEffort =
         typeof effortOpt?.currentValue === "string" ? effortOpt.currentValue : undefined;
+      const seedEffort = session.effortPinnedByUser
+        ? currentEffort
+        : settingsEffortForModel(session.settingsManager.getSettings(), newModelInfo, value);
       session.configOptions = buildConfigOptions(
         session.modes,
         session.models,
         session.modelInfos,
-        currentEffort,
+        seedEffort,
         session.agents,
         session.currentAgent,
         {
@@ -6575,14 +6640,25 @@ export class ClaudeAcpAgent {
         },
       );
 
-      // Sync effort with the SDK if it changed after the model switch
-      const newEffortOpt = session.configOptions.find((o) => o.id === EFFORT_CONFIG_ID);
-      const newEffort =
-        typeof newEffortOpt?.currentValue === "string" ? newEffortOpt.currentValue : undefined;
-      if (newEffort !== currentEffort) {
-        await session.query.applyFlagSettings({
-          effortLevel: toSdkEffortLevel(newEffort),
-        });
+      // Sync effort with the SDK only when a user pin changed across the
+      // switch — i.e. the new model clamped it away (buildConfigOptions
+      // validated the seed against the new model's levels), where the flag
+      // must be cleared too or the SDK would keep running the old pin
+      // invisibly. Settings-derived seeds are display-only: the CLI resolves
+      // persisted effort itself, and pinning it at the flag layer would
+      // shadow the per-model values on every later switch.
+      if (session.effortPinnedByUser) {
+        const newEffortOpt = session.configOptions.find((o) => o.id === EFFORT_CONFIG_ID);
+        const newEffort =
+          typeof newEffortOpt?.currentValue === "string" ? newEffortOpt.currentValue : undefined;
+        if (newEffort !== currentEffort) {
+          await session.query.applyFlagSettings({
+            effortLevel: toSdkEffortLevel(newEffort),
+          });
+          if (newEffort === undefined || newEffort === "default") {
+            session.effortPinnedByUser = false;
+          }
+        }
       }
 
       // Emit current_mode_update only after session.modes AND
@@ -6615,6 +6691,10 @@ export class ClaudeAcpAgent {
         await session.query.applyFlagSettings({
           effortLevel: toSdkEffortLevel(value),
         });
+        // "Default" clears the flag layer (toSdkEffortLevel → null), handing
+        // effort back to the CLI's persisted per-model resolution — so it
+        // un-pins; any other pick pins effort for the session.
+        session.effortPinnedByUser = value !== "default";
       }
     }
   }
@@ -7332,27 +7412,23 @@ export class ClaudeAcpAgent {
       disabledReason: fastModeDisabledReason,
     };
 
+    // The Effort picker seed mirrors what the CLI itself resolves from the
+    // persisted settings — the current model's `modelSettings` entry first
+    // (the CLI persists /effort per model), then the legacy top-level value.
+    // Display-only: no applyFlagSettings here. The CLI reads the same
+    // settings, so pinning the seed at the flag layer was always redundant —
+    // and it would override the CLI's own per-model restore on every later
+    // model switch. Only a user's explicit ACP picker choice pins the flag
+    // (see applyConfigOptionValue / Session.effortPinnedByUser).
     const configOptions = buildConfigOptions(
       modes,
       models,
       modelInfos,
-      settingsManager.getSettings().effortLevel,
+      settingsEffortForModel(settingsManager.getSettings(), currentModelInfo),
       agents,
       currentAgent,
       fastMode,
     );
-
-    // Apply the initial effort level to the SDK so it matches the UI default
-    const initialEffort = configOptions.find((o) => o.id === EFFORT_CONFIG_ID);
-    if (
-      initialEffort &&
-      typeof initialEffort.currentValue === "string" &&
-      initialEffort.currentValue !== "default"
-    ) {
-      await q.applyFlagSettings({
-        effortLevel: toSdkEffortLevel(initialEffort.currentValue),
-      });
-    }
     // Seed the context window WITHOUT any extra IPC on the session/new path.
     // On session/load, the resumed session's own `getContextUsage` report — a
     // response `getAvailableModels` already awaited to learn the live model
@@ -7792,6 +7868,32 @@ function isValidBaseUrl(baseUrl: string): boolean {
 // that the persisted Settings shape deliberately excludes.
 function toSdkEffortLevel(value: string | undefined): EffortLevel | null {
   return value === undefined || value === "default" ? null : (value as EffortLevel);
+}
+
+/** The effort level the CLI itself resolves for a model from the persisted
+ *  settings: the per-model entry (`modelSettings`, keyed by canonical model
+ *  name — the CLI persists /effort per model since 2.1.243) wins over the
+ *  legacy top-level `effortLevel`. Alias picker rows are looked up by their
+ *  resolved model id first, then the row value, then the raw config value
+ *  for models not in the picker. Exact keys only — the CLI's canonical-form
+ *  fallback matching isn't replicated, so a miss simply falls back to the
+ *  top-level value (best-effort display; `buildConfigOptions` still
+ *  validates the result against the model's supported levels). */
+export function settingsEffortForModel(
+  settings: Settings,
+  modelInfo: ModelInfo | undefined,
+  modelId?: string,
+): string | undefined {
+  const modelSettings = settings.modelSettings;
+  if (modelSettings) {
+    for (const key of [modelInfo?.resolvedModel, modelInfo?.value, modelId]) {
+      const perModel = key !== undefined ? modelSettings[key]?.effortLevel : undefined;
+      if (typeof perModel === "string") {
+        return perModel;
+      }
+    }
+  }
+  return settings.effortLevel;
 }
 
 // `supportedAgents()` always returns Claude Code's built-in subagents — the

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -11976,6 +11976,95 @@ describe("post-error recovery", () => {
     await agent.sessions["test-session"]?.consumer;
   });
 
+  it("uses a result's user_message_uuid to consume exactly the orphan it names", async () => {
+    // SDK 0.3.246+ stamps results with the triggering send's client uuid.
+    // With TWO cancelled commands pending (their dispatch frames lost), a
+    // stamped orphan result must consume the entry it NAMES — not the oldest
+    // — and the later /compact result, stamped with its own send, must not
+    // be eaten by the dup-over-loss one-skip that the leftover pending entry
+    // would otherwise trigger (which would hang the /compact prompt).
+    const agent = createMockAgent();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield lifecycleInit;
+        yield userEcho(u1.value); // turn 1 active
+        await iter.next(); // turn 2 queued (cancelled below; every frame lost)
+        const u3 = await iter.next(); // turn 3 queued (cancelled below)
+        await gate;
+        yield { type: "system", subtype: "session_state_changed", state: "idle" }; // turn 1 settles cancelled
+        // Both dispatch frames are LOST; only turn 3's dead turn flushes a
+        // result, stamped with the send it answers.
+        yield {
+          ...createResultMessage({
+            subtype: "error_during_execution",
+            stop_reason: null,
+            is_error: true,
+          }),
+          user_message_uuid: u3.value.uuid,
+        };
+        const u4 = await iter.next(); // /compact's pushed message
+        yield {
+          type: "system",
+          subtype: "status",
+          status: "compacting",
+          session_id: "test-session",
+        };
+        yield {
+          ...createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false }),
+          user_message_uuid: u4.value.uuid, // a live result names its own send
+        };
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    await waitFor(() => !!agent.sessions["test-session"]?.msgLifecycleV1);
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    const third = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "third" }],
+    });
+    await waitFor(() => (agent.sessions["test-session"]?.turnQueue?.length ?? 0) >= 3);
+
+    await agent.cancel({ sessionId: "test-session" });
+    expect(agent.sessions["test-session"]?.orphanCommands?.size).toBe(2);
+    const compact = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact" }],
+    });
+    release();
+
+    await expect(first).resolves.toEqual({
+      stopReason: "cancelled",
+      usage: cancelledTurnUsage,
+      _meta: cancelledTurnQuotaMeta,
+    });
+    await expect(second).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(third).resolves.toEqual({ stopReason: "cancelled" });
+    // Settles on its OWN stamped result — under positional attribution the
+    // one-skip would have consumed it for turn 2 and hung this prompt.
+    const compactResult = await compact;
+    expect(compactResult.stopReason).toBe("end_turn");
+    expect(compactResult.usage?.inputTokens).toBe(10);
+    // Turn 3's entry was consumed by name; turn 2's leftover pending entry
+    // is swept by /compact's activation.
+    expect(agent.sessions["test-session"]?.orphanCommands?.size).toBe(0);
+    await agent.sessions["test-session"]?.consumer;
+  });
+
   it("deletes (not zombifies) an orphan whose `cancelled` frame arrives AFTER its error result", async () => {
     // The live-observed abort ordering is started → error result → cancelled.
     // The result deletes the "started" entry when it is skipped; the late
@@ -15001,6 +15090,119 @@ describe("turn steering (_session/steering)", () => {
 
     await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
     expect(JSON.stringify(updates)).not.toContain("[Request interrupted by user]");
+  });
+
+  it("swallows a stamped interruption diagnostic that names the cancelled command", async () => {
+    // Same replay ordering as above, but the diagnostic carries the SDK
+    // 0.3.246+ user_message_uuid stamp naming the cancelled first prompt —
+    // the exact-join path must consume precisely that hand-off token.
+    const agent = createMockAgent();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const original = await iter.next();
+        await gate;
+        const replacement = await iter.next();
+        yield userEcho(original.value);
+        yield userEcho({
+          uuid: randomUUID(),
+          message: { role: "user", content: "[Request interrupted by user]" },
+        });
+        yield userEcho(replacement.value);
+        yield {
+          ...createResultMessage(),
+          subtype: "success",
+          is_error: true,
+          result: "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+          user_message_uuid: original.value.uuid,
+        };
+        yield createAssistantText("replacement answer");
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(
+      () =>
+        agent.sessions["test-session"]?.turnQueue?.length === 1 &&
+        agent.sessions["test-session"]?.activeTurn == null,
+    );
+    await agent.cancel({ sessionId: "test-session" });
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    release();
+
+    await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    expect(
+      agent.sessions["test-session"]?.pendingEmptyInterruptionDiagnosticCommands?.size ?? 0,
+    ).toBe(0);
+  });
+
+  it("does not let a stale hand-off token swallow a live turn's stamped interruption diagnostic", async () => {
+    // The diagnostic-shaped error is stamped with the LIVE replacement
+    // prompt's uuid — not the cancelled command the token was handed out for.
+    // The stamp positively refutes "this is the cancelled cycle's
+    // diagnostic", so it must reach the ordinary failure lanes and fail the
+    // replacement prompt instead of being silently eaten.
+    const agent = createMockAgent();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const original = await iter.next();
+        await gate;
+        const replacement = await iter.next();
+        yield userEcho(original.value);
+        yield userEcho({
+          uuid: randomUUID(),
+          message: { role: "user", content: "[Request interrupted by user]" },
+        });
+        yield userEcho(replacement.value);
+        yield {
+          ...createResultMessage(),
+          subtype: "success",
+          is_error: true,
+          result: "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+          user_message_uuid: replacement.value.uuid,
+        };
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(
+      () =>
+        agent.sessions["test-session"]?.turnQueue?.length === 1 &&
+        agent.sessions["test-session"]?.activeTurn == null,
+    );
+    await agent.cancel({ sessionId: "test-session" });
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    release();
+
+    await expect(second).rejects.toThrow("[ede_diagnostic]");
   });
 
   it("does not hide an empty user-interruption diagnostic without a cancelled predecessor", async () => {

--- a/src/tests/model-resolution.test.ts
+++ b/src/tests/model-resolution.test.ts
@@ -6,6 +6,7 @@ import {
   resolveModelPreference,
   applyAvailableModelsAllowlist,
   matchResumedModel,
+  settingsEffortForModel,
 } from "../acp-agent.js";
 
 // Mirrors a real `supportedModels()` response: alias rows carry
@@ -269,4 +270,44 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("model resolution (real SDK)
       q.return(undefined);
     }
   }, 30000);
+});
+
+describe("settingsEffortForModel", () => {
+  const SONNET: ModelInfo = {
+    value: "sonnet",
+    resolvedModel: "claude-sonnet-5",
+    displayName: "Sonnet",
+    description: "Sonnet 5 · Efficient for routine tasks",
+  };
+
+  it("prefers the per-model entry keyed by the resolved model id", () => {
+    const settings = {
+      effortLevel: "high" as const,
+      modelSettings: { "claude-sonnet-5": { effortLevel: "low" as const } },
+    };
+    expect(settingsEffortForModel(settings, SONNET)).toBe("low");
+  });
+
+  it("falls back to the picker row value, then the raw model id", () => {
+    const byValue = { modelSettings: { sonnet: { effortLevel: "medium" as const } } };
+    expect(settingsEffortForModel(byValue, SONNET)).toBe("medium");
+
+    const byRawId = { modelSettings: { "claude-x": { effortLevel: "xhigh" as const } } };
+    expect(settingsEffortForModel(byRawId, undefined, "claude-x")).toBe("xhigh");
+  });
+
+  it("falls back to the top-level effortLevel when no per-model entry matches", () => {
+    expect(settingsEffortForModel({ effortLevel: "high" }, SONNET)).toBe("high");
+    expect(
+      settingsEffortForModel(
+        { effortLevel: "high", modelSettings: { "claude-opus-4-8": { effortLevel: "low" } } },
+        SONNET,
+      ),
+    ).toBe("high");
+  });
+
+  it("returns undefined when neither layer sets an effort", () => {
+    expect(settingsEffortForModel({}, SONNET)).toBeUndefined();
+    expect(settingsEffortForModel({ modelSettings: {} }, undefined)).toBeUndefined();
+  });
 });

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -110,7 +110,7 @@ describe("session config options", () => {
       input: null,
       cancelled: false,
       permissionMode: "default",
-      settingsManager: {},
+      settingsManager: { getSettings: () => ({}) },
       modes: structuredClone(MOCK_MODES),
       models: structuredClone(MOCK_MODELS),
       modelInfos: MOCK_MODELS.availableModels.map((m): ModelInfo => ({
@@ -419,14 +419,18 @@ describe("session config options", () => {
 
       const effortOption = response.configOptions.find((o) => o.id === "effort");
       expect(effortOption).toBeUndefined();
-      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: null });
+      // Nothing was pinned at the flag layer (effort was "default"), so there
+      // is nothing to clear — the CLI resolves its own effort for the new model.
+      expect(applyFlagSettingsSpy).not.toHaveBeenCalled();
     });
 
     it("clamps effort in returned configOptions when new model has different supported levels", async () => {
-      // Set current effort to "max" which the new model won't support
+      // Set current effort to "max" which the new model won't support —
+      // pinned, as a user's ACP picker choice would be.
       const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
       const effortOpt = session.configOptions.find((o: any) => o.id === "effort");
       if (effortOpt) effortOpt.currentValue = "max";
+      session.effortPinnedByUser = true;
 
       session.modelInfos = [
         {
@@ -458,10 +462,12 @@ describe("session config options", () => {
     });
 
     it("preserves effort in returned configOptions when new model supports same level", async () => {
-      // Set effort to "low" first
+      // Set effort to "low" first — pinned, as a user's ACP picker choice
+      // would be (an unpinned value re-seeds from settings on a switch).
       const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
       const effortOpt = session.configOptions.find((o: any) => o.id === "effort");
       if (effortOpt) effortOpt.currentValue = "low";
+      session.effortPinnedByUser = true;
 
       const response = await agent.setSessionConfigOption({
         sessionId: SESSION_ID,
@@ -630,7 +636,7 @@ describe("session config options", () => {
       expect(effortOption).toBeUndefined();
     });
 
-    it("clears effort via applyFlagSettings when switching to a model without effort", async () => {
+    it("clears a pinned effort via applyFlagSettings when switching to a model without effort", async () => {
       const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
       session.modelInfos = [
         {
@@ -648,6 +654,14 @@ describe("session config options", () => {
         },
       ];
 
+      // Pin an effort the way a user would, then switch to a model that
+      // cannot serve it: the flag layer must be cleared alongside, or the
+      // SDK would keep running the old pin invisibly.
+      await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "effort",
+        value: "high",
+      });
       await agent.setSessionConfigOption({
         sessionId: SESSION_ID,
         configId: "model",
@@ -655,6 +669,8 @@ describe("session config options", () => {
       });
 
       expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: null });
+      // The clamp un-pins: a later switch back re-seeds from settings.
+      expect(session.effortPinnedByUser).toBe(false);
     });
 
     it("adds effort option when switching to a model that supports effort", async () => {
@@ -693,9 +709,11 @@ describe("session config options", () => {
 
     it("clamps effort to valid value when new model has different supported levels", async () => {
       const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
-      // Set current effort to "max" (not supported by sonnet in our mock)
+      // Set current effort to "max" (not supported by sonnet in our mock) —
+      // pinned, as a user's ACP picker choice would be.
       const effortOpt = session.configOptions.find((o: any) => o.id === "effort");
       if (effortOpt) effortOpt.currentValue = "max";
+      session.effortPinnedByUser = true;
 
       session.modelInfos = [
         {
@@ -747,6 +765,48 @@ describe("session config options", () => {
       expect(effortOption?.currentValue).toBe("low");
       // applyFlagSettings was called once for the effort change, but not again for the model switch
       expect(applyFlagSettingsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("seeds effort from the new model's persisted modelSettings entry on an unpinned switch", async () => {
+      // The CLI persists /effort per model (settings.modelSettings); with no
+      // user pin this session, the picker should show what the CLI will
+      // actually run on the new model, not drag the old model's value along.
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      session.settingsManager = {
+        getSettings: () => ({
+          effortLevel: "high",
+          modelSettings: { "claude-sonnet-4-6": { effortLevel: "low" } },
+        }),
+      };
+
+      const response = await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "model",
+        value: "claude-sonnet-4-6",
+      });
+
+      const effortOption = response.configOptions.find((o) => o.id === "effort");
+      expect(effortOption?.currentValue).toBe("low");
+      // Display-only: the CLI resolves persisted effort itself; pinning it at
+      // the flag layer would shadow the per-model values on later switches.
+      expect(applyFlagSettingsSpy).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the top-level settings effort when the new model has no per-model entry", async () => {
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      session.settingsManager = {
+        getSettings: () => ({ effortLevel: "medium" }),
+      };
+
+      const response = await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "model",
+        value: "claude-sonnet-4-6",
+      });
+
+      const effortOption = response.configOptions.find((o) => o.id === "effort");
+      expect(effortOption?.currentValue).toBe("medium");
+      expect(applyFlagSettingsSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tests/session-doubles.ts
+++ b/src/tests/session-doubles.ts
@@ -64,7 +64,7 @@ export function mockSessionState(
     modes: { currentModeId: "default", availableModes: [] },
     models: { currentModelId: "default", availableModels: [] },
     modelInfos: [],
-    settingsManager: { dispose: vi.fn() },
+    settingsManager: { dispose: vi.fn(), getSettings: () => ({}) },
     accumulatedUsage: {
       inputTokens: 0,
       outputTokens: 0,


### PR DESCRIPTION
- Seed the Effort picker from the CLI's persisted per-model effort
  (settings.modelSettings) with the legacy top-level effortLevel as
  fallback, and stop pinning settings-derived seeds at the flag layer —
  only explicit ACP picker choices pin effort now, so the CLI's own
  per-model restore survives model switches.
- Re-seed effort from the new model's persisted entry on unpinned model
  switches instead of dragging the old model's value along.
- Use the result's user_message_uuid (SDK 0.3.246+) as an exact join key:
  the empty-interruption diagnostic handler consumes exactly the token it
  names (and no longer swallows a live turn's stamped failure), and
  ensureActiveTurn consumes the named orphan / skips the dup-over-loss
  one-skip when the stamp refutes it. Older producers keep the heuristics.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
