### PR TITLE
feat(auth): refuse claude.ai subscriptions under `--hide-claude-auth`

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2365,6 +2365,10 @@ export class ClaudeAcpAgent {
    *  the caller must go on with: the new one, or the argument when no
    *  recreation is due.
    *
+   *  When the CLI never persisted that conversation — the first turn was the
+   *  one that signed out — the resume cannot succeed, so a fresh query starts
+   *  under the same id. The session then keeps working, with an empty history.
+   *
    *  The recreation runs the full creation guard, so a subscription account is
    *  refused with the subscription reason, a still-signed-out account with the
    *  plain sign-out error, and an accepted credential proceeds. A refusal keeps
@@ -2413,6 +2417,24 @@ export class ClaudeAcpAgent {
       // the new query continues the same conversation under the same id.
       await this.createSession(creationParams, { resume: sessionId });
     } catch (error) {
+      if (error instanceof RequestError && error.code === RequestError.resourceNotFound().code) {
+        // The CLI never wrote this conversation, because the very first turn
+        // was the one that signed out. Resuming it fails for ever, so start a
+        // fresh query under the same ACP session id: an empty history is a far
+        // better answer than a session the client can never use again.
+        this.logger.log(
+          `session ${sessionId} was never persisted; starting a fresh query under the same id`,
+        );
+        try {
+          await this.createSession(creationParams, { reuseSessionId: sessionId });
+          return;
+        } catch (fallbackError) {
+          if (!this.sessions[sessionId]) {
+            this.sessions[sessionId] = session;
+          }
+          throw fallbackError;
+        }
+      }
       // Keep the husk addressable: the client answers the refusal with its own
       // auth flow and then retries this session.
       if (!this.sessions[sessionId]) {
@@ -7172,6 +7194,11 @@ export class ClaudeAcpAgent {
       forkSession?: boolean;
       publicSessionId?: string;
       permissionMode?: PermissionMode;
+      /** Start a NEW conversation, but under this id instead of a random one.
+       *  `resume` continues a stored conversation and fails when the CLI never
+       *  wrote one; this keeps the ACP session id alive with an empty history.
+       *  The SDK accepts a caller-chosen id as long as `resume` is not set. */
+      reuseSessionId?: string;
     } = {},
   ): Promise<NewSessionResponse> {
     // Validate `cwd` up front. The ACP spec requires an absolute path, and the
@@ -7190,6 +7217,11 @@ export class ClaudeAcpAgent {
       sessionId = randomUUID();
     } else if (creationOpts.resume) {
       sessionId = creationOpts.resume;
+    } else if (creationOpts.reuseSessionId) {
+      // A new conversation that keeps the old id. `resume` stays unset, so the
+      // id below reaches the SDK as `options.sessionId` — the caller-chosen id
+      // of a fresh session.
+      sessionId = creationOpts.reuseSessionId;
     } else {
       sessionId = randomUUID();
     }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3050,12 +3050,36 @@ export class ClaudeAcpAgent {
 
     /** Complete a negotiated terminal failure on the prompt response itself,
      *  which is the canonical AIR carrier. Legacy clients keep the historical
-     *  JSON-RPC rejection path. */
+     *  JSON-RPC rejection path.
+     *
+     *  `auth_required` is the exception: ACP defines its JSON-RPC error as the
+     *  signal that starts the client's own auth flow (AIR parks the refused
+     *  prompt, shows its method chooser, and resumes the prompt after sign-in),
+     *  so replacing it with a successful `end_turn` would disable that flow.
+     *  Every client keeps the rejection; capable clients additionally receive
+     *  the signed-out *state* as one session-scoped failure whose `login`
+     *  action remains the way back in after the client's auth prompt is
+     *  dismissed. Its title stays the policy's client-neutral fallback — the
+     *  CLI's own text ("… Please run /login") is TUI advice, meaningless in an
+     *  ACP client, so it travels as expandable details instead. */
     const failActiveWithSessionFailure = async (
       kind: ClaudeFailureKind,
       error: unknown,
       title?: string,
     ) => {
+      if (kind === "auth_required") {
+        // One sign-out arrives twice — the synthetic login assistant message
+        // and the turn's error-shaped result repeat the same text — and the
+        // signed-out state does not change in between: publish once, and skip
+        // republishing while the previous sign-out is still active. A retry
+        // warning of the same kind is not a sign-out and must not suppress it.
+        if (!sessionFailures.hasActiveSessionError(kind)) {
+          await publishSessionFailure(kind, { turnScoped: false, details: title });
+        }
+        // Preserve legacy codes: only explicit `/login` signals trigger ACP's auth flow.
+        failActive(error);
+        return;
+      }
       if (!supportsAirSessionFailures(this.clientCapabilities)) {
         failActive(error);
         return;

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -162,6 +162,18 @@ import {
   supportsAirSessionFailures,
 } from "./session-failure-extension.js";
 import {
+  billsClaudeSubscription,
+  CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE,
+  CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON,
+  claudeLoginRequiredError,
+  type ClaudeSubscriptionGuardState,
+  claudeSubscriptionNotSupportedError,
+  holdsNonSubscriptionCredential,
+  refuseClaudeSubscriptionTurn,
+  shouldHideClaudeAuth,
+  warnClaudeSubscriptionGuardDegraded,
+} from "./hide-claude-auth.js";
+import {
   AGENT_FILE_CHANGE_REPORT_CAPABILITY,
   agentFileChangeReportMeta,
   agentFileChangeReportRequestId,
@@ -243,6 +255,8 @@ function isEmptyUserInterruptionDiagnostic(
 export interface Logger {
   log: (...args: any[]) => void;
   error: (...args: any[]) => void;
+  /** Optional: a caller that supplies no `warn` gets its warnings on `error`. */
+  warn?: (...args: any[]) => void;
 }
 
 type AccumulatedUsage = {
@@ -952,6 +966,16 @@ export type Session = {
    *  Keeping it on the Session lets replay seed a failure that the persistent
    *  consumer can later clear with the same id and a higher revision. */
   sessionFailureState: SessionFailureState;
+  /** State of the `--hide-claude-auth` subscription guard for this session.
+   *  Built on the first guarded turn; most sessions never need it. */
+  claudeSubscriptionGuard?: ClaudeSubscriptionGuardState;
+  /** Set under `--hide-claude-auth` when the CLI reported a sign-out during
+   *  this session. The query is closed and the account it cached at
+   *  `initialize` now describes a credential that no longer works, so the next
+   *  turn recreates the query before it runs. */
+  needsSignOutRespawn?: boolean;
+  /** The in-flight recreation, so turns that arrive together share one. */
+  signOutRespawn?: Promise<void>;
 };
 
 /** Result-message origin kinds that mark an AUTONOMOUS cycle — work the
@@ -1068,14 +1092,22 @@ type GatewayAuthMeta = {
    * - Redirect API calls via baseUrl
    * - Inject custom headers
    * - Bypass the default Claude login requirement
+   *
+   * Both members are optional in the type because the payload arrives
+   * unvalidated from the client. `authenticate` rejects a request that lacks a
+   * usable `baseUrl`.
    */
-  gateway: {
-    baseUrl: string;
-    headers: Record<string, string>;
+  gateway?: {
+    baseUrl?: string;
+    headers?: Record<string, string>;
   };
 };
 
 type GatewayAuthRequest = AuthenticateRequest & { _meta?: GatewayAuthMeta };
+
+/** The JSON-RPC code ACP assigns to `authRequired`. Read from the SDK so it
+ *  cannot drift from the errors this agent throws. */
+const AUTH_REQUIRED_CODE = RequestError.authRequired().code;
 
 const SUPPORTED_PROTOCOLS: LlmProtocol[] = ["anthropic", "bedrock", "vertex"];
 const PROVIDER_ID = "main";
@@ -1336,10 +1368,6 @@ function isMuslLibc(): boolean {
   const report = process.report?.getReport() as
     { header?: { glibcVersionRuntime?: string } } | undefined;
   return !report?.header?.glibcVersionRuntime;
-}
-
-function shouldHideClaudeAuth(): boolean {
-  return process.argv.includes("--hide-claude-auth");
 }
 
 /** Returned to clients when a prompt or cancel targets a session whose SDK
@@ -2031,8 +2059,35 @@ export class ClaudeAcpAgent {
     };
   }
 
+  /**
+   * `authenticate` — the legacy gateway methods store a provider override that
+   * every later session reads. Validate the payload here, with the same base
+   * URL rule as `providers/set`. An unchecked payload either throws a
+   * `TypeError` deep in session creation, or installs an empty base URL that
+   * silently turns the `--hide-claude-auth` subscription guard off.
+   *
+   * A call that carries no gateway payload at all keeps its historical
+   * meaning: it installs no override and succeeds. That has always been a
+   * no-op here, and a client that probes the method this way must keep
+   * working. Only a payload that IS present has to be usable.
+   */
   async authenticate(_params: AuthenticateRequest): Promise<void> {
     if (_params.methodId === "gateway" || _params.methodId === "gateway-bedrock") {
+      const gateway = (_params as GatewayAuthRequest)._meta?.gateway;
+      if (gateway !== undefined && gateway !== null) {
+        if (typeof gateway !== "object" || !isValidBaseUrl(gateway.baseUrl)) {
+          throw RequestError.invalidParams(
+            { baseUrl: (gateway as { baseUrl?: unknown }).baseUrl },
+            "`_meta.gateway.baseUrl` must be a non-empty absolute http(s) URL.",
+          );
+        }
+        if (gateway.headers !== undefined && typeof gateway.headers !== "object") {
+          throw RequestError.invalidParams(
+            undefined,
+            "`_meta.gateway.headers` must be an object of header names to values.",
+          );
+        }
+      }
       this.gatewayAuthRequest = _params as GatewayAuthRequest;
       return;
     }
@@ -2188,16 +2243,21 @@ export class ClaudeAcpAgent {
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
     if (this.providerUpdate) await this.providerUpdate;
-    const session = this.sessions[params.sessionId];
+    let session = this.sessions[params.sessionId];
     if (!session) {
       throw new Error("Session not found");
     }
+    const signOutRespawn = this.respawnSignedOutSession(params.sessionId, session);
+    if (signOutRespawn) session = await signOutRespawn;
     // The SDK query stream already terminated (see `queryClosed`); its iterator
     // can't be revived, so enqueueing here would hang on a deferred that never
     // settles. Fail clearly and let the client start a fresh session.
     if (session.queryClosed) {
       throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
+
+    const subscriptionGuard = this.runClaudeSubscriptionGuard(params.sessionId, session);
+    if (subscriptionGuard) await subscriptionGuard;
 
     if (session.autoModeFallbackWarningPending) {
       await this.sessionModes.publishFallbackWarning(params.sessionId, session);
@@ -2264,6 +2324,135 @@ export class ClaudeAcpAgent {
     this.ensureConsumer(session, params.sessionId);
     await this.publishGoalFromPrompt(params.sessionId, firstText, promptUuid);
     return response;
+  }
+
+  /** `--hide-claude-auth` applies only to the CLI's own login. A provider
+   *  override (`providers/set` or gateway `authenticate`) routes traffic away
+   *  from it, so the subscription guard is off while one is active. */
+  private claudeSubscriptionGuardActive(): boolean {
+    return shouldHideClaudeAuth() && this.resolveProviderConfig() === null;
+  }
+
+  /** Record that the CLI signed out during this session, and end the query.
+   *
+   *  Only under `--hide-claude-auth`. The account cached at `initialize` is
+   *  this integration's source of truth, and a sign-out proves that account
+   *  wrong: the credential behind it is gone, and whatever replaces it is
+   *  invisible until a new `initialize` runs. Closing the query here makes the
+   *  next turn recreate it, so the creation guard decides on the real account.
+   *
+   *  Idempotent: one sign-out reaches this twice (the synthetic login message
+   *  and the turn's error-shaped result), and the second call must not close
+   *  a stream the first one already closed. Closing settles the queued turns
+   *  through the consumer's end-of-stream path, which rejects each one. */
+  private markSessionForSignOutRespawn(sessionId: string, session: Session): void {
+    if (!shouldHideClaudeAuth() || session.needsSignOutRespawn) {
+      return;
+    }
+    if (!session.creationParams) {
+      this.logger.error(
+        `Session ${sessionId}: signed out, but the creation params are missing; cannot recreate the query`,
+      );
+      return;
+    }
+    session.needsSignOutRespawn = true;
+    this.logger.log(`Session ${sessionId}: signed out; the query is recreated on the next turn`);
+    this.closeQueryStream(session);
+  }
+
+  /** Recreate the query of a signed-out session, keeping the ACP session id and
+   *  resuming the Claude session so the history survives. Returns the session
+   *  the caller must go on with: the new one, or the argument when no
+   *  recreation is due.
+   *
+   *  The recreation runs the full creation guard, so a subscription account is
+   *  refused with the subscription reason, a still-signed-out account with the
+   *  plain sign-out error, and an accepted credential proceeds. A refusal keeps
+   *  the old husk in the session map, so the client can sign in and retry on
+   *  the same session instead of meeting "Session not found".
+   *
+   *  Returns `undefined`, not a resolved promise, when no recreation is due:
+   *  the callers enqueue their turn in one synchronous section, and an extra
+   *  microtask there would let the caller observe a half-built turn. */
+  private respawnSignedOutSession(
+    sessionId: string,
+    session: Session,
+  ): Promise<Session> | undefined {
+    if (!session.needsSignOutRespawn) {
+      return undefined;
+    }
+    return this.awaitSignOutRespawn(sessionId, session);
+  }
+
+  private async awaitSignOutRespawn(sessionId: string, session: Session): Promise<Session> {
+    const respawn = (session.signOutRespawn ??= this.recreateSignedOutQuery(
+      sessionId,
+      session,
+    ).finally(() => {
+      session.signOutRespawn = undefined;
+    }));
+    await respawn;
+    const respawned = this.sessions[sessionId];
+    if (!respawned) {
+      throw new Error("Session not found");
+    }
+    return respawned;
+  }
+
+  private async recreateSignedOutQuery(sessionId: string, session: Session): Promise<void> {
+    const creationParams = session.creationParams;
+    if (!creationParams) {
+      throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
+    }
+    this.logger.log(`Recreating Claude session ${sessionId} after a sign-out`);
+    // Already closed by `markSessionForSignOutRespawn`; idempotent here so a
+    // husk that reached this by another route still releases its resources.
+    this.closeQueryStream(session);
+    try {
+      // `resume` names the Claude session, which shares the ACP session id, so
+      // the new query continues the same conversation under the same id.
+      await this.createSession(creationParams, { resume: sessionId });
+    } catch (error) {
+      // Keep the husk addressable: the client answers the refusal with its own
+      // auth flow and then retries this session.
+      if (!this.sessions[sessionId]) {
+        this.sessions[sessionId] = session;
+      }
+      throw error;
+    }
+  }
+
+  /** Run the `--hide-claude-auth` guard before a turn starts. The returned
+   *  promise rejects with the `authRequired` error when a claude.ai
+   *  subscription would pay, or when the account holds no credential this
+   *  integration accepts. Every entry point that starts a turn must await it,
+   *  so the refusal reaches the client instead of a detached promise.
+   *
+   *  Returns `undefined`, not a resolved promise, while the guard is off: the
+   *  callers run in the same synchronous section as the turn they enqueue, and
+   *  an extra microtask there would let the caller observe a half-built turn. */
+  private runClaudeSubscriptionGuard(
+    sessionId: string,
+    session: Session,
+  ): Promise<void> | undefined {
+    if (!this.claudeSubscriptionGuardActive()) {
+      return undefined;
+    }
+    return refuseClaudeSubscriptionTurn({
+      sessionId,
+      query: session.query,
+      guardState: (session.claudeSubscriptionGuard ??= {}),
+      logger: this.logger,
+      sessionFailures: () =>
+        new SessionFailureController({
+          sessionId,
+          state: session.sessionFailureState,
+          capabilities: this.clientCapabilities,
+          isCurrent: () => this.sessions[sessionId] === session,
+          sendUpdate: (notification) => this.client.sessionUpdate(notification),
+          logger: this.logger,
+        }),
+    });
   }
 
   async goal(params: GoalRequest): Promise<GoalControlResponse> {
@@ -2369,10 +2558,12 @@ export class ClaudeAcpAgent {
    *  `startedNewTurn` result are preserved for compatibility. */
   async steer(params: SteerRequest): Promise<SteerResponse> {
     const sessionId = params.sessionId;
-    const session = this.sessions[sessionId];
+    let session = this.sessions[sessionId];
     if (!session) {
       throw new Error("Session not found");
     }
+    const signOutRespawn = this.respawnSignedOutSession(sessionId, session);
+    if (signOutRespawn) session = await signOutRespawn;
     if (session.queryClosed) {
       throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
@@ -2393,6 +2584,13 @@ export class ClaudeAcpAgent {
         // a normal session/prompt whose lifecycle owns the continuation result.
         return { outcome: "promptRequired", reason: "noRunningTurn" };
       }
+
+      // The detached `prompt()` below swallows its own rejection, so run the
+      // `--hide-claude-auth` guard here and let it reject `steer` itself.
+      // Otherwise the refusal never reaches the client and the Host reads
+      // "startedNewTurn" for a turn that never started.
+      const subscriptionGuard = this.runClaudeSubscriptionGuard(sessionId, session);
+      if (subscriptionGuard) await subscriptionGuard;
 
       // Preserve the established default for Hosts that do not opt in. This is
       // intentionally detached for compatibility with the existing contract.
@@ -3081,6 +3279,10 @@ export class ClaudeAcpAgent {
         // That is the normal course here, not the lost-failure case `failActive`
         // logs an error for.
         if (session.activeTurn && !session.activeTurn.settled) failActive(error);
+        // The row is published and the turn is rejected. Under
+        // `--hide-claude-auth` the account cached at `initialize` is now
+        // wrong, so end the query and let the next turn recreate it.
+        this.markSessionForSignOutRespawn(params.sessionId, session);
         return;
       }
       if (!supportsAirSessionFailures(this.clientCapabilities)) {
@@ -5592,6 +5794,21 @@ export class ClaudeAcpAgent {
     }
   }
 
+  /** Release a query that was spawned but never registered as a session. */
+  private discardUnregisteredQuery(
+    q: Query,
+    input: Pushable<SDKUserMessage>,
+    settingsManager: SettingsManager,
+  ): void {
+    settingsManager.dispose();
+    input.end();
+    try {
+      q.close();
+    } catch (error) {
+      this.logger.error("Failed to close unregistered Claude query", error);
+    }
+  }
+
   /** Mark a session's SDK query stream as permanently ended and release the
    *  resources tied to it: drop the consumer handle, dispose the settings
    *  watchers, end the input stream, and close the query (which terminates the
@@ -7325,234 +7542,254 @@ export class ClaudeAcpAgent {
       options,
     });
 
-    let initializationResult;
+    // `query()` spawns the CLI at once. Any throw between here and the
+    // registration in `this.sessions` would leave that child process running
+    // with nobody holding the query, so discard it before propagating.
     try {
-      initializationResult = await q.initializationResult();
-    } catch (error) {
-      if (
-        creationOpts.resume &&
-        error instanceof Error &&
-        (error.message === "Query closed before response received" ||
-          error.message.includes("No conversation found with session ID"))
-      ) {
-        throw RequestError.resourceNotFound(sessionId);
+      let initializationResult;
+      try {
+        initializationResult = await q.initializationResult();
+      } catch (error) {
+        if (
+          creationOpts.resume &&
+          error instanceof Error &&
+          (error.message === "Query closed before response received" ||
+            error.message.includes("No conversation found with session ID"))
+        ) {
+          throw RequestError.resourceNotFound(sessionId);
+        }
+        throw error;
       }
+
+      // Shared with the per-turn guard, so "warn once" spans the whole session.
+      const claudeSubscriptionGuard: ClaudeSubscriptionGuardState = {};
+      if (this.claudeSubscriptionGuardActive()) {
+        if (!initializationResult.account) {
+          warnClaudeSubscriptionGuardDegraded({
+            sessionId,
+            guardState: claudeSubscriptionGuard,
+            logger: this.logger,
+            cause: "the CLI reported no account at initialize",
+          });
+        } else if (billsClaudeSubscription(initializationResult.account)) {
+          throw claudeSubscriptionNotSupportedError();
+        } else if (!holdsNonSubscriptionCredential(initializationResult.account)) {
+          // Fail closed: the account holds nothing this integration can bill.
+          // A logged-out session must never exist, because the CLI can pick up
+          // a claude.ai login by itself and AIR resumes a parked prompt on the
+          // SAME session after a sign-in. Refusing before the session exists
+          // makes every sign-in lead to a new session and a fresh `initialize`.
+          throw claudeLoginRequiredError();
+        }
+      }
+
+      // Apply user's `availableModels` allowlist from settings.json before any
+      // downstream model handling. The SDK only enforces this allowlist in its
+      // own UI, not in `initializationResult.models`, so we filter here to keep
+      // configOptions, the current-model resolver, and the stored modelInfos
+      // consistent with what the user configured.
+      const settingsAvailableModels = settingsManager.getSettings().availableModels;
+      const settingsModelOverrides = settingsManager.getSettings().modelOverrides;
+      const allowedModels = Array.isArray(settingsAvailableModels)
+        ? applyAvailableModelsAllowlist(
+            initializationResult.models,
+            settingsAvailableModels,
+            settingsModelOverrides,
+          )
+        : initializationResult.models;
+
+      const { modelState: models, resumedContextWindow } = await getAvailableModels(
+        q,
+        allowedModels,
+        initializationResult.models,
+        settingsManager,
+        this.logger,
+        creationOpts.resume !== undefined,
+      );
+
+      // Resolve the current model's capabilities separately from the stable
+      // permission-mode catalog advertised to ACP clients.
+      // A resumed session can be running a model outside the `availableModels`
+      // allowlist (currentModelId is then the verbatim live id, see
+      // `matchResumedModel`); its capabilities are still known to the SDK's
+      // unfiltered list, so fall back to that before treating the model as
+      // unknown — otherwise auto mode would be spuriously clamped and the
+      // Fast-mode/Effort options hidden for a model that supports them.
+      const allowlistedModelInfo = allowedModels.find((m) => m.value === models.currentModelId);
+      const fallbackModelInfo = allowlistedModelInfo
+        ? undefined
+        : (resolveModelPreference(initializationResult.models, models.currentModelId) ?? undefined);
+      const currentModelInfo = allowlistedModelInfo ?? fallbackModelInfo;
+      // Register the fallback-resolved capabilities under the verbatim live id
+      // so every modelInfos consumer (buildConfigOptions' effort lookup, later
+      // rebuilds via session.modelInfos) agrees with the gating below. The
+      // picker options themselves come from `models.availableModels`, so this
+      // adds no selectable entry. The spread keeps every capability flag
+      // (current and future); the identity fields are overridden because the
+      // fuzzy-matched sibling's resolvedModel/displayName/description can
+      // describe a different context lane and would poison later resolvedModel
+      // matching (syncModelAfterExternalSwitch) and context-window inference
+      // (applyConfigOptionValue) if they traveled under this id.
+      const modelInfos = fallbackModelInfo
+        ? [
+            ...allowedModels,
+            {
+              ...fallbackModelInfo,
+              value: models.currentModelId,
+              displayName: models.currentModelId,
+              description: "",
+              resolvedModel: undefined,
+            },
+          ]
+        : allowedModels;
+      const { modes, autoModeFallbackWarningPending } = await this.sessionModes.initialize({
+        query: q,
+        requestedMode: initialPermissionMode,
+        currentModelInfo,
+        currentModelId: models.currentModelId,
+      });
+
+      const agents = await discoverCustomAgents(q);
+      // Only adopt the requested agent as the selected value if it's one we
+      // actually surface in the picker. A built-in (filtered out above) or
+      // otherwise-unknown name would leave the config option's `currentValue`
+      // pointing at an entry not in its own `options` list, which clients render
+      // as a blank/invalid selection.
+      const requestedAgent = userProvidedOptions?.agent;
+      const currentAgent =
+        requestedAgent && agents.some((a) => a.name === requestedAgent)
+          ? requestedAgent
+          : DEFAULT_AGENT_ID;
+
+      // Seed Fast mode from the SDK's reported state so the UI reflects reality
+      // (the CLI may start a session with fast mode already on, or force it off
+      // when `fastModePerSessionOptIn` is set). The toggle is only surfaced while
+      // the resolved model advertises `supportsFastMode`.
+      const fastModeEnabled =
+        initializationResult.fast_mode_state !== undefined &&
+        fastModeStateEnabled(initializationResult.fast_mode_state);
+      // `fast_mode_disabled_reason` reflects the post-switch model since SDK
+      // 0.3.219 (the initialize response used to answer from the spawn-time
+      // model). A fresh SDK session reports `sdk_opt_in_required` — the toggle IS
+      // the opt-in — which normalizes away, so only real blockers are retained.
+      const fastModeDisabledReason = fastModeEnabled
+        ? undefined
+        : normalizeFastModeDisabledReason(initializationResult.fast_mode_disabled_reason);
+      const fastMode: FastModeOptionState = {
+        supported: currentModelInfo?.supportsFastMode ?? false,
+        enabled: fastModeEnabled,
+        useBooleanOption: clientSupportsBooleanConfigOptions(this.clientCapabilities),
+        disabledReason: fastModeDisabledReason,
+      };
+
+      // The Effort picker seed mirrors what the CLI itself resolves from the
+      // persisted settings — the current model's `modelSettings` entry first
+      // (the CLI persists /effort per model), then the legacy top-level value.
+      // Display-only: no applyFlagSettings here. The CLI reads the same
+      // settings, so pinning the seed at the flag layer was always redundant —
+      // and it would override the CLI's own per-model restore on every later
+      // model switch. Only a user's explicit ACP picker choice pins the flag
+      // (see applyConfigOptionValue / Session.effortPinnedByUser).
+      const configOptions = buildConfigOptions(
+        modes,
+        models,
+        modelInfos,
+        settingsEffortForModel(settingsManager.getSettings(), currentModelInfo),
+        agents,
+        currentAgent,
+        fastMode,
+      );
+      // Seed the context window WITHOUT any extra IPC on the session/new path.
+      // On session/load, the resumed session's own `getContextUsage` report — a
+      // response `getAvailableModels` already awaited to learn the live model
+      // (resumed sessions ARE serviced pre-turn, unlike fresh ones) — is
+      // authoritative and wins. Otherwise: the cached authoritative window if a
+      // prior turn has learned it for this model (`result.modelUsage`,
+      // cross-session), else the text heuristic, else the default. We
+      // deliberately do NOT issue a getContextUsage call here: on a fresh
+      // session that control request is not serviced until the first prompt
+      // turn runs, so awaiting it — as 0.59.0 did — made session/new take ~15s
+      // (issues #886/#880). The authoritative window arrives on the first
+      // `result.modelUsage` and is cached from there.
+      //
+      // Text inference alone misses aliases that resolve to extended-context
+      // models with no "1m" token anywhere in their id or description (e.g.
+      // `sonnet` → claude-sonnet-5, natively ~1M): those stream
+      // `usage_update.size: 200000` until the first result's modelUsage corrects
+      // it — but the cache means only the FIRST session to ever run a turn on such
+      // a model eats that window, not every fresh session after a process
+      // restart (issue #596; a post-restart session/load is covered by the
+      // resumed report above).
+      //
+      // The inference fallback is deliberately keyed to the allowlisted entry: a
+      // fallback-resolved sibling's resolvedModel/displayName/description can
+      // describe a different context lane than the verbatim live id (e.g. an
+      // "opus[1m]" row matched for a bare 200k id), so on the fallback path only
+      // the id itself is a trustworthy window signal.
+      const seededWindow =
+        resumedContextWindow !== null
+          ? { size: resumedContextWindow, authoritative: true }
+          : immediateContextWindow(providerCacheKey, models.currentModelId, allowlistedModelInfo);
+
+      this.sessions[sessionId] = {
+        query: q,
+        input: input,
+        cancelled: false,
+        cwd: params.cwd,
+        sessionFingerprint: computeSessionFingerprint(params),
+        creationParams: params,
+        settingsManager,
+        titles: new SessionTitles(this, sessionId),
+        accumulatedUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cachedReadTokens: 0,
+          cachedWriteTokens: 0,
+        },
+        accumulatedModelUsage: {},
+        lastModelUsageReading: {},
+        modes,
+        models,
+        modelInfos,
+        autoModeFallbackWarningShown: false,
+        autoModeFallbackWarningPending,
+        configOptions,
+        agents,
+        currentAgent,
+        fastModeEnabled,
+        fastModeDisabledReason,
+        abortController,
+        emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
+        forwardSubagentText,
+        contextWindowSize: seededWindow.size,
+        contextWindowAuthoritative: seededWindow.authoritative,
+        providerCacheKey,
+        taskState,
+        toolUseCache: {},
+        emittedToolCalls: new Set(),
+        eagerToolCallSessions: new Map(),
+        liveBackgroundTasks: new Map(),
+        nativeSubagentsByTaskId: new Map(),
+        nativeSubagentTaskIdByToolUseId: new Map(),
+        nativeSubagentParentByToolUseId: new Map(),
+        emittedAssistantText: false,
+        owedTrailingIdles: 0,
+        messageIdToUuid: new Map(),
+        sessionFailureState: createSessionFailureState(),
+        claudeSubscriptionGuard,
+        fileChangeReportRequestIds: new Set(),
+        fileChangeAuditSupport,
+      };
+
+      return {
+        sessionId,
+        modes,
+        configOptions,
+      };
+    } catch (error) {
+      this.discardUnregisteredQuery(q, input, settingsManager);
       throw error;
     }
-
-    if (
-      shouldHideClaudeAuth() &&
-      initializationResult.account.subscriptionType &&
-      !this.gatewayAuthRequest
-    ) {
-      throw RequestError.authRequired(
-        undefined,
-        "This integration does not support using claude.ai subscriptions.",
-      );
-    }
-
-    // Apply user's `availableModels` allowlist from settings.json before any
-    // downstream model handling. The SDK only enforces this allowlist in its
-    // own UI, not in `initializationResult.models`, so we filter here to keep
-    // configOptions, the current-model resolver, and the stored modelInfos
-    // consistent with what the user configured.
-    const settingsAvailableModels = settingsManager.getSettings().availableModels;
-    const settingsModelOverrides = settingsManager.getSettings().modelOverrides;
-    const allowedModels = Array.isArray(settingsAvailableModels)
-      ? applyAvailableModelsAllowlist(
-          initializationResult.models,
-          settingsAvailableModels,
-          settingsModelOverrides,
-        )
-      : initializationResult.models;
-
-    const { modelState: models, resumedContextWindow } = await getAvailableModels(
-      q,
-      allowedModels,
-      initializationResult.models,
-      settingsManager,
-      this.logger,
-      creationOpts.resume !== undefined,
-    );
-
-    // Resolve the current model's capabilities separately from the stable
-    // permission-mode catalog advertised to ACP clients.
-    // A resumed session can be running a model outside the `availableModels`
-    // allowlist (currentModelId is then the verbatim live id, see
-    // `matchResumedModel`); its capabilities are still known to the SDK's
-    // unfiltered list, so fall back to that before treating the model as
-    // unknown — otherwise auto mode would be spuriously clamped and the
-    // Fast-mode/Effort options hidden for a model that supports them.
-    const allowlistedModelInfo = allowedModels.find((m) => m.value === models.currentModelId);
-    const fallbackModelInfo = allowlistedModelInfo
-      ? undefined
-      : (resolveModelPreference(initializationResult.models, models.currentModelId) ?? undefined);
-    const currentModelInfo = allowlistedModelInfo ?? fallbackModelInfo;
-    // Register the fallback-resolved capabilities under the verbatim live id
-    // so every modelInfos consumer (buildConfigOptions' effort lookup, later
-    // rebuilds via session.modelInfos) agrees with the gating below. The
-    // picker options themselves come from `models.availableModels`, so this
-    // adds no selectable entry. The spread keeps every capability flag
-    // (current and future); the identity fields are overridden because the
-    // fuzzy-matched sibling's resolvedModel/displayName/description can
-    // describe a different context lane and would poison later resolvedModel
-    // matching (syncModelAfterExternalSwitch) and context-window inference
-    // (applyConfigOptionValue) if they traveled under this id.
-    const modelInfos = fallbackModelInfo
-      ? [
-          ...allowedModels,
-          {
-            ...fallbackModelInfo,
-            value: models.currentModelId,
-            displayName: models.currentModelId,
-            description: "",
-            resolvedModel: undefined,
-          },
-        ]
-      : allowedModels;
-    const { modes, autoModeFallbackWarningPending } = await this.sessionModes.initialize({
-      query: q,
-      requestedMode: initialPermissionMode,
-      currentModelInfo,
-      currentModelId: models.currentModelId,
-    });
-
-    const agents = await discoverCustomAgents(q);
-    // Only adopt the requested agent as the selected value if it's one we
-    // actually surface in the picker. A built-in (filtered out above) or
-    // otherwise-unknown name would leave the config option's `currentValue`
-    // pointing at an entry not in its own `options` list, which clients render
-    // as a blank/invalid selection.
-    const requestedAgent = userProvidedOptions?.agent;
-    const currentAgent =
-      requestedAgent && agents.some((a) => a.name === requestedAgent)
-        ? requestedAgent
-        : DEFAULT_AGENT_ID;
-
-    // Seed Fast mode from the SDK's reported state so the UI reflects reality
-    // (the CLI may start a session with fast mode already on, or force it off
-    // when `fastModePerSessionOptIn` is set). The toggle is only surfaced while
-    // the resolved model advertises `supportsFastMode`.
-    const fastModeEnabled =
-      initializationResult.fast_mode_state !== undefined &&
-      fastModeStateEnabled(initializationResult.fast_mode_state);
-    // `fast_mode_disabled_reason` reflects the post-switch model since SDK
-    // 0.3.219 (the initialize response used to answer from the spawn-time
-    // model). A fresh SDK session reports `sdk_opt_in_required` — the toggle IS
-    // the opt-in — which normalizes away, so only real blockers are retained.
-    const fastModeDisabledReason = fastModeEnabled
-      ? undefined
-      : normalizeFastModeDisabledReason(initializationResult.fast_mode_disabled_reason);
-    const fastMode: FastModeOptionState = {
-      supported: currentModelInfo?.supportsFastMode ?? false,
-      enabled: fastModeEnabled,
-      useBooleanOption: clientSupportsBooleanConfigOptions(this.clientCapabilities),
-      disabledReason: fastModeDisabledReason,
-    };
-
-    // The Effort picker seed mirrors what the CLI itself resolves from the
-    // persisted settings — the current model's `modelSettings` entry first
-    // (the CLI persists /effort per model), then the legacy top-level value.
-    // Display-only: no applyFlagSettings here. The CLI reads the same
-    // settings, so pinning the seed at the flag layer was always redundant —
-    // and it would override the CLI's own per-model restore on every later
-    // model switch. Only a user's explicit ACP picker choice pins the flag
-    // (see applyConfigOptionValue / Session.effortPinnedByUser).
-    const configOptions = buildConfigOptions(
-      modes,
-      models,
-      modelInfos,
-      settingsEffortForModel(settingsManager.getSettings(), currentModelInfo),
-      agents,
-      currentAgent,
-      fastMode,
-    );
-    // Seed the context window WITHOUT any extra IPC on the session/new path.
-    // On session/load, the resumed session's own `getContextUsage` report — a
-    // response `getAvailableModels` already awaited to learn the live model
-    // (resumed sessions ARE serviced pre-turn, unlike fresh ones) — is
-    // authoritative and wins. Otherwise: the cached authoritative window if a
-    // prior turn has learned it for this model (`result.modelUsage`,
-    // cross-session), else the text heuristic, else the default. We
-    // deliberately do NOT issue a getContextUsage call here: on a fresh
-    // session that control request is not serviced until the first prompt
-    // turn runs, so awaiting it — as 0.59.0 did — made session/new take ~15s
-    // (issues #886/#880). The authoritative window arrives on the first
-    // `result.modelUsage` and is cached from there.
-    //
-    // Text inference alone misses aliases that resolve to extended-context
-    // models with no "1m" token anywhere in their id or description (e.g.
-    // `sonnet` → claude-sonnet-5, natively ~1M): those stream
-    // `usage_update.size: 200000` until the first result's modelUsage corrects
-    // it — but the cache means only the FIRST session to ever run a turn on such
-    // a model eats that window, not every fresh session after a process
-    // restart (issue #596; a post-restart session/load is covered by the
-    // resumed report above).
-    //
-    // The inference fallback is deliberately keyed to the allowlisted entry: a
-    // fallback-resolved sibling's resolvedModel/displayName/description can
-    // describe a different context lane than the verbatim live id (e.g. an
-    // "opus[1m]" row matched for a bare 200k id), so on the fallback path only
-    // the id itself is a trustworthy window signal.
-    const seededWindow =
-      resumedContextWindow !== null
-        ? { size: resumedContextWindow, authoritative: true }
-        : immediateContextWindow(providerCacheKey, models.currentModelId, allowlistedModelInfo);
-
-    this.sessions[sessionId] = {
-      query: q,
-      input: input,
-      cancelled: false,
-      cwd: params.cwd,
-      sessionFingerprint: computeSessionFingerprint(params),
-      creationParams: params,
-      settingsManager,
-      titles: new SessionTitles(this, sessionId),
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      accumulatedModelUsage: {},
-      lastModelUsageReading: {},
-      modes,
-      models,
-      modelInfos,
-      autoModeFallbackWarningShown: false,
-      autoModeFallbackWarningPending,
-      configOptions,
-      agents,
-      currentAgent,
-      fastModeEnabled,
-      fastModeDisabledReason,
-      abortController,
-      emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
-      forwardSubagentText,
-      contextWindowSize: seededWindow.size,
-      contextWindowAuthoritative: seededWindow.authoritative,
-      providerCacheKey,
-      taskState,
-      toolUseCache: {},
-      emittedToolCalls: new Set(),
-      eagerToolCallSessions: new Map(),
-      liveBackgroundTasks: new Map(),
-      nativeSubagentsByTaskId: new Map(),
-      nativeSubagentTaskIdByToolUseId: new Map(),
-      nativeSubagentParentByToolUseId: new Map(),
-      emittedAssistantText: false,
-      owedTrailingIdles: 0,
-      messageIdToUuid: new Map(),
-      sessionFailureState: createSessionFailureState(),
-      fileChangeReportRequestIds: new Set(),
-      fileChangeAuditSupport,
-    };
-
-    return {
-      sessionId,
-      modes,
-      configOptions,
-    };
   }
 
   /**
@@ -7582,17 +7819,82 @@ export class ClaudeAcpAgent {
         this.logger.log(`Recreating Claude session ${sessionId} for provider update`);
         this.closeQueryStream(session);
         delete this.sessions[sessionId];
-        await this.createSession(session.creationParams, { resume: sessionId });
+        try {
+          await this.createSession(session.creationParams, { resume: sessionId });
+        } catch (error) {
+          // One session that cannot come back must not abort the switch. The
+          // `--hide-claude-auth` guard makes this a normal outcome of
+          // `providers/disable`: the override kept a subscription account
+          // usable, and creation refuses without it. The session is already
+          // gone, so tell the client why and go on to the next one.
+          this.reportSessionLostOnProviderUpdate(sessionId, session, error);
+        }
       }
     });
-    this.providerUpdate = update;
+    // Sessions and prompts await `providerUpdate` before they run. A rejected
+    // promise stored here would reject every one of them, and would surface as
+    // an unhandled rejection once this call returned. Keep the failure for the
+    // caller of `providers/set` and `providers/disable` only.
+    const waitable = update.catch((error) => {
+      this.logger.error(`Provider update failed: ${error}`);
+    });
+    this.providerUpdate = waitable;
     try {
       await update;
     } finally {
-      if (this.providerUpdate === update) {
+      if (this.providerUpdate === waitable) {
         this.providerUpdate = null;
       }
     }
+  }
+
+  /** Tell a capable client that a session died during a provider switch. The
+   *  session is already removed, so the failure is published on the state it
+   *  left behind, with the refusal reason when the error carries one. */
+  private reportSessionLostOnProviderUpdate(
+    sessionId: string,
+    session: Session,
+    error: unknown,
+  ): void {
+    this.logger.error(
+      `Session ${sessionId}: could not be recreated for the provider update: ${error}`,
+    );
+    const isAuthRequired = error instanceof RequestError && error.code === AUTH_REQUIRED_CODE;
+    const reason =
+      error instanceof RequestError &&
+      typeof error.data === "object" &&
+      error.data !== null &&
+      "reason" in error.data &&
+      typeof error.data.reason === "string"
+        ? error.data.reason
+        : undefined;
+    const details =
+      reason === CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON
+        ? CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    const controller = new SessionFailureController({
+      sessionId,
+      state: session.sessionFailureState,
+      capabilities: this.clientCapabilities,
+      // The session is gone from `this.sessions` by now, so the usual
+      // identity check would call this publisher stale and drop the row.
+      isCurrent: () => true,
+      sendUpdate: (notification) => this.client.sessionUpdate(notification),
+      logger: this.logger,
+    });
+    void controller
+      .publish(isAuthRequired ? "auth_required" : "internal_error", {
+        sessionScoped: true,
+        details,
+        ...(reason ? { reason } : {}),
+      })
+      .catch((publishError) => {
+        this.logger.error(
+          `Session ${sessionId}: could not publish the provider-update failure: ${publishError}`,
+        );
+      });
   }
 }
 
@@ -7811,13 +8113,18 @@ function snapshotFromUsage(usage: {
  * otherwise anthropic.
  */
 function gatewayRequestToProviderConfig(request?: GatewayAuthRequest): ProviderConfig | null {
-  if (!request?._meta) {
+  // `authenticate` validates the payload before it stores one, so a stored
+  // request always carries a usable gateway. Re-check the shape here anyway:
+  // this function decides whether a provider override is active, and the
+  // `--hide-claude-auth` guard is off while one is.
+  const gateway = request?._meta?.gateway;
+  if (!gateway || !isValidBaseUrl(gateway.baseUrl)) {
     return null;
   }
   return {
-    apiType: request.methodId === "gateway-bedrock" ? "bedrock" : "anthropic",
-    baseUrl: request._meta.gateway.baseUrl,
-    headers: request._meta.gateway.headers,
+    apiType: request?.methodId === "gateway-bedrock" ? "bedrock" : "anthropic",
+    baseUrl: gateway.baseUrl,
+    headers: gateway.headers ?? {},
   };
 }
 
@@ -7882,7 +8189,7 @@ function createEnvForProvider(config: ProviderConfig | null): Record<string, str
 /**
  * Validate a provider base URL: must be a non-empty absolute http(s) URL.
  */
-function isValidBaseUrl(baseUrl: string): boolean {
+function isValidBaseUrl(baseUrl: string | undefined): baseUrl is string {
   if (typeof baseUrl !== "string" || baseUrl.trim() === "") {
     return false;
   }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3077,7 +3077,10 @@ export class ClaudeAcpAgent {
           await publishSessionFailure(kind, { turnScoped: false, details: title });
         }
         // Preserve legacy codes: only explicit `/login` signals trigger ACP's auth flow.
-        failActive(error);
+        // The first delivery rejects the turn, so the second one finds it settled.
+        // That is the normal course here, not the lost-failure case `failActive`
+        // logs an error for.
+        if (session.activeTurn && !session.activeTurn.settled) failActive(error);
         return;
       }
       if (!supportsAirSessionFailures(this.clientCapabilities)) {
@@ -4467,6 +4470,15 @@ export class ClaudeAcpAgent {
                 await sessionFailures.clear(
                   (failure) =>
                     failure.recoveryPolicy === "real_model_success" ||
+                    // A real model answered, so the session is signed in. The
+                    // `auth_status` message is the primary recovery signal, but
+                    // it reports a login the query process itself runs, and a
+                    // client can sign the user in out of band (AIR runs
+                    // `claude /login` in a terminal, in a separate process).
+                    // Without this a stale signed-out record would outlive the
+                    // sign-out and suppress the next one, which the
+                    // `auth_required` dedupe below reads.
+                    failure.recoveryPolicy === "auth_status" ||
                     (failure.severity === "warning" && failure.turnId === activeTurnId),
                 );
               }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3934,19 +3934,21 @@ export class ClaudeAcpAgent {
                 // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
                 break;
               case "api_retry": {
+                const kind =
+                  message.error_status === null
+                    ? "transport_lost"
+                    : providerFailureCategory(message.error);
+                // A 401 retry is the CLI's credential re-check: it gives up on
+                // the first attempt and reports the sign-out, which is the real
+                // signal and carries the `login` action. A "Retrying" warning
+                // here would outlive the `auth_required` rejection with no
+                // action to clear it (issue #1072).
+                if (kind === "auth_required") break;
                 const title =
                   message.error_status === null
                     ? `Reconnecting to Claude, attempt ${message.attempt} of ${message.max_retries}.`
                     : `Retrying Claude, attempt ${message.attempt} of ${message.max_retries}.`;
-                await publishSessionFailure(
-                  message.error_status === null
-                    ? "transport_lost"
-                    : providerFailureCategory(message.error),
-                  {
-                    title,
-                    severity: "warning",
-                  },
-                );
+                await publishSessionFailure(kind, { title, severity: "warning" });
                 break;
               }
               case "model_refusal_fallback": {

--- a/src/hide-claude-auth.ts
+++ b/src/hide-claude-auth.ts
@@ -17,6 +17,9 @@
  *    `providers/disable` later removed.
  * 2. A sign-out during the session ends the query. The next turn recreates it,
  *    so the next `initialize` reports the real account and layer 1 judges it.
+ *    The recreation resumes the stored conversation. When the CLI never wrote
+ *    one, because the first turn was the one that signed out, the recreation
+ *    starts a fresh query under the same session id instead.
  *
  * One case is left open. The CLI re-reads its credential store on its own. A
  * file-based credential can therefore be removed and replaced by a claude.ai

--- a/src/hide-claude-auth.ts
+++ b/src/hide-claude-auth.ts
@@ -1,0 +1,291 @@
+/**
+ * `--hide-claude-auth`: this integration must never bill a claude.ai
+ * subscription. The flag hides the claude.ai login method from `initialize`
+ * and makes the agent behave like a logged-out CLI whenever a subscription
+ * would pay for a turn. `acp-agent.ts` decides *when* the guard applies (flag
+ * on, no provider override) and calls in here for the *what*.
+ *
+ * The account the CLI reports at `initialize` is the source of truth. The SDK
+ * memoizes it, so it is a constant for the life of a query, and two layers
+ * keep it honest:
+ *
+ * 1. Session creation refuses an account that holds no credential this
+ *    integration accepts. A logged-out session never exists, so the client's
+ *    sign-in always leads to a new session with a fresh `initialize`. The
+ *    per-turn guard repeats the check on the same cached account, which costs
+ *    microseconds and covers a session created under a provider override that
+ *    `providers/disable` later removed.
+ * 2. A sign-out during the session ends the query. The next turn recreates it,
+ *    so the next `initialize` reports the real account and layer 1 judges it.
+ *
+ * One case is left open. The CLI re-reads its credential store on its own. A
+ * file-based credential can therefore be removed and replaced by a claude.ai
+ * subscription between two turns. This covers a managed Console key and a key
+ * from a settings helper. No turn fails in between, so nothing ends the query,
+ * and the cached account still names the key that is gone. Closing this case
+ * would cost one `initialize` control request per turn. That buys too little
+ * for the price.
+ */
+
+import { RequestError } from "@agentclientprotocol/sdk";
+import type { AccountInfo, Query } from "@anthropic-ai/claude-agent-sdk";
+import type { SessionFailureController } from "./session-failure-extension.js";
+
+export function shouldHideClaudeAuth(): boolean {
+  return process.argv.includes("--hide-claude-auth");
+}
+
+/**
+ * `data.reason` carried by the `authRequired` JSON-RPC error when the flag
+ * blocks a turn. From the client's point of view the agent is logged out (same
+ * error code and flow as a signed-out CLI); the reason lets it render a
+ * different hint. A string enum so further reasons can be added without a
+ * shape change.
+ */
+export const CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON = "claude_subscription_not_supported";
+export type AuthRequiredReason = typeof CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON;
+
+export const CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE =
+  "This integration does not support using claude.ai subscriptions.";
+
+/** The message of the plain sign-out refusal. It carries no `reason`: the
+ *  account holds nothing this integration can bill, which is the ordinary
+ *  signed-out state every ACP client already knows how to answer. */
+export const CLAUDE_LOGIN_REQUIRED_MESSAGE =
+  "Sign in with an API key or a Console account to use this integration.";
+
+/**
+ * The `apiKeySource` values that outrank a stored subscription.
+ *
+ * The SDK documents its `ApiKeySource` type as the origin of the credential
+ * used for API requests. `ANTHROPIC_API_KEY` is the environment variable,
+ * `apiKeyHelper` is the configured helper command, and `/login managed key` is
+ * a key that `/login` created with an Anthropic Console account. Each of the
+ * three is an API key that pays instead of the subscription. Every other
+ * member means no API key is in use: `none`, and the legacy `user`, `project`,
+ * `org`, `temporary` and `oauth` that current CLIs never emit.
+ */
+const API_KEY_SOURCES_ABOVE_SUBSCRIPTION: ReadonlySet<string> = new Set([
+  "ANTHROPIC_API_KEY",
+  "apiKeyHelper",
+  "/login managed key",
+]);
+
+/**
+ * True when a turn on this account is paid by a claude.ai subscription.
+ *
+ * The SDK types `apiKeySource` and `tokenSource` as an open `string`, so this
+ * is an allowlist. An account bills the subscription only when every field
+ * proves it, and an unknown value keeps the guard on.
+ *
+ * - `subscriptionType` must be set. Without it the CLI reports no subscription.
+ * - `tokenSource` must be absent. The CLI sets it in place of the subscription
+ *   when a bearer or OAuth environment token pays for the turn.
+ * - `apiProvider` must be absent or `firstParty`. The SDK documents that the
+ *   Anthropic OAuth login applies only to `firstParty`; for a third-party
+ *   backend such as `bedrock`, `vertex`, `foundry` or `gateway` the other
+ *   fields are absent and the authentication is external.
+ * - `apiKeySource` must not be one of {@link API_KEY_SOURCES_ABOVE_SUBSCRIPTION}.
+ *   Claude Code's credential precedence puts those keys above the `/login`
+ *   subscription, so the key pays and the stored subscription is inert.
+ */
+export function billsClaudeSubscription(account: AccountInfo | undefined): boolean {
+  if (!account?.subscriptionType) {
+    return false;
+  }
+  if (account.tokenSource) {
+    return false;
+  }
+  if (account.apiProvider !== undefined && account.apiProvider !== "firstParty") {
+    return false;
+  }
+  return !API_KEY_SOURCES_ABOVE_SUBSCRIPTION.has(account.apiKeySource ?? "");
+}
+
+/**
+ * True when the account already holds a credential this integration accepts:
+ * a third-party backend, a bearer or OAuth environment token, or one of the
+ * API key sources in {@link API_KEY_SOURCES_ABOVE_SUBSCRIPTION}.
+ *
+ * False therefore covers both the signed-out CLI and the account whose only
+ * credential is a claude.ai subscription. {@link billsClaudeSubscription} runs
+ * first and separates the two, so a caller that reaches a `false` here is
+ * looking at a session with no way to pay.
+ */
+export function holdsNonSubscriptionCredential(account: AccountInfo | undefined): boolean {
+  if (!account) {
+    return false;
+  }
+  if (account.apiProvider !== undefined && account.apiProvider !== "firstParty") {
+    return true;
+  }
+  if (account.tokenSource) {
+    return true;
+  }
+  return API_KEY_SOURCES_ABOVE_SUBSCRIPTION.has(account.apiKeySource ?? "");
+}
+
+export function claudeSubscriptionNotSupportedError(): RequestError {
+  return RequestError.authRequired(
+    { reason: CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON satisfies AuthRequiredReason },
+    CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE,
+  );
+}
+
+/** The signed-out refusal. Deliberately without `data`, so a client that reads
+ *  `data.reason` sees the plain ACP sign-out it already handles. */
+export function claudeLoginRequiredError(): RequestError {
+  return RequestError.authRequired(undefined, CLAUDE_LOGIN_REQUIRED_MESSAGE);
+}
+
+/**
+ * The state the guard keeps for one session. It lives on the session so that a
+ * concurrent pair of turns shares one account read and one failure row, and so
+ * that each degraded-guard warning is logged once.
+ */
+export type ClaudeSubscriptionGuardState = {
+  /** The in-flight guard run. Set before the first `await`. */
+  pendingRun?: Promise<RequestError | undefined>;
+  /** True after the "no account source" warning was logged for this session. */
+  degradedWarningLogged?: boolean;
+};
+
+export type GuardLogger = {
+  error: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+};
+
+function warn(logger: GuardLogger, message: string): void {
+  (logger.warn ?? logger.error).call(logger, message);
+}
+
+/**
+ * Report once per session that the guard cannot read the account at all. The
+ * guard is then absent, not passing. The CLI build decides this, not the user,
+ * so a message on every turn would only add noise.
+ */
+export function warnClaudeSubscriptionGuardDegraded(options: {
+  sessionId: string;
+  guardState: ClaudeSubscriptionGuardState;
+  logger: GuardLogger;
+  cause: string;
+}): void {
+  const { guardState } = options;
+  if (guardState.degradedWarningLogged) {
+    return;
+  }
+  guardState.degradedWarningLogged = true;
+  warn(
+    options.logger,
+    `Session ${options.sessionId}: the --hide-claude-auth subscription guard is degraded ` +
+      `(${options.cause}). This session cannot detect a claude.ai subscription.`,
+  );
+}
+
+type GuardOptions = {
+  sessionId: string;
+  query: Pick<Query, "accountInfo">;
+  guardState: ClaudeSubscriptionGuardState;
+  /** Built lazily: most turns pass and never need a controller. */
+  sessionFailures: () => SessionFailureController;
+  logger: GuardLogger;
+};
+
+/**
+ * The per-turn guard for a live session.
+ *
+ * It decides on the account the SDK cached at `initialize`, which is this
+ * integration's source of truth. That account is a constant for the life of
+ * the query, so the check costs microseconds. It still earns its place: it
+ * covers a session created under a provider override that `providers/disable`
+ * later removed, so the create-time check never ran for the routing in force
+ * now. A sign-out ends the query (see `markSessionForSignOutRespawn` in
+ * `acp-agent.ts`), so the next turn recreates it and `initialize` reports the
+ * real account. This guard does not see the residual case the module header
+ * names either.
+ *
+ * A turn is refused when the account bills a subscription, and also when it
+ * holds nothing this integration accepts, which is the user signing out in
+ * mid-session. The refusal mirrors the signed-out path exactly (see
+ * `failActiveWithSessionFailure` for `auth_required` in `acp-agent.ts`): every
+ * client gets the `authRequired` JSON-RPC rejection that starts its own auth
+ * flow, and a capable client additionally gets one session-scoped access
+ * failure whose `login` action stays the way back in.
+ *
+ * Fails open when no account can be read at all: session creation already
+ * refused every account without a usable credential, and an unavailable probe
+ * must not block a session that passed that check.
+ */
+export async function refuseClaudeSubscriptionTurn(options: GuardOptions): Promise<void> {
+  // Concurrent turns must not each re-read the account and each publish a row.
+  // Store the run before the first await, and let the others await the same one.
+  const { guardState } = options;
+  const run = (guardState.pendingRun ??= evaluateGuard(options).finally(() => {
+    if (guardState.pendingRun === run) {
+      guardState.pendingRun = undefined;
+    }
+  }));
+  const refusal = await run;
+  if (refusal) {
+    throw refusal;
+  }
+}
+
+/** Read the account, publish at most one failure row, and return the error the
+ *  turn must be rejected with. Never throws: an unreadable account fails open. */
+async function evaluateGuard(options: GuardOptions): Promise<RequestError | undefined> {
+  const account = await readGuardAccount(options);
+  if (!account) {
+    return undefined;
+  }
+  if (billsClaudeSubscription(account)) {
+    await publishRefusal(options.sessionFailures(), {
+      details: CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE,
+      reason: CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON,
+    });
+    return claudeSubscriptionNotSupportedError();
+  }
+  if (!holdsNonSubscriptionCredential(account)) {
+    await publishRefusal(options.sessionFailures(), { details: CLAUDE_LOGIN_REQUIRED_MESSAGE });
+    return claudeLoginRequiredError();
+  }
+  return undefined;
+}
+
+/** The account the SDK cached at `initialize`. `undefined` when the query
+ *  cannot answer at all. */
+async function readGuardAccount(options: GuardOptions): Promise<AccountInfo | undefined> {
+  const { query } = options;
+  if (typeof query.accountInfo !== "function") {
+    warnClaudeSubscriptionGuardDegraded({
+      ...options,
+      cause: "the SDK query has no accountInfo method",
+    });
+    return undefined;
+  }
+  try {
+    return await query.accountInfo();
+  } catch (error) {
+    options.logger.error(
+      `Session ${options.sessionId}: accountInfo failed; skipping the subscription check for this turn:`,
+      error instanceof Error ? error.message : String(error),
+    );
+    return undefined;
+  }
+}
+
+/** The refusal state does not change between turns: publish once, and skip a
+ *  republish while the previous failure with this reason is still active. */
+async function publishRefusal(
+  sessionFailures: SessionFailureController,
+  failure: { details: string; reason?: string },
+): Promise<void> {
+  if (sessionFailures.hasActiveSessionError("auth_required", failure.reason)) {
+    return;
+  }
+  await sessionFailures.publish("auth_required", {
+    sessionScoped: true,
+    details: failure.details,
+    ...(failure.reason ? { reason: failure.reason } : {}),
+  });
+}

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -296,6 +296,18 @@ export class SessionFailureController {
     }
   }
 
+  /** Whether a session-scoped error of `kind` is active. A turn-scoped
+   *  warning of the same kind (an `api_retry` notice) does not count: it
+   *  reports a retry in progress, not the state the error would publish. */
+  hasActiveSessionError(kind: ClaudeFailureKind): boolean {
+    for (const failure of this.state.active.values()) {
+      if (failure.kind === kind && failure.severity === "error" && failure.turnId === undefined) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   recordActive(failure: PublishedSessionFailure): void {
     this.state.revisions.set(failure.id, failure.revision);
     this.state.active.set(failure.id, failure);

--- a/src/session-failure-extension.ts
+++ b/src/session-failure-extension.ts
@@ -48,6 +48,10 @@ export type PublishedSessionFailure = {
   severity: AirSessionFailureSeverity;
   title: string;
   details?: string;
+  /** A machine-readable refinement of `kind`, e.g. the `--hide-claude-auth`
+   *  subscription guard's reason on an `auth_required` failure. Absent for a
+   *  plain sign-out. */
+  reason?: string;
   actions: AirSessionFailureAction[];
   recoveryPolicy: SessionFailureRecoveryPolicy;
 };
@@ -58,6 +62,7 @@ type SessionFailureOptions = {
   title?: string;
   details?: string;
   severity?: AirSessionFailureSeverity;
+  reason?: string;
 };
 
 export type SessionFailureState = {
@@ -158,6 +163,7 @@ export function sessionFailureMeta(failure: PublishedSessionFailure) {
     severity: failure.severity,
     title: failure.title,
     ...(failure.details ? { details: failure.details } : {}),
+    ...(failure.reason ? { reason: failure.reason } : {}),
     actions: failure.actions,
   });
 }
@@ -298,10 +304,21 @@ export class SessionFailureController {
 
   /** Whether a session-scoped error of `kind` is active. A turn-scoped
    *  warning of the same kind (an `api_retry` notice) does not count: it
-   *  reports a retry in progress, not the state the error would publish. */
-  hasActiveSessionError(kind: ClaudeFailureKind): boolean {
+   *  reports a retry in progress, not the state the error would publish.
+   *
+   *  `reason` refines `kind`, so the active record must carry the same one,
+   *  and an omitted `reason` matches only a record with no reason. A plain
+   *  sign-out and the `--hide-claude-auth` subscription refusal are both
+   *  `auth_required`, but they tell the user different things. Neither may
+   *  suppress the other. */
+  hasActiveSessionError(kind: ClaudeFailureKind, reason?: string): boolean {
     for (const failure of this.state.active.values()) {
-      if (failure.kind === kind && failure.severity === "error" && failure.turnId === undefined) {
+      if (
+        failure.kind === kind &&
+        failure.severity === "error" &&
+        failure.turnId === undefined &&
+        failure.reason === reason
+      ) {
         return true;
       }
     }
@@ -369,6 +386,7 @@ export class SessionFailureController {
       severity: failureOptions.severity ?? "error",
       title,
       ...(failureOptions.details ? { details: failureOptions.details } : {}),
+      ...(failureOptions.reason ? { reason: failureOptions.reason } : {}),
       actions: failureOptions.severity === "warning" ? [] : policy.actions,
       recoveryPolicy: sessionFailureRecoveryPolicy(
         kind,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6529,13 +6529,19 @@ describe("stop reason propagation", () => {
 
   it("does not republish auth_required when the result repeats the login text", async () => {
     const updates: SessionNotification[] = [];
+    const logged: string[] = [];
     const agent = new ClaudeAcpAgent(
       {
         sessionUpdate: async (update: SessionNotification) => {
           updates.push(update);
         },
       } as unknown as AcpClient,
-      { log: () => {}, error: () => {} },
+      {
+        log: () => {},
+        error: (message: unknown) => {
+          logged.push(String(message));
+        },
+      },
     );
     (agent as any).clientCapabilities = airSessionFailureCapabilities;
     // The CLI reports one signed-out turn twice: the synthetic login assistant
@@ -6574,6 +6580,84 @@ describe("stop reason propagation", () => {
     expect([...agent.sessions["test-session"].sessionFailureState.active.keys()]).toEqual([
       failures[0].id,
     ]);
+    // The first delivery already rejected the turn, so the second one has no
+    // turn to fail. That is expected here and must not be logged as a fault.
+    expect(logged.join("\n")).not.toContain("cannot fail active turn");
+  });
+
+  it("republishes the signed-out state after a real model answer cleared the last one", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    const signedOut = () => {
+      const message = createAssistantError("authentication_failed");
+      message.message.model = "<synthetic>";
+      message.message.content = [
+        { type: "text", text: "Not logged in \u00b7 Please run /login", citations: null },
+      ] as any;
+      return message;
+    };
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      for (const turn of [
+        [signedOut()],
+        [
+          createAssistantError(undefined, "signed in again"),
+          createResultMessage({
+            subtype: "success",
+            stop_reason: "end_turn",
+            is_error: false,
+            result: "signed in again",
+          }),
+        ],
+        [signedOut()],
+      ]) {
+        const next = await iter.next();
+        yield {
+          type: "user",
+          message: next.value.message,
+          parent_tool_use_id: null,
+          uuid: next.value.uuid,
+          session_id: "test-session",
+          isReplay: true,
+        };
+        yield* turn;
+      }
+    }
+    agent.sessions["test-session"] = mockSessionState({
+      query: wrapQuery(messageGenerator()),
+      input,
+    });
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "one" }] }),
+    ).rejects.toThrow();
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "two" }] }),
+    ).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    // A client can sign the user in out of band — AIR runs `claude /login` in a
+    // terminal — and then no `auth_status` message arrives. A real model answer
+    // is the proof that the session is signed in again.
+    expect(agent.sessions["test-session"].sessionFailureState.active.size).toBe(0);
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "three" }] }),
+    ).rejects.toThrow();
+
+    // The next sign-out reaches the client as its own row, not as silence.
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(2);
+    expect(failures[1].id).not.toEqual(failures[0].id);
+    expect(failures[1]).toEqual(
+      expect.objectContaining({ category: "access", severity: "error", actions: ["login"] }),
+    );
   });
 
   it("publishes no retry warning for an authentication_failed api_retry", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6255,7 +6255,6 @@ describe("stop reason propagation", () => {
   });
 
   it.each([
-    ["authentication_failed", "access"],
     ["billing_error", "limit"],
     ["account_on_hold", "limit"],
     ["rate_limit", "limit"],
@@ -6392,6 +6391,52 @@ describe("stop reason propagation", () => {
     expect(JSON.stringify(updates)).not.toContain("sessionFailure");
   });
 
+  const sessionFailuresFromUpdates = (updates: SessionNotification[]) =>
+    updates.map((u) => (u.update as any)?._meta?.jetbrains?.air?.sessionFailure).filter(Boolean);
+
+  it("rejects authentication_failed and publishes a session-scoped access failure", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    injectSession(agent, [
+      createAssistantError("authentication_failed", "Claude request failed."),
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Claude request failed.",
+      }),
+    ]);
+
+    // The auth flow hangs off the JSON-RPC rejection (the client parks the
+    // prompt and runs its own sign-in), so the turn is rejected even for
+    // capable clients; the signed-out state travels separately as one
+    // session-scoped failure with a client-neutral title.
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        severity: "error",
+        title: "Sign in to continue using Claude.",
+        details: "Claude request failed.",
+        actions: ["login"],
+      }),
+    );
+    expect(failures[0].id).toContain("session-error");
+  });
+
   it("recovers auth_required internally after a successful auth_status", async () => {
     const updates: SessionNotification[] = [];
     const agent = new ClaudeAcpAgent(
@@ -6420,22 +6465,23 @@ describe("stop reason propagation", () => {
       },
     ]);
 
-    const response = await agent.prompt({
-      sessionId: "test-session",
-      prompt: [{ type: "text", text: "test" }],
-    });
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
-    const active = sessionFailureFromResponse(response);
-    expect(active).toEqual(
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
       expect.objectContaining({
         category: "access",
         revision: 1,
-        title: "Authentication required.",
+        details: "Authentication required.",
       }),
     );
-    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
-    expect(agent.sessions["test-session"].sessionFailureState.active.has(active.id)).toBe(false);
-    expect(JSON.stringify({ response, updates })).not.toContain("private login token");
+    expect(agent.sessions["test-session"].sessionFailureState.active.has(failures[0].id)).toBe(
+      false,
+    );
+    expect(JSON.stringify(updates)).not.toContain("private login token");
   });
 
   it("keeps auth_required active when auth_status reports an error", async () => {
@@ -6467,17 +6513,118 @@ describe("stop reason propagation", () => {
       },
     ]);
 
-    const response = await agent.prompt({
-      sessionId: "test-session",
-      prompt: [{ type: "text", text: "test" }],
-    });
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
-    expect(sessionFailureFromResponse(response)).toEqual(
-      expect.objectContaining({ category: "access", severity: "error" }),
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(expect.objectContaining({ category: "access", severity: "error" }));
+    expect(agent.sessions["test-session"].sessionFailureState.active.has(failures[0].id)).toBe(
+      true,
     );
-    expect(JSON.stringify(updates)).not.toContain("sessionFailure");
-    expect(JSON.stringify({ response, updates })).not.toContain("private login token");
-    expect(JSON.stringify({ response, updates })).not.toContain("private login error");
+    expect(JSON.stringify(updates)).not.toContain("private login token");
+    expect(JSON.stringify(updates)).not.toContain("private login error");
+  });
+
+  it("does not republish auth_required when the result repeats the login text", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    // The CLI reports one signed-out turn twice: the synthetic login assistant
+    // message rejects the turn, then the result repeats the same text. One
+    // session-scoped failure covers both; its title is the client-neutral
+    // fallback while the CLI's TUI advice travels as details.
+    const syntheticLogin = createAssistantError("authentication_failed");
+    syntheticLogin.message.model = "<synthetic>";
+    syntheticLogin.message.content = [
+      { type: "text", text: "Not logged in · Please run /login", citations: null },
+    ] as any;
+    injectSession(agent, [
+      syntheticLogin,
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Not logged in · Please run /login",
+      }),
+    ]);
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        severity: "error",
+        title: "Sign in to continue using Claude.",
+        details: "Not logged in · Please run /login",
+      }),
+    );
+    expect([...agent.sessions["test-session"].sessionFailureState.active.keys()]).toEqual([
+      failures[0].id,
+    ]);
+  });
+
+  it("publishes the sign-out after an authentication_failed retry warning", async () => {
+    const updates: SessionNotification[] = [];
+    const agent = new ClaudeAcpAgent(
+      {
+        sessionUpdate: async (update: SessionNotification) => {
+          updates.push(update);
+        },
+      } as unknown as AcpClient,
+      { log: () => {}, error: () => {} },
+    );
+    (agent as any).clientCapabilities = airSessionFailureCapabilities;
+    // The retry notice is a turn-scoped `auth_required` warning. It reports a
+    // retry, not the signed-out state, so it must not suppress the
+    // session-scoped error that carries the `login` action.
+    injectSession(agent, [
+      {
+        type: "system",
+        subtype: "api_retry",
+        attempt: 1,
+        max_retries: 5,
+        retry_delay_ms: 100,
+        error_status: 401,
+        error: "authentication_failed",
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      createAssistantError("authentication_failed", "Claude request failed."),
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Claude request failed.",
+      }),
+    ]);
+
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] }),
+    ).rejects.toThrow();
+    await agent.sessions["test-session"]?.consumer;
+    const failures = sessionFailuresFromUpdates(updates);
+    expect(failures.map((f) => f.severity)).toEqual(["warning", "error"]);
+    expect(failures[1]).toEqual(
+      expect.objectContaining({
+        category: "access",
+        title: "Sign in to continue using Claude.",
+        actions: ["login"],
+      }),
+    );
+    expect(failures[1].id).toContain("session-error");
   });
 
   it("keeps the historical failure record unchanged after recovery", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -6576,7 +6576,7 @@ describe("stop reason propagation", () => {
     ]);
   });
 
-  it("publishes the sign-out after an authentication_failed retry warning", async () => {
+  it("publishes no retry warning for an authentication_failed api_retry", async () => {
     const updates: SessionNotification[] = [];
     const agent = new ClaudeAcpAgent(
       {
@@ -6587,15 +6587,15 @@ describe("stop reason propagation", () => {
       { log: () => {}, error: () => {} },
     );
     (agent as any).clientCapabilities = airSessionFailureCapabilities;
-    // The retry notice is a turn-scoped `auth_required` warning. It reports a
-    // retry, not the signed-out state, so it must not suppress the
-    // session-scoped error that carries the `login` action.
+    // The 401 retry is the CLI's credential re-check. The sign-out that
+    // follows is the signal, so the retry publishes nothing and the only
+    // failure is the session-scoped error with the `login` action.
     injectSession(agent, [
       {
         type: "system",
         subtype: "api_retry",
         attempt: 1,
-        max_retries: 5,
+        max_retries: 10,
         retry_delay_ms: 100,
         error_status: 401,
         error: "authentication_failed",
@@ -6616,15 +6616,16 @@ describe("stop reason propagation", () => {
     ).rejects.toThrow();
     await agent.sessions["test-session"]?.consumer;
     const failures = sessionFailuresFromUpdates(updates);
-    expect(failures.map((f) => f.severity)).toEqual(["warning", "error"]);
-    expect(failures[1]).toEqual(
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(
       expect.objectContaining({
         category: "access",
+        severity: "error",
         title: "Sign in to continue using Claude.",
         actions: ["login"],
       }),
     );
-    expect(failures[1].id).toContain("session-error");
+    expect(failures[0].id).toContain("session-error");
   });
 
   it("keeps the historical failure record unchanged after recovery", async () => {

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -1,8 +1,29 @@
+import { randomUUID } from "node:crypto";
 import { describe, expect, it, Mock, vi, afterEach, beforeEach } from "vitest";
+import type { AccountInfo } from "@anthropic-ai/claude-agent-sdk";
 import { AcpClient, ClaudeAcpAgent } from "../acp-agent.js";
-import { makeMockQuery } from "./helpers.js";
+import {
+  billsClaudeSubscription,
+  CLAUDE_LOGIN_REQUIRED_MESSAGE,
+  CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE,
+  CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON,
+} from "../hide-claude-auth.js";
+import { SessionFailureController } from "../session-failure-extension.js";
+import { DEFAULT_CONTEXT_USAGE, makeMockQuery } from "./helpers.js";
 
 const mockQuery = vi.hoisted(() => vi.fn());
+
+/** The real `process`. Several tests stub the global with a plain object
+ *  spread, which drops the EventEmitter methods, so hold the original. */
+const realProcess = process;
+
+/** Yield one macrotask on real timers so Node can report an unhandled
+ *  rejection. The suite runs on fake timers, so switch back afterwards. */
+async function flushMacrotask(): Promise<void> {
+  vi.useRealTimers();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  vi.useFakeTimers();
+}
 
 vi.mock("@anthropic-ai/claude-agent-sdk", async () => ({
   ...(await vi.importActual<typeof import("@anthropic-ai/claude-agent-sdk")>(
@@ -228,6 +249,910 @@ describe("authorization", () => {
     );
   });
 
+  describe("--hide-claude-auth subscription guard", () => {
+    const REASON = CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_REASON;
+    const MESSAGE = CLAUDE_SUBSCRIPTION_NOT_SUPPORTED_MESSAGE;
+    const LOGIN_REQUIRED_MESSAGE = CLAUDE_LOGIN_REQUIRED_MESSAGE;
+    const AUTH_REQUIRED_CODE = -32000;
+    const INVALID_PARAMS_CODE = -32602;
+    /** The refusal every client gets: the ACP auth error with the reason. */
+    const refusal = {
+      code: AUTH_REQUIRED_CODE,
+      message: `Authentication required: ${MESSAGE}`,
+      data: { reason: REASON },
+    };
+    /** The turn the mock query cannot run. `makeMockQuery` has no `next`, so a
+     *  turn that the guard let through dies in the consumer with this error.
+     *  Asserting it proves the guard passed instead of merely not refusing. */
+    const MOCK_QUERY_TURN_ERROR = "session.query.next is not a function";
+    const models = [
+      { value: "id", displayName: "name", description: "description", supportsAutoMode: true },
+    ];
+    /** A session-creation account that passes the fail-closed check, so a test
+     *  can drive the per-turn guard from a session that legally exists. */
+    const SIGNED_IN_WITH_KEY = { apiKeySource: "ANTHROPIC_API_KEY" };
+
+    function mockAccount(
+      account: Record<string, unknown>,
+      overrides: Record<string, unknown> = {},
+    ) {
+      mockQuery.mockImplementation(() =>
+        makeMockQuery({
+          initializationResult: async () => ({ models, account }),
+          ...overrides,
+        }),
+      );
+    }
+
+    function hideClaudeAuth() {
+      vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
+    }
+
+    const airSessionFailureCapabilities = {
+      _meta: { jetbrains: { air: { version: 1, capabilities: ["sessionFailure"] } } },
+    };
+
+    /** An agent that records every `session/update` it sends. `capable` decides
+     *  whether the client advertises the AIR session-failure capability. */
+    function createRecordingAgent(
+      capable: boolean,
+      logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void; warn?: any },
+    ): [ClaudeAcpAgent, any[]] {
+      const updates: any[] = [];
+      const agent = new ClaudeAcpAgent(
+        {
+          sessionUpdate: async (update: any) => {
+            updates.push(update);
+          },
+        } as unknown as AcpClient,
+        logger,
+      );
+      if (capable) {
+        (agent as any).clientCapabilities = airSessionFailureCapabilities;
+      }
+      return [agent, updates];
+    }
+
+    function failuresIn(updates: any[]) {
+      return updates
+        .map((update) => update.update?._meta?.jetbrains?.air?.sessionFailure)
+        .filter(Boolean);
+    }
+
+    function newSessionParams() {
+      return { cwd: process.cwd(), mcpServers: [] };
+    }
+
+    describe("billsClaudeSubscription", () => {
+      /** Every member of the SDK's `ApiKeySource` enum, plus a value no
+       *  current CLI emits: the field is an open `string`, so an unknown one
+       *  must keep the guard on. */
+      const API_KEY_SOURCES = [
+        "ANTHROPIC_API_KEY",
+        "apiKeyHelper",
+        "/login managed key",
+        "none",
+        "user",
+        "project",
+        "org",
+        "temporary",
+        "oauth",
+        "a-source-only-a-future-cli-emits",
+      ];
+      const OUTRANKS_SUBSCRIPTION = new Set([
+        "ANTHROPIC_API_KEY",
+        "apiKeyHelper",
+        "/login managed key",
+      ]);
+
+      it.each(API_KEY_SOURCES)("classifies apiKeySource %s", (apiKeySource) => {
+        const account = { subscriptionType: "pro", apiKeySource } satisfies AccountInfo;
+        expect(billsClaudeSubscription(account)).toBe(!OUTRANKS_SUBSCRIPTION.has(apiKeySource));
+      });
+
+      /** Every member of the SDK's `apiProvider` enum. Only `firstParty` uses
+       *  the Anthropic OAuth login the subscription belongs to. */
+      const API_PROVIDERS = [
+        "firstParty",
+        "bedrock",
+        "vertex",
+        "foundry",
+        "anthropicAws",
+        "anthropicGoogleCloud",
+        "mantle",
+        "gateway",
+      ] as const;
+
+      it.each(API_PROVIDERS)("classifies apiProvider %s", (apiProvider) => {
+        const account = { subscriptionType: "pro", apiProvider } satisfies AccountInfo;
+        expect(billsClaudeSubscription(account)).toBe(apiProvider === "firstParty");
+      });
+
+      it("bills the subscription when apiProvider and apiKeySource are absent", () => {
+        const account = { subscriptionType: "max" } satisfies AccountInfo;
+        expect(billsClaudeSubscription(account)).toBe(true);
+      });
+
+      it("does not bill the subscription when a bearer token pays", () => {
+        const account = {
+          subscriptionType: "pro",
+          tokenSource: "ANTHROPIC_AUTH_TOKEN",
+          apiKeySource: "none",
+        } satisfies AccountInfo;
+        expect(billsClaudeSubscription(account)).toBe(false);
+      });
+
+      it("is false without a subscription", () => {
+        expect(billsClaudeSubscription({} satisfies AccountInfo)).toBe(false);
+        expect(billsClaudeSubscription(undefined)).toBe(false);
+        const withKey = { apiKeySource: "ANTHROPIC_API_KEY" } satisfies AccountInfo;
+        expect(billsClaudeSubscription(withKey)).toBe(false);
+      });
+    });
+
+    describe("fails closed at session creation", () => {
+      /** What the flag does with an account at session creation. */
+      type Verdict = "subscription" | "signedOut" | "allowed";
+
+      const CASES: Array<{ name: string; account: AccountInfo; verdict: Verdict }> = [
+        { name: "a logged-out CLI", account: {}, verdict: "signedOut" },
+        {
+          name: "an account with no key in use",
+          account: { apiKeySource: "none" },
+          verdict: "signedOut",
+        },
+        {
+          name: "a claude.ai subscription",
+          account: { subscriptionType: "pro" },
+          verdict: "subscription",
+        },
+        {
+          name: "ANTHROPIC_API_KEY",
+          account: { apiKeySource: "ANTHROPIC_API_KEY" },
+          verdict: "allowed",
+        },
+        { name: "apiKeyHelper", account: { apiKeySource: "apiKeyHelper" }, verdict: "allowed" },
+        {
+          name: "a Console login",
+          account: { apiKeySource: "/login managed key" },
+          verdict: "allowed",
+        },
+        {
+          name: "a bearer token",
+          account: { tokenSource: "ANTHROPIC_AUTH_TOKEN" },
+          verdict: "allowed",
+        },
+        { name: "bedrock", account: { apiProvider: "bedrock" }, verdict: "allowed" },
+        { name: "vertex", account: { apiProvider: "vertex" }, verdict: "allowed" },
+      ];
+
+      async function assertVerdict(
+        create: () => Promise<unknown>,
+        verdict: Verdict,
+      ): Promise<void> {
+        if (verdict === "allowed") {
+          await expect(create()).resolves.toMatchObject({ sessionId: expect.any(String) });
+          return;
+        }
+        const error: any = await create().then(
+          () => undefined,
+          (thrown) => thrown,
+        );
+        expect(error).toBeDefined();
+        expect(error.code).toBe(AUTH_REQUIRED_CODE);
+        if (verdict === "subscription") {
+          expect(error.message).toBe(`Authentication required: ${MESSAGE}`);
+          expect(error.data).toEqual({ reason: REASON });
+        } else {
+          expect(error.message).toBe(`Authentication required: ${LOGIN_REQUIRED_MESSAGE}`);
+          // The plain sign-out carries no reason: it is the state every ACP
+          // client already answers with its own auth flow.
+          expect(error.data).toBeUndefined();
+        }
+      }
+
+      it.each(CASES)("refuses or allows $name", async ({ account, verdict }) => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount(account as Record<string, unknown>);
+
+        await assertVerdict(() => agent.newSession(newSessionParams()), verdict);
+      });
+
+      it.each(CASES)("refuses or allows $name on loadSession", async ({ account, verdict }) => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount(account as Record<string, unknown>);
+
+        await assertVerdict(
+          () => agent.loadSession({ sessionId: randomUUID(), ...newSessionParams() }),
+          verdict,
+        );
+      });
+
+      it.each(CASES)("refuses or allows $name on resumeSession", async ({ account, verdict }) => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount(account as Record<string, unknown>);
+
+        await assertVerdict(
+          () => agent.resumeSession({ sessionId: randomUUID(), ...newSessionParams() }),
+          verdict,
+        );
+      });
+
+      it("allows a logged-out account while a provider override is active", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({});
+        await agent.unstable_setProvider({
+          providerId: "main",
+          apiType: "anthropic",
+          baseUrl: "https://gateway.example/v1",
+          headers: {},
+        });
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+
+      it("allows a logged-out account without the flag", async () => {
+        const [agent] = await createAgentMock();
+        mockAccount({});
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+    });
+
+    describe("on session creation", () => {
+      it("rejects like a logged-out agent, with the reason in data", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(agent.newSession(newSessionParams())).rejects.toMatchObject(refusal);
+      });
+
+      it("rejects loadSession the same way", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(
+          agent.loadSession({ sessionId: randomUUID(), ...newSessionParams() }),
+        ).rejects.toMatchObject(refusal);
+      });
+
+      it("rejects resumeSession the same way", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(
+          agent.resumeSession({ sessionId: randomUUID(), ...newSessionParams() }),
+        ).rejects.toMatchObject(refusal);
+      });
+
+      it("allows a session without the flag", async () => {
+        const [agent] = await createAgentMock();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+
+      it("allows a session when an API key pays next to a stored subscription", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro", apiKeySource: "ANTHROPIC_API_KEY" });
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+
+      it("allows a session after gateway authenticate", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await agent.authenticate({
+          methodId: "gateway",
+          _meta: { gateway: { baseUrl: "https://gateway.example", headers: {} } },
+        });
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+
+      it("allows a session after providers/set", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await agent.unstable_setProvider({
+          providerId: "main",
+          apiType: "anthropic",
+          baseUrl: "https://gateway.example/v1",
+          headers: {},
+        });
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+      });
+
+      it("warns once when the CLI reports no account at all", async () => {
+        const warnings: string[] = [];
+        const [agent] = createRecordingAgent(false, {
+          log: () => {},
+          error: () => {},
+          warn: (message: unknown) => warnings.push(String(message)),
+        });
+        hideClaudeAuth();
+        mockQuery.mockImplementation(() =>
+          makeMockQuery({ initializationResult: async () => ({ models }) }),
+        );
+
+        await expect(agent.newSession(newSessionParams())).resolves.toMatchObject({
+          sessionId: expect.any(String),
+        });
+        expect(warnings.filter((message) => message.includes("guard is degraded"))).toHaveLength(1);
+      });
+    });
+
+    describe("gateway authenticate validation", () => {
+      it("accepts a call with no gateway payload and installs no override", async () => {
+        const [agent] = await createAgentMock();
+
+        // Historically a no-op: it stored a request that resolved to no
+        // provider config. Clients that probe the method this way must keep
+        // working, so this stays a success, not an `invalidParams`.
+        await expect(agent.authenticate({ methodId: "gateway" } as any)).resolves.toBeUndefined();
+        expect(agent.resolveProviderConfig()).toBeNull();
+
+        await expect(
+          agent.authenticate({ methodId: "gateway", _meta: {} } as any),
+        ).resolves.toBeUndefined();
+        expect(agent.resolveProviderConfig()).toBeNull();
+      });
+
+      it("keeps the guard on when no gateway payload was installed", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(
+          agent.authenticate({ methodId: "gateway", _meta: {} } as any),
+        ).resolves.toBeUndefined();
+        // No override is active, so the subscription guard still applies.
+        await expect(agent.newSession(newSessionParams())).rejects.toMatchObject(refusal);
+      });
+
+      it("rejects a present but unusable gateway payload", async () => {
+        const [agent] = await createAgentMock();
+
+        await expect(
+          agent.authenticate({ methodId: "gateway", _meta: { gateway: {} } } as any),
+        ).rejects.toMatchObject({ code: INVALID_PARAMS_CODE });
+        expect(agent.resolveProviderConfig()).toBeNull();
+      });
+
+      it("rejects an empty baseUrl instead of disabling the guard", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount({ subscriptionType: "pro" });
+
+        await expect(
+          agent.authenticate({
+            methodId: "gateway",
+            _meta: { gateway: { baseUrl: "", headers: {} } },
+          } as any),
+        ).rejects.toMatchObject({ code: INVALID_PARAMS_CODE });
+        expect(agent.resolveProviderConfig()).toBeNull();
+        // The rejected payload stored nothing, so the guard still applies.
+        await expect(agent.newSession(newSessionParams())).rejects.toMatchObject(refusal);
+      });
+    });
+
+    describe("on every prompt", () => {
+      const promptParams = (sessionId: string) => ({
+        sessionId,
+        prompt: [{ type: "text" as const, text: "hello" }],
+      });
+
+      it("rejects a turn when the live account became a subscription", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        // Spawn-time account passes; the store changes underneath the session.
+        const accountInfo = vi.fn(async () => ({ subscriptionType: "pro", apiKeySource: "none" }));
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        expect(accountInfo).toHaveBeenCalledTimes(1);
+        // Refused before anything reached the SDK: no turn was queued.
+        expect(agent.sessions[sessionId].turnQueue ?? []).toHaveLength(0);
+      });
+
+      it("publishes one session-scoped access failure for capable clients", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, {
+          accountInfo: async () => ({ subscriptionType: "pro", apiKeySource: "none" }),
+        });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+
+        const failures = failuresIn(updates);
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toEqual(
+          expect.objectContaining({
+            category: "access",
+            severity: "error",
+            title: "Sign in to continue using Claude.",
+            details: MESSAGE,
+            reason: REASON,
+            actions: ["login"],
+          }),
+        );
+        expect(failures[0].turnId).toBeUndefined();
+        expect([...agent.sessions[sessionId].sessionFailureState.active.values()]).toHaveLength(1);
+      });
+
+      it("gives a client without the capability the reason on the error only", async () => {
+        const [agent, updates] = createRecordingAgent(false);
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo: async () => ({ subscriptionType: "pro" }) });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        expect(failuresIn(updates)).toEqual([]);
+      });
+
+      it("publishes one failure row for two concurrent prompts", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo: async () => ({ subscriptionType: "pro" }) });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        const outcomes = await Promise.allSettled([
+          agent.prompt(promptParams(sessionId)),
+          agent.prompt(promptParams(sessionId)),
+        ]);
+
+        expect(outcomes.map((outcome) => outcome.status)).toEqual(["rejected", "rejected"]);
+        for (const outcome of outcomes) {
+          expect((outcome as PromiseRejectedResult).reason).toMatchObject(refusal);
+        }
+        expect(failuresIn(updates)).toHaveLength(1);
+      });
+
+      it("survives a cancel that races the refused prompt", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (error: unknown) => unhandled.push(error);
+        realProcess.on("unhandledRejection", onUnhandled);
+        try {
+          const [agent] = createRecordingAgent(true);
+          hideClaudeAuth();
+          mockAccount(SIGNED_IN_WITH_KEY, {
+            accountInfo: async () => ({ subscriptionType: "pro" }),
+          });
+          const { sessionId } = await agent.newSession(newSessionParams());
+
+          const refused = agent.prompt(promptParams(sessionId));
+          const cancelled = agent.cancel({ sessionId });
+
+          await expect(refused).rejects.toMatchObject(refusal);
+          await expect(cancelled).resolves.toBeUndefined();
+          await flushMacrotask();
+          expect(unhandled).toEqual([]);
+        } finally {
+          realProcess.off("unhandledRejection", onUnhandled);
+        }
+      });
+
+      it("does not probe the account when a provider override is active", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        const accountInfo = vi.fn(async () => ({ subscriptionType: "pro" }));
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo });
+        await agent.unstable_setProvider({
+          providerId: "main",
+          apiType: "anthropic",
+          baseUrl: "https://gateway.example/v1",
+          headers: {},
+        });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toThrow(MOCK_QUERY_TURN_ERROR);
+        expect(accountInfo).not.toHaveBeenCalled();
+      });
+
+      it("does not probe the account without the flag", async () => {
+        const [agent] = await createAgentMock();
+        const accountInfo = vi.fn(async () => ({ subscriptionType: "pro" }));
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toThrow(MOCK_QUERY_TURN_ERROR);
+        expect(accountInfo).not.toHaveBeenCalled();
+      });
+
+      it("lets the turn through when the live account is not a subscription", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        const accountInfo = vi.fn(async () => ({ apiKeySource: "ANTHROPIC_API_KEY" }));
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toThrow(MOCK_QUERY_TURN_ERROR);
+        expect(accountInfo).toHaveBeenCalledTimes(1);
+      });
+
+      it("fails open when the CLI cannot answer accountInfo", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, {
+          accountInfo: async () => {
+            throw new Error("unsupported control request");
+          },
+        });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toThrow(MOCK_QUERY_TURN_ERROR);
+      });
+
+      it("fails open and warns once when the SDK has no accountInfo", async () => {
+        const warnings: string[] = [];
+        const [agent] = createRecordingAgent(false, {
+          log: () => {},
+          error: () => {},
+          warn: (message: unknown) => warnings.push(String(message)),
+        });
+        hideClaudeAuth();
+        mockAccount({ apiKeySource: "ANTHROPIC_API_KEY" });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        const outcomes = await Promise.allSettled([
+          agent.prompt(promptParams(sessionId)),
+          agent.prompt(promptParams(sessionId)),
+        ]);
+
+        for (const outcome of outcomes) {
+          expect(outcome.status).toBe("rejected");
+          expect((outcome as PromiseRejectedResult).reason).toMatchObject({
+            message: expect.stringContaining(MOCK_QUERY_TURN_ERROR),
+          });
+        }
+        expect(warnings.filter((message) => message.includes("guard is degraded"))).toHaveLength(1);
+      });
+    });
+
+    describe("respawns after a mid-session sign-out", () => {
+      const promptParams = (sessionId: string) => ({
+        sessionId,
+        prompt: [{ type: "text" as const, text: "hello" }],
+      });
+
+      /** The CLI's sign-out report: an error-shaped result whose text is the
+       *  TUI advice the live loop maps to `auth_required`. */
+      const signOutResult = () => ({
+        type: "result" as const,
+        subtype: "success" as const,
+        stop_reason: null,
+        is_error: true,
+        result: "Not logged in · Please run /login",
+        errors: [],
+        duration_ms: 0,
+        duration_api_ms: 0,
+        num_turns: 1,
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [],
+        uuid: randomUUID(),
+        session_id: "test-session",
+      });
+
+      const successResult = () => ({
+        ...signOutResult(),
+        is_error: false,
+        stop_reason: "end_turn",
+        result: "done",
+      });
+
+      /** One scripted SDK query. It echoes each pushed user message, then emits
+       *  the messages the script holds for that turn, so a real `newSession` +
+       *  `prompt` round trip runs against it. */
+      function scriptedQuery(args: any, account: Record<string, unknown>, script: any[][]) {
+        const input = args.prompt;
+        const turns = [...script];
+        async function* messages() {
+          const iterator = input[Symbol.asyncIterator]();
+          for (;;) {
+            const { value, done } = await iterator.next();
+            if (done || !value) return;
+            yield {
+              type: "user",
+              message: value.message,
+              parent_tool_use_id: null,
+              uuid: value.uuid,
+              session_id: "test-session",
+              isReplay: true,
+            };
+            for (const message of turns.shift() ?? []) yield message;
+          }
+        }
+        const query: any = messages();
+        query.initializationResult = async () => ({ models, account });
+        query.accountInfo = async () => account;
+        query.setModel = async () => {};
+        query.setPermissionMode = async () => {};
+        query.supportedCommands = async () => [];
+        query.mcpServerStatus = async () => [];
+        query.getContextUsage = async () => DEFAULT_CONTEXT_USAGE;
+        query.close = vi.fn();
+        query.interrupt = vi.fn(async () => {});
+        query.stopTask = vi.fn(async () => {});
+        return query;
+      }
+
+      /** Script the successive `query()` calls: the first builds the session
+       *  that signs out, each later one is a respawn. */
+      function mockQueries(
+        ...spawns: Array<{ account: Record<string, unknown>; script: any[][] }>
+      ) {
+        let spawn = 0;
+        mockQuery.mockImplementation((args: any) => {
+          const current = spawns[Math.min(spawn, spawns.length - 1)];
+          spawn += 1;
+          return scriptedQuery(args, current.account, current.script);
+        });
+      }
+
+      /** Create a session, run one turn, and let the CLI sign out during it. */
+      async function signOutDuringTurn(agent: ClaudeAcpAgent) {
+        const { sessionId } = await agent.newSession(newSessionParams());
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject({
+          code: AUTH_REQUIRED_CODE,
+        });
+        expect(agent.sessions[sessionId].needsSignOutRespawn).toBe(true);
+        expect(agent.sessions[sessionId].queryClosed).toBe(true);
+        return sessionId;
+      }
+
+      it("refuses the next turn when the CLI now holds a subscription", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQueries(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { account: { subscriptionType: "pro" }, script: [] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        // The respawn ran, resuming the same Claude session so history is kept.
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+        expect(mockQuery.mock.calls[1][0].options).toMatchObject({ resume: sessionId });
+        // The refusal keeps the husk, so the client can sign in and retry here.
+        expect(agent.sessions[sessionId]).toBeDefined();
+        expect(failuresIn(updates).filter((failure) => failure.kind !== "advisory")).toHaveLength(
+          1,
+        );
+      });
+
+      it("proceeds when the CLI now holds a key, on a clean failure state", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQueries(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { account: SIGNED_IN_WITH_KEY, script: [[successResult()]] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.prompt(promptParams(sessionId))).resolves.toMatchObject({
+          stopReason: "end_turn",
+        });
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+        const respawned = agent.sessions[sessionId];
+        expect(respawned.needsSignOutRespawn).toBeUndefined();
+        expect(respawned.queryClosed).toBeUndefined();
+        // The recreated session starts with no active failure: the sign-out
+        // row belonged to the query that is gone.
+        expect([...respawned.sessionFailureState.active.values()]).toHaveLength(0);
+      });
+
+      it("refuses with the plain error and no second row when still signed out", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQueries(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { account: {}, script: [] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+        const rowsAfterSignOut = failuresIn(updates).length;
+
+        const error: any = await agent.prompt(promptParams(sessionId)).then(
+          () => undefined,
+          (thrown) => thrown,
+        );
+        expect(error.code).toBe(AUTH_REQUIRED_CODE);
+        expect(error.message).toBe(`Authentication required: ${LOGIN_REQUIRED_MESSAGE}`);
+        expect(error.data).toBeUndefined();
+        expect(failuresIn(updates)).toHaveLength(rowsAfterSignOut);
+      });
+
+      it("shares one respawn between two prompts", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQueries(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { account: { subscriptionType: "pro" }, script: [] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        const outcomes = await Promise.allSettled([
+          agent.prompt(promptParams(sessionId)),
+          agent.prompt(promptParams(sessionId)),
+        ]);
+
+        expect(outcomes.map((outcome) => outcome.status)).toEqual(["rejected", "rejected"]);
+        for (const outcome of outcomes) {
+          expect((outcome as PromiseRejectedResult).reason).toMatchObject(refusal);
+        }
+        // One respawn, not two.
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+      });
+
+      it("answers a cancel during the dead state", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQueries(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { account: SIGNED_IN_WITH_KEY, script: [[successResult()]] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.cancel({ sessionId })).resolves.toBeUndefined();
+        expect(agent.sessions[sessionId].needsSignOutRespawn).toBe(true);
+      });
+
+      it("leaves the session alone without the flag", async () => {
+        const [agent] = createRecordingAgent(true);
+        mockQueries({ account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject({
+          code: AUTH_REQUIRED_CODE,
+        });
+        expect(agent.sessions[sessionId].needsSignOutRespawn).toBeUndefined();
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe("reason-aware failure dedupe", () => {
+      /** A controller on the session's own state, publishing through the same
+       *  client, so its rows land in the same `updates` array the agent uses. */
+      function controllerFor(agent: ClaudeAcpAgent, sessionId: string) {
+        return new SessionFailureController({
+          sessionId,
+          state: agent.sessions[sessionId].sessionFailureState,
+          capabilities: (agent as any).clientCapabilities,
+          isCurrent: () => true,
+          sendUpdate: (notification) => (agent as any).client.sessionUpdate(notification),
+          logger: { error: () => {} },
+        });
+      }
+
+      const promptParams = (sessionId: string) => ({
+        sessionId,
+        prompt: [{ type: "text" as const, text: "hello" }],
+      });
+
+      it("publishes the subscription row while a plain sign-out is active", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo: async () => ({ subscriptionType: "pro" }) });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await controllerFor(agent, sessionId).publish("auth_required", { sessionScoped: true });
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+
+        const failures = failuresIn(updates);
+        expect(failures).toHaveLength(2);
+        expect(failures[0].reason).toBeUndefined();
+        expect(failures[1].reason).toBe(REASON);
+      });
+
+      it("publishes a plain sign-out while the subscription row is active", async () => {
+        const [agent, updates] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo: async () => ({ subscriptionType: "pro" }) });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+
+        const controller = controllerFor(agent, sessionId);
+        // This is the check `failActiveWithSessionFailure` makes before it
+        // publishes a sign-out. The subscription row must not answer it.
+        expect(controller.hasActiveSessionError("auth_required")).toBe(false);
+        expect(controller.hasActiveSessionError("auth_required", REASON)).toBe(true);
+        await controller.publish("auth_required", { sessionScoped: true });
+
+        const failures = failuresIn(updates);
+        expect(failures).toHaveLength(2);
+        expect(failures[0].reason).toBe(REASON);
+        expect(failures[1].reason).toBeUndefined();
+      });
+    });
+
+    describe("on steer", () => {
+      it("rejects a steer that would start a new turn", async () => {
+        const [agent] = await createAgentMock();
+        hideClaudeAuth();
+        mockAccount(SIGNED_IN_WITH_KEY, { accountInfo: async () => ({ subscriptionType: "pro" }) });
+        const { sessionId } = await agent.newSession(newSessionParams());
+
+        await expect(
+          agent.steer({ sessionId, prompt: [{ type: "text", text: "hello" }] }),
+        ).rejects.toMatchObject(refusal);
+        expect(agent.sessions[sessionId].turnQueue ?? []).toHaveLength(0);
+      });
+    });
+
+    describe("on providers/disable", () => {
+      it("keeps going when a session cannot be recreated", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (error: unknown) => unhandled.push(error);
+        realProcess.on("unhandledRejection", onUnhandled);
+        try {
+          const [agent, updates] = createRecordingAgent(true);
+          hideClaudeAuth();
+          await agent.unstable_setProvider({
+            providerId: "main",
+            apiType: "anthropic",
+            baseUrl: "https://gateway.example/v1",
+            headers: {},
+          });
+          // The override kept these sessions legal; without it they are not.
+          mockAccount({ subscriptionType: "pro" });
+          const first = await agent.newSession(newSessionParams());
+          const second = await agent.newSession(newSessionParams());
+
+          await expect(agent.unstable_disableProvider({ providerId: "main" })).resolves.toEqual({});
+
+          // The loop ran to the end: both sessions are gone and both reported.
+          expect(agent.sessions[first.sessionId]).toBeUndefined();
+          expect(agent.sessions[second.sessionId]).toBeUndefined();
+          const failures = failuresIn(updates).filter((failure) => failure.reason === REASON);
+          expect(failures).toHaveLength(2);
+          expect(failures[0]).toMatchObject({ category: "access", details: MESSAGE });
+
+          // `providerUpdate` is not poisoned: the next call reaches the guard
+          // and reports the guard's own reason.
+          await expect(agent.newSession(newSessionParams())).rejects.toMatchObject(refusal);
+          await flushMacrotask();
+          expect(unhandled).toEqual([]);
+        } finally {
+          realProcess.off("unhandledRejection", onUnhandled);
+        }
+      });
+    });
+  });
+
   it("SSH session falls back to single legacy login method", async () => {
     const [agent] = await createAgentMock();
     vi.stubGlobal("process", { ...process, env: { ...process.env, SSH_TTY: "/dev/pts/0" } });
@@ -300,5 +1225,53 @@ describe("authorization", () => {
     expect(initializeResponse.authMethods).toContainEqual(
       expect.objectContaining({ id: "console-login" }),
     );
+  });
+});
+
+describe("session failure reason field", () => {
+  it("carries reason only when the publisher passes one", async () => {
+    const { SessionFailureController, createSessionFailureState } =
+      await import("../session-failure-extension.js");
+    const capabilities = {
+      _meta: { jetbrains: { air: { version: 1, capabilities: ["sessionFailure"] } } },
+    } as any;
+
+    const withReason: any[] = [];
+    const controllerWithReason = new SessionFailureController({
+      sessionId: "s1",
+      state: createSessionFailureState(),
+      capabilities,
+      isCurrent: () => true,
+      sendUpdate: async (notification) => {
+        withReason.push(notification);
+      },
+      logger: { error: () => {} },
+    });
+    await controllerWithReason.publish("auth_required", {
+      sessionScoped: true,
+      details: "This integration does not support using claude.ai subscriptions.",
+      reason: "claude_subscription_not_supported",
+    });
+    const subscriptionFailure = withReason[0]?.update?._meta?.jetbrains?.air?.sessionFailure;
+    expect(subscriptionFailure).toMatchObject({ reason: "claude_subscription_not_supported" });
+
+    const withoutReason: any[] = [];
+    const controllerWithoutReason = new SessionFailureController({
+      sessionId: "s2",
+      state: createSessionFailureState(),
+      capabilities,
+      isCurrent: () => true,
+      sendUpdate: async (notification) => {
+        withoutReason.push(notification);
+      },
+      logger: { error: () => {} },
+    });
+    await controllerWithoutReason.publish("auth_required", {
+      sessionScoped: true,
+      details: "Authentication required.",
+    });
+    const signedOutFailure = withoutReason[0]?.update?._meta?.jetbrains?.air?.sessionFailure;
+    expect(signedOutFailure).toBeDefined();
+    expect(signedOutFailure.reason).toBeUndefined();
   });
 });

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -1041,6 +1041,90 @@ describe("authorization", () => {
         expect(agent.sessions[sessionId].needsSignOutRespawn).toBeUndefined();
         expect(mockQuery).toHaveBeenCalledTimes(1);
       });
+
+      /** The CLI writes a conversation only after a turn produced something.
+       *  A session that signed out on its very first turn has none, so its
+       *  `resume` fails. `initError` is how that reaches `createSession`. */
+      function mockQuerySpawns(
+        ...spawns: Array<{
+          account?: Record<string, unknown>;
+          script?: any[][];
+          initError?: Error;
+        }>
+      ) {
+        let spawn = 0;
+        mockQuery.mockImplementation((args: any) => {
+          const current = spawns[Math.min(spawn, spawns.length - 1)];
+          spawn += 1;
+          const query = scriptedQuery(
+            args,
+            current.account ?? SIGNED_IN_WITH_KEY,
+            current.script ?? [],
+          );
+          if (current.initError) {
+            const error = current.initError;
+            query.initializationResult = async () => {
+              throw error;
+            };
+          }
+          return query;
+        });
+      }
+
+      const NO_CONVERSATION = () => new Error("No conversation found with session ID abc-123-def");
+
+      it("starts a fresh query when the conversation was never persisted", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQuerySpawns(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { initError: NO_CONVERSATION() },
+          { account: SIGNED_IN_WITH_KEY, script: [[successResult()]] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.prompt(promptParams(sessionId))).resolves.toMatchObject({
+          stopReason: "end_turn",
+        });
+
+        // Resume, then the fallback: a NEW conversation under the same id.
+        expect(mockQuery).toHaveBeenCalledTimes(3);
+        const fallback = mockQuery.mock.calls[2][0].options;
+        expect(fallback.sessionId).toBe(sessionId);
+        expect(fallback.resume).toBeUndefined();
+        expect(agent.sessions[sessionId]).toBeDefined();
+      });
+
+      it("refuses the fresh query when the guard rejects the new account", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQuerySpawns(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { initError: NO_CONVERSATION() },
+          { account: { subscriptionType: "pro" }, script: [] },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        // The husk stays addressable: the next prompt meets the guard again,
+        // not "Session not found".
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toMatchObject(refusal);
+        expect(agent.sessions[sessionId]).toBeDefined();
+      });
+
+      it("does not retry a resume that failed for another reason", async () => {
+        const [agent] = createRecordingAgent(true);
+        hideClaudeAuth();
+        mockQuerySpawns(
+          { account: SIGNED_IN_WITH_KEY, script: [[signOutResult()]] },
+          { initError: new Error("boom") },
+        );
+        const sessionId = await signOutDuringTurn(agent);
+
+        await expect(agent.prompt(promptParams(sessionId))).rejects.toThrow("boom");
+        // One recreate attempt, no fallback.
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+      });
     });
 
     describe("reason-aware failure dedupe", () => {


### PR DESCRIPTION
Stacked on #1071. The first three commits are that PR; review the last commit here.

## What

`--hide-claude-auth` hid the claude.ai login method from `initialize`, but nothing stopped a session from billing a subscription that was already stored. This moves the decision into `src/hide-claude-auth.ts` with two layers:

1. Session creation refuses an account that holds no credential this integration accepts, so a logged-out session never exists.
2. A sign-out during the session ends the query. The next turn recreates it, so the next `initialize` reports the real account.

A per-turn guard repeats the check on the account the SDK cached at `initialize`. It reads no process and costs microseconds. It covers a session created under a provider override that `providers/disable` later removed.

"Bills a subscription" is an allowlist of `apiKeySource` values that outrank a stored subscription, so an unknown SDK value keeps the guard on. The guard fails open when the account cannot be read at all, and warns once per session.

## Client-visible additions (all additive)

- The `authRequired` JSON-RPC error carries `data.reason: "claude_subscription_not_supported"` when the guard blocks a turn. Same error code and same message string as before. A plain sign-out still carries no `data`.
- `PublishedSessionFailure` gains an optional `reason`, emitted in the failure `_meta` only when set. `hasActiveSessionError` matches on it, so the subscription refusal and a plain sign-out cannot suppress each other.

## Behavior changes not behind the flag

- `providers/set` and `providers/disable` no longer reject the whole call when one session cannot be recreated. The session gets a per-session failure row, the switch goes on to the next session. The affected session is the one signal for that case; AIR never reaches it, because it sends `providers/set` only while a pooled client is created, before any session exists.
- `authenticate` validates a gateway payload that is present. A call with no `_meta.gateway` keeps its historical meaning: no override, success.
- A failed session creation closes the query it spawned instead of leaking the CLI process.

## Compatibility

Checked against Zed and the JetBrains clients (`plugins/llm`, AIR main and stable). No consumer sends a gateway `authenticate` without a payload, none passes `--hide-claude-auth` by default, every one already handles the `auth_required` JSON-RPC rejection, and every `_meta` / error `data` parser ignores unknown fields.

## Test plan

- `npm run build`, `npm run check`: clean.
- `npm run test:run`: 1153 passed, 27 skipped.
- New tests in `src/tests/authorization.test.ts` cover the guard end to end: creation refusal, per-turn refusal, sign-out respawn, provider override on/off, gateway payload validation, degraded guard.

## Follow-up commit in this PR

- `fix(auth): start a fresh query when a signed-out session cannot be resumed` — when the CLI never persisted the session, `resume` answers `resourceNotFound`; the respawn now starts a fresh query under the same ACP session id instead of failing every later prompt.

Tests after it: 1156 passed, 27 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
