### PR TITLE
fix: seed config options for a resolvable model id on in-session switch

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -689,6 +689,14 @@ export type Session = {
   modes: SessionModeState;
   models: SessionModelState;
   modelInfos: ModelInfo[];
+  /** The SDK's own unfiltered model table from the initialize response.
+   *  Capability source for ids `modelInfos` doesn't cover: `modelInfos` may be
+   *  filtered by the user's `availableModels` allowlist, and an external
+   *  switch can land on an id no picker entry describes (see
+   *  {@link resolveModelCapabilityFallback}). Optional: a session built
+   *  without it simply never finds a capability donor and keeps the plain
+   *  raw-id tracking. */
+  sdkModelInfos?: ModelInfo[];
   /** Prevents the model-specific Auto fallback from spamming the transcript. */
   autoModeFallbackWarningShown?: boolean;
   /** Initial mode fallback is reported after session/new, on the first prompt. */
@@ -6577,7 +6585,32 @@ export class ClaudeAcpAgent {
       // the Auto fallback below; its `displayName`/`description` also let us infer the
       // context window for semantic aliases (e.g. `default`) whose ID alone
       // carries no "1m" token.
-      const newModelInfo = session.modelInfos.find((m) => m.value === value);
+      let newModelInfo = session.modelInfos.find((m) => m.value === value);
+      if (!newModelInfo) {
+        // No table entry covers this id — an external `/model` switch (or a
+        // raw-id round-trip) landed on a model the picker never listed, e.g.
+        // a newly shipped id or one excluded by the `availableModels`
+        // allowlist. Mirror createSession's fallback registration: borrow the
+        // closest SDK-table row's capability flags under the verbatim id,
+        // with the donor's identity fields stripped so a different-lane
+        // sibling's resolvedModel/displayName/description can't poison later
+        // resolvedModel matching or context-window inference. The rebuild
+        // below then keeps effort/Fast-mode/auto gating truthful instead of
+        // silently dropping those options (the env-pinned path seeds them
+        // for the same id). No donor: the id stays tracked raw, with no
+        // capability claims.
+        const donor = resolveModelCapabilityFallback(session.sdkModelInfos ?? [], value);
+        if (donor) {
+          newModelInfo = {
+            ...donor,
+            value,
+            displayName: value,
+            description: "",
+            resolvedModel: undefined,
+          };
+          session.modelInfos = [...session.modelInfos, newModelInfo];
+        }
+      }
       if (session.models.currentModelId !== value) {
         // Seed the new model's context window WITHOUT any IPC on the switch
         // path: cached authoritative value if we've already learned it (from a
@@ -6714,10 +6747,13 @@ export class ClaudeAcpAgent {
   ): Promise<void> {
     // Map the SDK-reported model onto one of the session's model options
     // (handles display names and `resolvedModel` ids). The switched-to model
-    // may not be among the options — e.g. excluded by the user's
-    // `availableModels` allowlist — in which case we track the raw id: the
-    // picker shows no selection, but the model-dependent bookkeeping and any
-    // later `setModel` round-trip stay truthful to what the SDK is running.
+    // may not be among the options — a newly shipped id, or one excluded by
+    // the user's `availableModels` allowlist — in which case we track the
+    // raw id: the picker shows no selection, but the model-dependent
+    // bookkeeping and any later `setModel` round-trip stay truthful to what
+    // the SDK is running. applyConfigOptionValue seeds capability flags for
+    // such ids from the closest SDK-table row, so a raw-tracked id keeps its
+    // effort/Fast-mode options whenever the family is known.
     const resolved = resolveModelPreference(session.modelInfos, switchedModel);
     const value = resolved?.value ?? switchedModel;
     if (session.models.currentModelId === value) return;
@@ -7481,6 +7517,7 @@ export class ClaudeAcpAgent {
       modes,
       models,
       modelInfos,
+      sdkModelInfos: initializationResult.models,
       autoModeFallbackWarningShown: false,
       autoModeFallbackWarningPending,
       configOptions,
@@ -8313,6 +8350,45 @@ export function resolveModelPreference(models: ModelInfo[], preference: string):
     }
   }
 
+  return bestMatch;
+}
+
+/** Resolve the model-table row that best describes the CAPABILITIES of a
+ *  model id with no row of its own — an id the SDK is running that no picker
+ *  entry covers, e.g. a newly shipped id switched to via a `/model` prompt,
+ *  or a model excluded by the `availableModels` allowlist.
+ *
+ *  The ordinary identity tiers run first, so an allowlist-excluded id still
+ *  lands on its exact unfiltered row. On a miss, the tokenized family tier
+ *  retries with the version guard relaxed: a "claude-fable-5-1" pin must
+ *  never RENDER as the "claude-fable-5" picker row — that guard protects
+ *  picker identity — but the family row is still the best available
+ *  description of what the id supports (effort levels, fast mode, auto
+ *  mode). This is the same capability-over-identity split createSession
+ *  applies when it registers a fuzzy-matched sibling's flags under a
+ *  verbatim live id; callers must likewise strip the donor's identity
+ *  fields before registering it under the new id. Returns null when the
+ *  table has no plausible family row, so genuinely unknown ids keep their
+ *  truthful raw-id tracking with no capability claims. */
+export function resolveModelCapabilityFallback(
+  models: ModelInfo[],
+  modelId: string,
+): ModelInfo | null {
+  const resolved = resolveModelPreference(models, modelId);
+  if (resolved) return resolved;
+
+  const { tokens, contextHint } = tokenizeModelPreference(modelId);
+  if (tokens.length === 0) return null;
+
+  let bestMatch: ModelInfo | null = null;
+  let bestScore = 0;
+  for (const model of models) {
+    const score = scoreModelMatch(model, tokens, contextHint);
+    if (0 < score && (!bestMatch || bestScore < score)) {
+      bestMatch = model;
+      bestScore = score;
+    }
+  }
   return bestMatch;
 }
 

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -1108,5 +1108,146 @@ describe("createSession options merging", () => {
       await new Promise((resolve) => setImmediate(resolve));
       expect((agent as any).sessions[sessionId].models.currentModelId).toBe("claude-sonnet-4-6");
     });
+
+    // A `/model` switch to an id no picker entry covers (e.g. a newly shipped
+    // model) must not silently drop the Effort option: the same id pinned via
+    // ANTHROPIC_MODEL seeds it fully, because the SDK's init table then
+    // carries a custom entry with capability flags. Mid-session there is no
+    // such entry, so capability flags are borrowed from the closest SDK-table
+    // family row and registered under the verbatim id.
+    it("seeds effort when an external switch lands on an unlisted id from a known family", async () => {
+      initModels = [
+        {
+          value: "claude-sonnet-4-6",
+          displayName: "Claude Sonnet",
+          description: "Fast",
+          supportsAutoMode: true,
+        },
+        {
+          value: "claude-fable-5[1m]",
+          resolvedModel: "claude-fable-5",
+          displayName: "Fable",
+          description: "Capable",
+          supportsAutoMode: true,
+          supportsEffort: true,
+          supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        },
+      ];
+      const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+      const sessionId = response.sessionId;
+      const callback = (capturedOptions!.hooks!.PostModelSwitch!.at(-1) as any).hooks[0];
+
+      await callback(
+        {
+          hook_event_name: "PostModelSwitch",
+          session_id: sessionId,
+          transcript_path: "",
+          cwd: process.cwd(),
+          from_model: "claude-sonnet-4-6",
+          to_model: "claude-fable-5-1",
+          requested_model: "claude-fable-5-1",
+          source: "command",
+          context_tokens: 0,
+          prompt_cache_warm: false,
+          cache_ttl: "5m",
+          estimated_cache_write_usd: 0,
+          pricing: "catalog",
+        },
+        undefined,
+        { signal: new AbortController().signal },
+      );
+
+      await vi.waitFor(() => {
+        expect((agent as any).sessions[sessionId].models.currentModelId).toBe("claude-fable-5-1");
+      });
+      const session = (agent as any).sessions[sessionId];
+
+      // The Effort option exists and lists the family row's levels.
+      const effortOption = session.configOptions.find((o: any) => o.id === "effort");
+      expect(effortOption).toBeDefined();
+      expect(effortOption.options.map((o: any) => o.value)).toEqual([
+        "default",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+      ]);
+
+      // Capabilities are registered under the verbatim id with the donor's
+      // identity fields stripped, and the picker itself gains no entry.
+      const registered = session.modelInfos.find((m: any) => m.value === "claude-fable-5-1");
+      expect(registered).toMatchObject({
+        displayName: "claude-fable-5-1",
+        supportsEffort: true,
+      });
+      expect(registered.resolvedModel).toBeUndefined();
+      expect(session.models.availableModels).toHaveLength(2);
+      const modelOption = session.configOptions.find((o: any) => o.id === "model");
+      expect(modelOption?.currentValue).toBe("claude-fable-5-1");
+
+      // The donor's "[1m]" spelling must not leak into context inference:
+      // the stripped identity leaves the default window for the unknown id.
+      expect(session.contextWindowSize).toBe(200000);
+    });
+
+    it("keeps truthful raw tracking, without effort, for an id from no known family", async () => {
+      initModels = [
+        {
+          value: "claude-sonnet-4-6",
+          displayName: "Claude Sonnet",
+          description: "Fast",
+          supportsAutoMode: true,
+        },
+        {
+          value: "claude-fable-5[1m]",
+          resolvedModel: "claude-fable-5",
+          displayName: "Fable",
+          description: "Capable",
+          supportsAutoMode: true,
+          supportsEffort: true,
+          supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        },
+      ];
+      // Start on the effort-capable model so the raw fallback demonstrably
+      // DROPS the option rather than never having had it.
+      process.env.ANTHROPIC_MODEL = "fable";
+      const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+      const sessionId = response.sessionId;
+      expect(
+        (agent as any).sessions[sessionId].configOptions.some((o: any) => o.id === "effort"),
+      ).toBe(true);
+      const callback = (capturedOptions!.hooks!.PostModelSwitch!.at(-1) as any).hooks[0];
+
+      await callback(
+        {
+          hook_event_name: "PostModelSwitch",
+          session_id: sessionId,
+          transcript_path: "",
+          cwd: process.cwd(),
+          from_model: "claude-fable-5",
+          to_model: "claude-vega-2",
+          requested_model: "claude-vega-2",
+          source: "command",
+          context_tokens: 0,
+          prompt_cache_warm: false,
+          cache_ttl: "5m",
+          estimated_cache_write_usd: 0,
+          pricing: "catalog",
+        },
+        undefined,
+        { signal: new AbortController().signal },
+      );
+
+      await vi.waitFor(() => {
+        expect((agent as any).sessions[sessionId].models.currentModelId).toBe("claude-vega-2");
+      });
+      const session = (agent as any).sessions[sessionId];
+
+      // No family row exists, so no capability claims are made: the id is
+      // tracked verbatim and the Effort option is dropped.
+      expect(session.configOptions.some((o: any) => o.id === "effort")).toBe(false);
+      expect(session.modelInfos.some((m: any) => m.value === "claude-vega-2")).toBe(false);
+    });
   });
 });

--- a/src/tests/model-resolution.test.ts
+++ b/src/tests/model-resolution.test.ts
@@ -4,6 +4,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { ModelInfo } from "@anthropic-ai/claude-agent-sdk";
 import {
   resolveModelPreference,
+  resolveModelCapabilityFallback,
   applyAvailableModelsAllowlist,
   matchResumedModel,
   settingsEffortForModel,
@@ -111,6 +112,41 @@ describe("resolveModelPreference - resolvedModel matching", () => {
     expect(resolveModelPreference(models, "claude-sonnet-5-1m")?.value).toBe("sonnet[1m]");
     // Bare preferences still land on the bare row via the substring tier.
     expect(resolveModelPreference(models, "claude-sonnet-5")?.value).toBe("sonnet");
+  });
+});
+
+describe("resolveModelCapabilityFallback", () => {
+  it("keeps the identity tiers: an exact resolvedModel id lands on its own row", () => {
+    expect(
+      resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "claude-haiku-4-5-20251001")?.value,
+    ).toBe("haiku");
+  });
+
+  it("falls back to the family row for a new minor version the identity resolver refuses", () => {
+    // The identity resolver must NOT map a 5.1 id onto the 5.0 row (the
+    // picker would then claim the session runs a different model)...
+    expect(resolveModelPreference(LIVE_SHAPED_MODELS, "claude-sonnet-5-1")).toBeNull();
+    // ...but for capability description the family row is the best available
+    // source, so the fallback returns it.
+    expect(resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "claude-sonnet-5-1")?.value).toBe(
+      "sonnet",
+    );
+  });
+
+  it("describes a retired dated id via its family row even across generations", () => {
+    expect(resolveModelPreference(LIVE_SHAPED_MODELS, "claude-sonnet-4-6")).toBeNull();
+    expect(resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "claude-sonnet-4-6")?.value).toBe(
+      "sonnet",
+    );
+  });
+
+  it("returns null for an id from no known family", () => {
+    expect(resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "claude-gpt-99")).toBeNull();
+  });
+
+  it("returns null when the id yields no usable tokens", () => {
+    expect(resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "claude-5-1")).toBeNull();
+    expect(resolveModelCapabilityFallback(LIVE_SHAPED_MODELS, "")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Pinning a newly shipped id via `ANTHROPIC_MODEL` seeds the effort option fully, because the CLI appends a custom entry with capability flags to its init model table. The same id reached through an in-session `/model` switch resolves against nothing (a `claude-fable-5-1` pin must not render as the `claude-fable-5` picker row), so the rebuild dropped the effort option the runtime demonstrably supports, and the CLI does not expose the switched id through `supportedModels()` or `reinitialize()` mid-session either, so there is no entry to find later.

The fix registers capability flags for such ids at the `applyConfigOptionValue` chokepoint: the identity tiers run against the stored unfiltered SDK table first (which also covers ids excluded by an `availableModels` allowlist), then a version-relaxed family match donates flags that are registered under the verbatim id with the donor's identity fields stripped, mirroring what createSession already does for out-of-picker live models. Genuinely unknown ids keep the truthful raw-id tracking with no capability claims.

Closes #1075. Composes with #1034: the change is in the shared apply path rather than picker validation, so with both landed a raw id set through the config option gets the same seeding.

Verified with `npm run check`, `npm run build`, and `npm run test:run`: 1057 passed and 27 skipped, with the same 17 pre-existing Windows path-display failures that fail identically on main.
