### PR TITLE
fix: separate local command output from the model's reply

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3494,11 +3494,18 @@ export class ClaudeAcpAgent {
                 break;
               }
               case "local_command_output": {
+                // A command's output is a complete message, but the model's
+                // reply to the same turn streams in as further
+                // `agent_message_chunk`s, which by protocol concatenate onto
+                // this one. Close it with a blank line so the two render as
+                // separate blocks: without it `/goal ship the release` reads
+                // as "Goal set: ship the releaseI'll start on that now."
+                const output = message.content.replace(/\s+$/, "");
                 await sendUpdate({
                   sessionId: message.session_id,
                   update: {
                     sessionUpdate: "agent_message_chunk",
-                    content: { type: "text", text: message.content },
+                    content: { type: "text", text: output ? `${output}\n\n` : output },
                   },
                 });
                 break;

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4064,6 +4064,53 @@ describe("subagent permission attribution (issue #851)", () => {
     ).toBe("toolu_parent");
   });
 
+  it("closes local command output so the model's reply is a separate block", async () => {
+    const updates: AcpSessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: AcpSessionNotification) => updates.push(update),
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    injectGeneratorSession(
+      agent,
+      makeGenerator([
+        {
+          type: "system",
+          subtype: "local_command_output",
+          content: "Goal set: ship the release",
+          uuid: randomUUID(),
+          session_id: "test-session",
+        },
+        {
+          type: "assistant",
+          parent_tool_use_id: null,
+          uuid: randomUUID(),
+          session_id: "test-session",
+          message: {
+            id: randomUUID(),
+            role: "assistant",
+            model: "claude-sonnet-4-20250514",
+            content: [{ type: "text", text: "I'll start on that now." }],
+            usage: SUBAGENT_TEST_USAGE,
+          },
+        },
+        successResult(),
+      ]),
+    );
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/goal ship the release" }],
+    });
+
+    const text = updates
+      .filter(({ update }) => update.sessionUpdate === "agent_message_chunk")
+      .map(({ update }) => (update as { content: { text: string } }).content.text)
+      .join("");
+    expect(text).toBe("Goal set: ship the release\n\nI'll start on that now.");
+  });
+
   it("prunes the mapping when the task settles (task_notification)", async () => {
     const agent = new ClaudeAcpAgent(
       { sessionUpdate: vi.fn(async () => {}) } as unknown as AcpClient,


### PR DESCRIPTION
A local slash command's output is forwarded as an `agent_message_chunk` (`src/acp-agent.ts`, the `local_command_output` case). The model's reply to that same turn then streams in as further `agent_message_chunk`s, which by protocol concatenate onto it, and nothing closes the command's own output.

So the two run together with no boundary. Sending `/goal ship the release` to Claude Code produces the command's "Goal set: ship the release" and the model's "I'll start on that now." as one string, rendered as `Goal set: ship the releaseI'll start on that now.` A client cannot fix this on its side, since both arrive as ordinary agent message chunks with nothing to tell them apart.

The output now ends with a blank line so it is its own block. Test asserts the joined chunk text for a `/goal` turn.