### PR TITLE
fix(auth): keep the JSON-RPC auth_required rejection for capable clients

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3050,12 +3050,36 @@ export class ClaudeAcpAgent {
 
     /** Complete a negotiated terminal failure on the prompt response itself,
      *  which is the canonical AIR carrier. Legacy clients keep the historical
-     *  JSON-RPC rejection path. */
+     *  JSON-RPC rejection path.
+     *
+     *  `auth_required` is the exception: ACP defines its JSON-RPC error as the
+     *  signal that starts the client's own auth flow (AIR parks the refused
+     *  prompt, shows its method chooser, and resumes the prompt after sign-in),
+     *  so replacing it with a successful `end_turn` would disable that flow.
+     *  Every client keeps the rejection; capable clients additionally receive
+     *  the signed-out *state* as one session-scoped failure whose `login`
+     *  action remains the way back in after the client's auth prompt is
+     *  dismissed. Its title stays the policy's client-neutral fallback — the
+     *  CLI's own text ("… Please run /login") is TUI advice, meaningless in an
+     *  ACP client, so it travels as expandable details instead. */
     const failActiveWithSessionFailure = async (
       kind: ClaudeFailureKind,
       error: unknown,
       title?: string,
     ) => {
+      if (kind === "auth_required") {
+        // One sign-out arrives twice — the synthetic login assistant message
+        // and the turn's error-shaped result repeat the same text — and the
+        // signed-out state does not change in between: publish once, and skip
+        // republishing while the previous sign-out is still active. A retry
+        // warning of the same kind is not a sign-out and must not suppress it.
+        if (!sessionFailures.hasActiveSessionError(kind)) {
+          await publishSessionFailure(kind, { turnScoped: false, details: title });
+        }
+        // Preserve legacy codes: only explicit `/login` signals trigger ACP's auth flow.
+        failActive(error);
+        return;
+      }
       if (!supportsAirSessionFailures(this.clientCapabilities)) {
         failActive(error);
         return;

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3077,7 +3077,10 @@ export class ClaudeAcpAgent {
           await publishSessionFailure(kind, { turnScoped: false, details: title });
         }
         // Preserve legacy codes: only explicit `/login` signals trigger ACP's auth flow.
-        failActive(error);
+        // The first delivery rejects the turn, so the second one finds it settled.
+        // That is the normal course here, not the lost-failure case `failActive`
+        // logs an error for.
+        if (session.activeTurn && !session.activeTurn.settled) failActive(error);
         return;
       }
       if (!supportsAirSessionFailures(this.clientCapabilities)) {
@@ -4467,6 +4470,15 @@ export class ClaudeAcpAgent {
                 await sessionFailures.clear(
                   (failure) =>
                     failure.recoveryPolicy === "real_model_success" ||
+                    // A real model answered, so the session is signed in. The
+                    // `auth_status` message is the primary recovery signal, but
+                    // it reports a login the query process itself runs, and a
+                    // client can sign the user in out of band (AIR runs
+                    // `claude /login` in a terminal, in a separate process).
+                    // Without this a stale signed-out record would outlive the
+                    // sign-out and suppress the next one, which the
+                    // `auth_required` dedupe below reads.
+                    failure.recoveryPolicy === "auth_status" ||
                     (failure.severity === "warning" && failure.turnId === activeTurnId),
                 );
               }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3934,19 +3934,21 @@ export class ClaudeAcpAgent {
                 // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
                 break;
               case "api_retry": {
+                const kind =
+                  message.error_status === null
+                    ? "transport_lost"
+                    : providerFailureCategory(message.error);
+                // A 401 retry is the CLI's credential re-check: it gives up on
+                // the first attempt and reports the sign-out, which is the real
+                // signal and carries the `login` action. A "Retrying" warning
+                // here would outlive the `auth_required` rejection with no
+                // action to clear it (issue #1072).
+                if (kind === "auth_required") break;
                 const title =
                   message.error_status === null
                     ? `Reconnecting to Claude, attempt ${message.attempt} of ${message.max_retries}.`
                     : `Retrying Claude, attempt ${message.attempt} of ${message.max_retries}.`;
-                await publishSessionFailure(
-                  message.error_status === null
-                    ? "transport_lost"
-                    : providerFailureCategory(message.error),
-                  {
-                    title,
-                    severity: "warning",
-                  },
-                );
+                await publishSessionFailure(kind, { title, severity: "warning" });
                 break;
               }
               case "model_refusal_fallback": {

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -296,6 +296,18 @@ export class SessionFailureController {
     }
   }
 
+  /** Whether a session-scoped error of `kind` is active. A turn-scoped
+   *  warning of the same kind (an `api_retry` notice) does not count: it
+   *  reports a retry in progress, not the state the error would publish. */
+  hasActiveSessionError(kind: ClaudeFailureKind): boolean {
+    for (const failure of this.state.active.values()) {
+      if (failure.kind === kind && failure.severity === "error" && failure.turnId === undefined) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   recordActive(failure: PublishedSessionFailure): void {
     this.state.revisions.set(failure.id, failure.revision);
     this.state.active.set(failure.id, failure);

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6529,13 +6529,19 @@ describe("stop reason propagation", () => {
 
   it("does not republish auth_required when the result repeats the login text", async () => {
     const updates: SessionNotification[] = [];
+    const logged: string[] = [];
     const agent = new ClaudeAcpAgent(
       {
         sessionUpdate: async (update: SessionNotification) => {
           updates.push(update);
         },
       } as unknown as AcpClient,
-      { log: () => {}, error: () => {} },
+      {
+        log: () => {},
+        error: (message: unknown) => {
+          logged.push(String(message));
+        },
+      },
     );
     (agent as any).clientCapabilities = airSessionFailureCapabilities;
     // The CLI reports one signed-out turn twice: the synthetic login assistant
@@ -6574,6 +6580,84 @@ describe("stop reason propagation", () => {
     expect([...agent.sessions["test-session"].sessionFailureState.active.keys()]).toEqual([
       failures[0].id,
     ]);
+    // The first delivery already rejected the turn, so the second one has no
+    // turn to fail. That is expected here and must not be logged as a fault.
+    expect(logged.join("\n")).not.toContain("cannot fail active turn");
+  });
+
+  it("republishes the signed-out state after a real model answer cleared the last one", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    const signedOut = () => {
+      const message = createAssistantError("authentication_failed");
+      message.message.model = "<synthetic>";
+      message.message.content = [
+        { type: "text", text: "Not logged in \u00b7 Please run /login", citations: null },
+      ] as any;
+      return message;
+    };
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      for (const turn of [
+        [signedOut()],
+        [
+          createAssistantError(undefined, "signed in again"),
+          createResultMessage({
+            subtype: "success",
+            stop_reason: "end_turn",
+            is_error: false,
+            result: "signed in again",
+          }),
+        ],
+        [signedOut()],
+      ]) {
+        const next = await iter.next();
+        yield {
+          type: "user",
+          message: next.value.message,
+          parent_tool_use_id: null,
+          uuid: next.value.uuid,
+          session_id: "test-session",
+          isReplay: true,
+        };
+        yield* turn;
+      }
+    }
+    agent.sessions["test-session"] = mockSessionState({
+      query: wrapQuery(messageGenerator()),
+      input,
+    });
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "one" }] }),
+    ).rejects.toThrow();
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "two" }] }),
+    ).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    // A client can sign the user in out of band — AIR runs `claude /login` in a
+    // terminal — and then no `auth_status` message arrives. A real model answer
+    // is the proof that the session is signed in again.
+    expect(agent.sessions["test-session"].sessionFailureState.active.size).toBe(0);
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "three" }] }),
+    ).rejects.toThrow();
+
+    // The next sign-out reaches the client as its own row, not as silence.
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(2);
+    expect(failures[1].id).not.toEqual(failures[0].id);
+    expect(failures[1]).toEqual(
+      expect.objectContaining({ category: "access", severity: "error", actions: ["login"] }),
+    );
   });
 
   it("publishes no retry warning for an authentication_failed api_retry", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6255,7 +6255,6 @@ describe("stop reason propagation", () => {
   });
 
   it.each([
-    ["authentication_failed", "access"],
     ["billing_error", "limit"],
     ["account_on_hold", "limit"],
     ["rate_limit", "limit"],
@@ -6392,6 +6391,52 @@ describe("stop reason propagation", () => {
     expect(JSON.stringify(updates)).not.toContain("sessionFailure");
   });
 
+  const sessionFailuresFromUpdates = (updates: SessionNotification[]) =>
+    updates.map((u) => (u.update as any)?._meta?.jetbrains?.air?.sessionFailure).filter(Boolean);
+
+  it("rejects authentication_failed and publishes a session-scoped access failure", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    injectSession(agent, [
+      createAssistantError("authentication_failed", "Claude request failed."),
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Claude request failed.",
+      }),
+    ]);
+
+    // The auth flow hangs off the JSON-RPC rejection (the client parks the
+    // prompt and runs its own sign-in), so the turn is rejected even for
+    // capable clients; the signed-out state travels separately as one
+    // session-scoped failure with a client-neutral title.
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        severity: "error",
+        title: "Sign in to continue using Claude.",
+        details: "Claude request failed.",
+        actions: ["login"],
+      }),
+    );
+    expect(failures[0].id).toContain("session-error");
+  });
+
   it("recovers auth_required internally after a successful auth_status", async () => {
     const updates: SessionNotification[] = [];
     const agent = new ClaudeAcpAgent(
@@ -6420,22 +6465,23 @@ describe("stop reason propagation", () => {
       },
     ]);
 
-    const response = await agent.prompt({
-      sessionId: "test-session",
-      prompt: [{ type: "text", text: "test" }],
-    });
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
-    const active = sessionFailureFromResponse(response);
-    expect(active).toEqual(
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
       expect.objectContaining({
         category: "access",
         revision: 1,
-        title: "Authentication required.",
+        details: "Authentication required.",
       }),
     );
-    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
-    expect(agent.sessions["test-session"].sessionFailureState.active.has(active.id)).toBe(false);
-    expect(JSON.stringify({ response, updates })).not.toContain("private login token");
+    expect(agent.sessions["test-session"].sessionFailureState.active.has(failures[0].id)).toBe(
+      false,
+    );
+    expect(JSON.stringify(updates)).not.toContain("private login token");
   });
 
   it("keeps auth_required active when auth_status reports an error", async () => {
@@ -6467,17 +6513,118 @@ describe("stop reason propagation", () => {
       },
     ]);
 
-    const response = await agent.prompt({
-      sessionId: "test-session",
-      prompt: [{ type: "text", text: "test" }],
-    });
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
-    expect(sessionFailureFromResponse(response)).toEqual(
-      expect.objectContaining({ category: "access", severity: "error" }),
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(expect.objectContaining({ category: "access", severity: "error" }));
+    expect(agent.sessions["test-session"].sessionFailureState.active.has(failures[0].id)).toBe(
+      true,
     );
-    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
-    expect(JSON.stringify({ response, updates })).not.toContain("private login token");
-    expect(JSON.stringify({ response, updates })).not.toContain("private login error");
+    expect(JSON.stringify(updates)).not.toContain("private login token");
+    expect(JSON.stringify(updates)).not.toContain("private login error");
+  });
+
+  it("does not republish auth_required when the result repeats the login text", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    // The CLI reports one signed-out turn twice: the synthetic login assistant
+    // message rejects the turn, then the result repeats the same text. One
+    // session-scoped failure covers both; its title is the client-neutral
+    // fallback while the CLI's TUI advice travels as details.
+    const syntheticLogin = createAssistantError("authentication_failed");
+    syntheticLogin.message.model = "<synthetic>";
+    syntheticLogin.message.content = [
+      { type: "text", text: "Not logged in · Please run /login", citations: null },
+    ] as any;
+    injectSession(agent, [
+      syntheticLogin,
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Not logged in · Please run /login",
+      }),
+    ]);
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        severity: "error",
+        title: "Sign in to continue using Claude.",
+        details: "Not logged in · Please run /login",
+      }),
+    );
+    expect([...agent.sessions["test-session"].sessionFailureState.active.keys()]).toEqual([
+      failures[0].id,
+    ]);
+  });
+
+  it("publishes the sign-out after an authentication_failed retry warning", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    // The retry notice is a turn-scoped `auth_required` warning. It reports a
+    // retry, not the signed-out state, so it must not suppress the
+    // session-scoped error that carries the `login` action.
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "api_retry",
+        attempt: 1,
+        max_retries: 5,
+        retry_delay_ms: 100,
+        error_status: 401,
+        error: "authentication_failed",
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      createAssistantError("authentication_failed", "Claude request failed."),
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Claude request failed.",
+      }),
+    ]);
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures.map((f) => f.severity)).toEqual(["warning", "error"]);
+    expect(failures[1]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        title: "Sign in to continue using Claude.",
+        actions: ["login"],
+      }),
+    );
+    expect(failures[1].id).toContain("session-error");
   });
 
   it("keeps the historical failure record unchanged after recovery", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6576,7 +6576,7 @@ describe("stop reason propagation", () => {
     ]);
   });
 
-  it("publishes the sign-out after an authentication_failed retry warning", async () => {
+  it("publishes no retry warning for an authentication_failed api_retry", async () => {
     const updates: SessionNotification[] = [];
     const agent = new ClaudeAcpAgent(
       {
@@ -6587,15 +6587,15 @@ describe("stop reason propagation", () => {
       { log: () => {}, error: () => {} },
     );
     (agent as any).clientCapabilities = airSessionFailureCapabilities;
-    // The retry notice is a turn-scoped `auth_required` warning. It reports a
-    // retry, not the signed-out state, so it must not suppress the
-    // session-scoped error that carries the `login` action.
+    // The 401 retry is the CLI's credential re-check. The sign-out that
+    // follows is the signal, so the retry publishes nothing and the only
+    // failure is the session-scoped error with the `login` action.
     injectSession(agent, [
       {
         type: "system",
         subtype: "api_retry",
         attempt: 1,
-        max_retries: 5,
+        max_retries: 10,
         retry_delay_ms: 100,
         error_status: 401,
         error: "authentication_failed",
@@ -6616,15 +6616,16 @@ describe("stop reason propagation", () => {
     ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
     const failures = sessionFailuresFromUpdates(updates);
-    expect(failures.map((f) => f.severity)).toEqual(["warning", "error"]);
-    expect(failures[1]).toEqual(
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
       expect.objectContaining({
         category: "access",
+        severity: "error",
         title: "Sign in to continue using Claude.",
         actions: ["login"],
       }),
     );
-    expect(failures[1].id).toContain("session-error");
+    expect(failures[0].id).toContain("session-error");
   });
 
   it("keeps the historical failure record unchanged after recovery", async () => {


### PR DESCRIPTION
## Problem

#1073: ACP defines the `auth_required` JSON-RPC error as the signal that starts the client's own auth flow. AIR parks the refused prompt, shows its method chooser, and resumes the prompt after sign-in. #979 attached the typed failure to a successful `end_turn` response for capable clients, which replaced that signal. The chooser never appeared, and the refused prompt was lost.

Also, the CLI reports one sign-out twice (the synthetic login assistant message and the error-shaped result), so one sign-out published two failure rows, and their title was CLI TUI advice ("Not logged in · Please run /login") that has no meaning in an ACP client.

#1072: a related defect. When a running CLI loses its credentials, the next request gets a 401 and the CLI emits one `api_retry` with `authentication_failed` before it reports the sign-out. The agent published that retry as an `access` warning that nothing cleared, so a capable client showed "Retrying Claude, attempt 1 of 10." with no action in place of the signed-out state.

#1074: a sign-in done outside the query process (AIR runs `claude auth login` in a terminal) sends no `auth_status`, so the stored sign-out record survives. The next sign-out reads the stale record and publishes nothing, and the `login` action is lost.

## Change

- Every client keeps the JSON-RPC `auth_required` rejection.
- A capable client additionally receives the signed-out state as one session-scoped `access` failure. Its `login` action remains the way back in after the client's auth prompt is dismissed.
- The failure title is the client-neutral policy fallback. The CLI text travels as expandable `details`.
- One sign-out publishes one failure. Only an active session-scoped `auth_required` error suppresses a repeat.
- An `api_retry` whose error maps to `auth_required` publishes no warning. The sign-out that follows is the real signal.
- A real model answer clears the stored sign-out record too, so a later sign-out publishes a fresh failure.
- The second delivery of one sign-out no longer logs "cannot fail active turn" as an error.

## Tests

- `rejects authentication_failed and publishes a session-scoped access failure`
- `does not republish auth_required when the result repeats the login text`
- `publishes no retry warning for an authentication_failed api_retry`
- `republishes the signed-out state after a real model answer cleared the last one`
- The two `auth_status` recovery tests now assert the rejection and the session update instead of the prompt response.

`npm test`, `npm run check`, and `npm run build` pass locally.

Fixes #1073.
Fixes #1072.
Fixes #1074.

Tracked in IJAI-1374.


