### PR TITLE
fix: restore session forks and speed up loading

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -80,6 +80,7 @@ import {
   SDKMessage,
   SDKMessageOrigin,
   SDKPartialAssistantMessage,
+  SessionMessage,
   SDKUserMessage,
   Settings,
   SlashCommand,
@@ -155,7 +156,7 @@ import {
   refusalFallbackToCreateRequest,
 } from "./elicitation.js";
 import { forkSession } from "./fork-session.js";
-import { readResumedModelHint } from "./resumed-session.js";
+import { readResumedSession, type ResumedSessionSnapshot } from "./resumed-session.js";
 import { SessionTiming } from "./session-timing.js";
 import { ALLOW_BYPASS, resolvePermissionMode } from "./permissions/modes.js";
 import { normalizeDurablePermissionChangeSet } from "./permissions/normalization.js";
@@ -2150,10 +2151,11 @@ export class ClaudeAcpAgent {
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
     const timing = new SessionTiming(this.logger, "load", params.sessionId);
     if (this.providerUpdate) await this.providerUpdate;
-    const result = await this.getOrCreateSession(params);
+    const resumedSession = await readResumedSession(params.sessionId, this.logger);
+    const result = await this.getOrCreateSession(params, resumedSession);
     timing.phase("session-ready");
 
-    await this.replaySessionHistory(params.sessionId);
+    await this.replaySessionHistory(params.sessionId, resumedSession.messages);
     timing.phase("replay");
 
     // Send available commands after replay so it doesn't interleave with history
@@ -6489,10 +6491,13 @@ export class ClaudeAcpAgent {
     return { configOptions: session.configOptions };
   }
 
-  private async replaySessionHistory(sessionId: string): Promise<void> {
+  private async replaySessionHistory(
+    sessionId: string,
+    resumedMessages?: SessionMessage[],
+  ): Promise<void> {
     const replayStartedAt = performance.now();
     const toolUseCache: ToolUseCache = {};
-    const messages = await getSessionMessages(sessionId);
+    const messages = resumedMessages ?? (await getSessionMessages(sessionId));
     const historyLoadedAt = performance.now();
     this.logger.log(
       `[session/replay] sessionId=${sessionId} phase=read durationMs=${Math.round(historyLoadedAt - replayStartedAt)} messages=${messages.length}`,
@@ -7594,13 +7599,16 @@ export class ClaudeAcpAgent {
     });
   }
 
-  private async getOrCreateSession(params: {
-    sessionId: string;
-    cwd: string;
-    mcpServers?: NewSessionRequest["mcpServers"];
-    additionalDirectories?: NewSessionRequest["additionalDirectories"];
-    _meta?: NewSessionRequest["_meta"];
-  }): Promise<NewSessionResponse> {
+  private async getOrCreateSession(
+    params: {
+      sessionId: string;
+      cwd: string;
+      mcpServers?: NewSessionRequest["mcpServers"];
+      additionalDirectories?: NewSessionRequest["additionalDirectories"];
+      _meta?: NewSessionRequest["_meta"];
+    },
+    resumedSession?: ResumedSessionSnapshot,
+  ): Promise<NewSessionResponse> {
     const existingSession = this.sessions[params.sessionId];
     if (existingSession) {
       const fingerprint = computeSessionFingerprint(params);
@@ -7618,7 +7626,9 @@ export class ClaudeAcpAgent {
       await this.teardownSession(params.sessionId);
     }
 
-    const resumedModelHint = await readResumedModelHint(params.sessionId, params.cwd, this.logger);
+    const resumedModelHint = resumedSession
+      ? resumedSession.model
+      : (await readResumedSession(params.sessionId, this.logger)).model;
 
     const response = await this.createSession(
       {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -7697,6 +7697,7 @@ export class ClaudeAcpAgent {
       resumedModelHint?: string;
     } = {},
   ): Promise<NewSessionResponse> {
+    const createStartedAt = performance.now();
     // Validate `cwd` up front. The ACP spec requires an absolute path, and the
     // directory must actually exist on the machine running the agent. Without
     // this check a session is created against a missing directory and the
@@ -7721,7 +7722,7 @@ export class ClaudeAcpAgent {
     } else {
       sessionId = randomUUID();
     }
-    const timing = new SessionTiming(this.logger, "create", sessionId);
+    const timing = new SessionTiming(this.logger, "create", sessionId, createStartedAt);
     timing.phase("validate-cwd");
 
     const input = new Pushable<SDKUserMessage>();

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -7725,6 +7725,21 @@ export class ClaudeAcpAgent {
     const timing = new SessionTiming(this.logger, "create", sessionId, createStartedAt);
     timing.phase("validate-cwd");
 
+    // Most session/load calls already carry a transcript snapshot so history
+    // replay and model restoration share one local read. A few resume paths
+    // intentionally call createSession directly (legacy session/new metadata,
+    // sign-out respawn, provider rerouting), so fill the same fast local hint
+    // here when the caller did not provide it. Never fall back to the slow
+    // getContextUsage control request.
+    let resumedModelHint = creationOpts.resumedModelHint;
+    if (
+      creationOpts.resume !== undefined &&
+      !Object.prototype.hasOwnProperty.call(creationOpts, "resumedModelHint")
+    ) {
+      resumedModelHint = (await readResumedSession(creationOpts.resume, this.logger)).model;
+      timing.phase("resume-transcript");
+    }
+
     const input = new Pushable<SDKUserMessage>();
 
     const settingsManager = new SettingsManager(params.cwd, {
@@ -8145,7 +8160,7 @@ export class ClaudeAcpAgent {
         this.logger,
         creationOpts.resume !== undefined,
         sessionId,
-        creationOpts.resumedModelHint,
+        resumedModelHint,
       );
       timing.phase("models");
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -155,6 +155,8 @@ import {
   refusalFallbackToCreateRequest,
 } from "./elicitation.js";
 import { forkSession } from "./fork-session.js";
+import { readResumedModelHint } from "./resumed-session.js";
+import { SessionTiming } from "./session-timing.js";
 import { ALLOW_BYPASS, resolvePermissionMode } from "./permissions/modes.js";
 import { normalizeDurablePermissionChangeSet } from "./permissions/normalization.js";
 import { buildClaudePermissionOptions } from "./permissions/options.js";
@@ -842,17 +844,16 @@ export type Session = {
    *  prompts so mid-stream usage_update notifications report a correct `size`
    *  before the turn's first result message arrives. Seeded synchronously at
    *  session creation and on model switches from the per-model cache or the
-   *  text heuristic (DEFAULT_CONTEXT_WINDOW when both miss; on session/load the
-   *  resumed session's own `getContextUsage` report wins, see
-   *  `readResumedLiveModel`), then confirmed — and the cache populated — by each
-   *  result's modelUsage. No extra `getContextUsage` IPC is on these paths: on a
-   *  fresh session it stalls until the first turn runs (see the seeding call
+   *  text heuristic (DEFAULT_CONTEXT_WINDOW when both miss), then confirmed —
+   *  and the cache populated — by each result's modelUsage. No extra
+   *  `getContextUsage` IPC is on these paths: before the first turn it can add
+   *  tens of seconds to both fresh and resumed sessions (see the seeding call
    *  sites and `contextWindowCache`). */
   contextWindowSize: number;
   contextUsedTokens?: number;
   /** Whether `contextWindowSize` came from an authoritative source (the
-   *  cross-session cache, a resumed session's `getContextUsage` report, or a
-   *  `result.modelUsage`) rather than the text heuristic / default. Guards the
+   *  cross-session cache or a `result.modelUsage`) rather than the text
+   *  heuristic / default. Guards the
    *  mid-stream `message_start` heuristic upgrade: an authoritative window that
    *  happens to equal DEFAULT_CONTEXT_WINDOW must not be mistaken for "unseeded"
    *  and clobbered by a "1m" text match. */
@@ -2129,6 +2130,7 @@ export class ClaudeAcpAgent {
     if (this.providerUpdate) await this.providerUpdate;
     return forkSession(params, {
       liveMessageIdToUuid: this.sessions[params.sessionId]?.messageIdToUuid,
+      logger: this.logger,
       messageIdForGrouping,
     });
   }
@@ -2146,10 +2148,13 @@ export class ClaudeAcpAgent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
+    const timing = new SessionTiming(this.logger, "load", params.sessionId);
     if (this.providerUpdate) await this.providerUpdate;
     const result = await this.getOrCreateSession(params);
+    timing.phase("session-ready");
 
     await this.replaySessionHistory(params.sessionId);
+    timing.phase("replay");
 
     // Send available commands after replay so it doesn't interleave with history
     setTimeout(() => {
@@ -4107,14 +4112,11 @@ export class ClaudeAcpAgent {
                 // right after the user sees "Compacting completed", which is
                 // confusing and wrong.
                 //
-                // Prefer the SDK's authoritative post-compaction `used` via
-                // getContextUsage — it reflects the real retained context
-                // (system prompt + tools + surviving messages), which the
-                // per-message API usage numbers can't give us until the next
-                // turn's result. If the control request fails, fall back to the
-                // used:0 approximation: directionally correct (context just
-                // dropped dramatically) and replaced within seconds by the next
-                // result message.
+                // The compact boundary already carries the retained token
+                // count. Prefer it over a getContextUsage control request,
+                // which can block the live query for tens of seconds. Older
+                // SDK frames without post_tokens fall back to used:0 and are
+                // corrected by the next result message.
                 //
                 // `size` keeps coming from session.contextWindowSize —
                 // compaction frees occupancy, it doesn't change the model's
@@ -4128,10 +4130,10 @@ export class ClaudeAcpAgent {
                   compactMetadata ? contextCompactionMetadataFromBoundary(compactMetadata) : {},
                   true,
                 );
-                const usedTokens = await fetchContextUsedTokens(session.query, this.logger);
+                const usedTokens = compactMetadata?.post_tokens ?? 0;
                 lastAssistantUsage = null;
-                lastAssistantTotalUsage = usedTokens ?? 0;
-                session.contextUsedTokens = usedTokens ?? 0;
+                lastAssistantTotalUsage = usedTokens;
+                session.contextUsedTokens = usedTokens;
                 await sendUpdate({
                   sessionId: message.session_id,
                   update: {
@@ -6488,8 +6490,13 @@ export class ClaudeAcpAgent {
   }
 
   private async replaySessionHistory(sessionId: string): Promise<void> {
+    const replayStartedAt = performance.now();
     const toolUseCache: ToolUseCache = {};
     const messages = await getSessionMessages(sessionId);
+    const historyLoadedAt = performance.now();
+    this.logger.log(
+      `[session/replay] sessionId=${sessionId} phase=read durationMs=${Math.round(historyLoadedAt - replayStartedAt)} messages=${messages.length}`,
+    );
     const session = this.sessions[sessionId];
     const forwardSubagentText =
       session?.forwardSubagentText ?? supportsSubagentTranscript(this.clientCapabilities);
@@ -6824,6 +6831,10 @@ export class ClaudeAcpAgent {
         );
       }
     }
+    const replayFinishedAt = performance.now();
+    this.logger.log(
+      `[session/replay] sessionId=${sessionId} phase=publish durationMs=${Math.round(replayFinishedAt - historyLoadedAt)} totalMs=${Math.round(replayFinishedAt - replayStartedAt)} messages=${messages.length}`,
+    );
   }
 
   async readTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
@@ -7607,6 +7618,8 @@ export class ClaudeAcpAgent {
       await this.teardownSession(params.sessionId);
     }
 
+    const resumedModelHint = await readResumedModelHint(params.sessionId, params.cwd, this.logger);
+
     const response = await this.createSession(
       {
         cwd: params.cwd,
@@ -7616,6 +7629,7 @@ export class ClaudeAcpAgent {
       },
       {
         resume: params.sessionId,
+        resumedModelHint,
       },
     );
 
@@ -7667,6 +7681,10 @@ export class ClaudeAcpAgent {
        *  wrote one; this keeps the ACP session id alive with an empty history.
        *  The SDK accepts a caller-chosen id as long as `resume` is not set. */
       reuseSessionId?: string;
+      /** Concrete model id from the resumed transcript's last real assistant
+       *  message. Claude Code restores from this same record, so it lets us
+       *  report the live model without a slow getContextUsage control request. */
+      resumedModelHint?: string;
     } = {},
   ): Promise<NewSessionResponse> {
     // Validate `cwd` up front. The ACP spec requires an absolute path, and the
@@ -7693,6 +7711,8 @@ export class ClaudeAcpAgent {
     } else {
       sessionId = randomUUID();
     }
+    const timing = new SessionTiming(this.logger, "create", sessionId);
+    timing.phase("validate-cwd");
 
     const input = new Pushable<SDKUserMessage>();
 
@@ -7700,6 +7720,7 @@ export class ClaudeAcpAgent {
       logger: this.logger,
     });
     await settingsManager.initialize();
+    timing.phase("settings");
 
     const mcpServers: Record<string, McpServerConfig> = {};
     if (Array.isArray(params.mcpServers)) {
@@ -7954,7 +7975,7 @@ export class ClaudeAcpAgent {
         // switches the session's model with no refusal-fallback frame, and
         // the client's picker silently drifts. `source: 'sdk'` is the
         // adapter's own setModel (applyConfigOptionValue already synced it),
-        // and 'resume' restores are read back via readResumedLiveModel, so
+        // and 'resume' restores are read from the transcript before startup, so
         // only the remaining sources sync here (CLI 2.1.251+; older CLIs
         // never fire the hook and keep the pre-hook behavior).
         PostModelSwitch: [
@@ -8041,6 +8062,7 @@ export class ClaudeAcpAgent {
       prompt: input,
       options,
     });
+    timing.phase("prepare-query");
 
     // `query()` spawns the CLI at once. Any throw between here and the
     // registration in `this.sessions` would leave that child process running
@@ -8060,6 +8082,7 @@ export class ClaudeAcpAgent {
         }
         throw error;
       }
+      timing.phase("sdk-initialize");
 
       // Publish the identity BEFORE the guard can refuse this session. A
       // refusal is exactly when the client most needs to know which account it
@@ -8103,14 +8126,17 @@ export class ClaudeAcpAgent {
           )
         : initializationResult.models;
 
-      const { modelState: models, resumedContextWindow } = await getAvailableModels(
+      const models = await getAvailableModels(
         q,
         allowedModels,
         initializationResult.models,
         settingsManager,
         this.logger,
         creationOpts.resume !== undefined,
+        sessionId,
+        creationOpts.resumedModelHint,
       );
+      timing.phase("models");
 
       // Resolve the current model's capabilities separately from the stable
       // permission-mode catalog advertised to ACP clients.
@@ -8153,8 +8179,10 @@ export class ClaudeAcpAgent {
         currentModelInfo,
         currentModelId: models.currentModelId,
       });
+      timing.phase("modes");
 
       const agents = await discoverCustomAgents(q);
+      timing.phase("agents");
       // Only adopt the requested agent as the selected value if it's one we
       // actually surface in the picker. A built-in (filtered out above) or
       // otherwise-unknown name would leave the config option's `currentValue`
@@ -8204,18 +8232,13 @@ export class ClaudeAcpAgent {
         currentAgent,
         fastMode,
       );
-      // Seed the context window WITHOUT any extra IPC on the session/new path.
-      // On session/load, the resumed session's own `getContextUsage` report — a
-      // response `getAvailableModels` already awaited to learn the live model
-      // (resumed sessions ARE serviced pre-turn, unlike fresh ones) — is
-      // authoritative and wins. Otherwise: the cached authoritative window if a
-      // prior turn has learned it for this model (`result.modelUsage`,
-      // cross-session), else the text heuristic, else the default. We
-      // deliberately do NOT issue a getContextUsage call here: on a fresh
-      // session that control request is not serviced until the first prompt
-      // turn runs, so awaiting it — as 0.59.0 did — made session/new take ~15s
-      // (issues #886/#880). The authoritative window arrives on the first
-      // `result.modelUsage` and is cached from there.
+      // Seed the context window without extra IPC. The cached authoritative
+      // window from a prior turn wins (`result.modelUsage`, cross-session),
+      // then the text heuristic, then the default. We deliberately do NOT issue
+      // a getContextUsage call here: before the first prompt turn that control
+      // request can take tens of seconds, on resumed as well as fresh sessions.
+      // The authoritative window arrives on the first `result.modelUsage` and
+      // is cached from there.
       //
       // Text inference alone misses aliases that resolve to extended-context
       // models with no "1m" token anywhere in their id or description (e.g.
@@ -8223,18 +8246,18 @@ export class ClaudeAcpAgent {
       // `usage_update.size: 200000` until the first result's modelUsage corrects
       // it — but the cache means only the FIRST session to ever run a turn on such
       // a model eats that window, not every fresh session after a process
-      // restart (issue #596; a post-restart session/load is covered by the
-      // resumed report above).
+      // restart (issue #596).
       //
       // The inference fallback is deliberately keyed to the allowlisted entry: a
       // fallback-resolved sibling's resolvedModel/displayName/description can
       // describe a different context lane than the verbatim live id (e.g. an
       // "opus[1m]" row matched for a bare 200k id), so on the fallback path only
       // the id itself is a trustworthy window signal.
-      const seededWindow =
-        resumedContextWindow !== null
-          ? { size: resumedContextWindow, authoritative: true }
-          : immediateContextWindow(providerCacheKey, models.currentModelId, allowlistedModelInfo);
+      const seededWindow = immediateContextWindow(
+        providerCacheKey,
+        models.currentModelId,
+        allowlistedModelInfo,
+      );
 
       this.sessions[sessionId] = {
         query: q,
@@ -8286,6 +8309,7 @@ export class ClaudeAcpAgent {
         fileChangeReportRequestIds: new Set(),
         fileChangeAuditSupport,
       };
+      timing.phase("register");
 
       return {
         sessionId,
@@ -9314,17 +9338,6 @@ export function applyAvailableModelsAllowlist(
   return result;
 }
 
-/** Read the model a resumed session is actually running (via the
- *  `getContextUsage` control request — the same source `/context` prints) and
- *  map it onto the picker, along with the report's authoritative context
- *  window (`rawMaxTokens`). Resumed sessions get this request serviced before
- *  any turn runs in the new process — unlike fresh sessions, where it stalls
- *  until the first prompt turn (issues #886/#880) — so the same response that
- *  restores the live model (issue #845) also seeds the window for free,
- *  covering post-restart reloads of models the text heuristic misses (issue
- *  #596). Best-effort: a control-request failure is logged and returns nulls
- *  so callers keep their current choice; failing the whole session/load over
- *  an unreadable report would be worse. */
 /** Whether a rejected `setModel` was vetoed by a user-configured
  *  PreModelSwitch hook. The CLI's rejection message is the stable,
  *  distinguishable marker ("Model switch blocked by a PreModelSwitch hook:
@@ -9334,23 +9347,6 @@ function isPreModelSwitchHookBlock(error: unknown): boolean {
   return error instanceof Error && error.message.includes("blocked by a PreModelSwitch hook");
 }
 
-async function readResumedLiveModel(
-  query: Query,
-  models: ModelInfo[],
-  logger: Logger,
-): Promise<{ model: ModelInfo | null; contextWindow: number | null }> {
-  try {
-    const usage = await query.getContextUsage();
-    return {
-      model: usage.model ? matchResumedModel(models, usage.model) : null,
-      contextWindow: usage.rawMaxTokens > 0 ? usage.rawMaxTokens : null,
-    };
-  } catch (error) {
-    logger.error("Failed to read the resumed session's live model:", error);
-    return { model: null, contextWindow: null };
-  }
-}
-
 async function getAvailableModels(
   query: Query,
   models: ModelInfo[],
@@ -9358,17 +9354,13 @@ async function getAvailableModels(
   settingsManager: SettingsManager,
   logger: Logger,
   isResumedSession: boolean,
-): Promise<{ modelState: SessionModelState; resumedContextWindow: number | null }> {
+  sessionId: string,
+  resumedModelHint?: string,
+): Promise<SessionModelState> {
   const settings = settingsManager.getSettings();
 
   let currentModel = models[0];
   let resolvedFromInput: string | undefined;
-  // The context window reported alongside a resumed session's live model.
-  // Only ever non-null on the paths where `currentModel` IS the live model
-  // (no override, or a failed override re-assert), so the window always
-  // describes the model the session actually runs.
-  let resumedContextWindow: number | null = null;
-
   // Model priority (highest to lowest):
   // 1. ANTHROPIC_MODEL environment variable
   // 2. settings.model (user configuration)
@@ -9388,17 +9380,14 @@ async function getAvailableModels(
     }
   }
 
-  // A resumed session restores the model it was previously running (the CLI
-  // re-reads it from the transcript), so without an env/settings override the
-  // freshly-computed default above can disagree with what the session actually
-  // runs — session/load then reports a model the session isn't using (issue
-  // #845). Ask the CLI for the live model and reflect it. No `setModel` here:
-  // the SDK is already running this model, and pushing a picker alias back
-  // (e.g. "opus[1m]") could change the live model rather than describe it.
+  // A resumed session restores the model from its last real assistant
+  // transcript record. Use that same local record instead of getContextUsage:
+  // the latter is a control request to the live CLI process and can add tens
+  // of seconds to session/load before its first turn. No `setModel` here: the
+  // SDK is already running this model, and pushing a picker alias back (e.g.
+  // "opus[1m]") could change the live model rather than describe it.
   if (resolvedFromInput === undefined && isResumedSession) {
-    const live = await readResumedLiveModel(query, models, logger);
-    currentModel = live.model ?? currentModel;
-    resumedContextWindow = live.contextWindow;
+    currentModel = resumedModelHint ? matchResumedModel(models, resumedModelHint) : currentModel;
   }
 
   // Skip the setModel round-trip when we can prove the SDK has already landed
@@ -9419,9 +9408,16 @@ async function getAvailableModels(
     resolvedFromInput === undefined ||
     (!isResumedSession && currentModel.value === resolvedFromInput && sdkSawSameValue);
   if (!skipSetModel) {
+    const setModelStartedAt = performance.now();
     try {
       await query.setModel(currentModel.value);
+      logger.log(
+        `[session/models] sessionId=${sessionId} phase=set-model durationMs=${Math.round(performance.now() - setModelStartedAt)} model=${currentModel.value} outcome=success`,
+      );
     } catch (error) {
+      logger.log(
+        `[session/models] sessionId=${sessionId} phase=set-model durationMs=${Math.round(performance.now() - setModelStartedAt)} model=${currentModel.value} outcome=error`,
+      );
       // On a fresh session the pin is a defining option — fail loudly. A
       // resumed session already runs fine on the transcript's model, so
       // failing the whole session/load over the re-assert would be worse
@@ -9449,23 +9445,18 @@ async function getAvailableModels(
         currentModel = models[0];
       } else {
         logger.error(`Failed to re-assert model "${currentModel.value}" on resume:`, error);
-        const live = await readResumedLiveModel(query, models, logger);
-        currentModel = live.model ?? currentModel;
-        resumedContextWindow = live.contextWindow;
+        currentModel = resumedModelHint ? matchResumedModel(models, resumedModelHint) : models[0];
       }
     }
   }
 
   return {
-    modelState: {
-      availableModels: models.map((model) => ({
-        modelId: model.value,
-        name: model.displayName,
-        description: model.description,
-      })),
-      currentModelId: currentModel.value,
-    },
-    resumedContextWindow,
+    availableModels: models.map((model) => ({
+      modelId: model.value,
+      name: model.displayName,
+      description: model.description,
+    })),
+    currentModelId: currentModel.value,
   };
 }
 
@@ -10592,28 +10583,11 @@ function commonPrefixLength(a: string, b: string) {
  *  models with no "1m" anywhere (e.g. `sonnet` → claude-sonnet-5, natively
  *  ~1M). Such a miss falls back to the default window and is corrected by
  *  `result.modelUsage` (and cached) within one turn. We do NOT consult the
- *  SDK's `getContextUsage` to close that gap: on a fresh session it is not
- *  serviced before the first prompt turn (issues #886/#880, see
- *  `contextWindowCache`; resumed sessions do get it, via
- *  `readResumedLiveModel`). */
+ *  SDK's `getContextUsage` to close that gap: before the first prompt turn it
+ *  can take tens of seconds (issues #886/#880, see `contextWindowCache`). */
 function inferContextWindowFromModel(...texts: Array<string | undefined>): number | null {
   if (texts.some((text) => text != null && /\b1m\b/i.test(text))) return 1_000_000;
   return null;
-}
-
-/** Fetch the SDK's authoritative context-window occupancy via the
- *  `getContextUsage` control request. Unlike the per-message API usage numbers
- *  (which only count message tokens), this `totalTokens` includes the system
- *  prompt, tool schemas, MCP tools, and memory-file overhead — the real
- *  occupancy the user sees. Returns `null` on any control-request failure. */
-async function fetchContextUsedTokens(query: Query, logger: Logger): Promise<number | null> {
-  try {
-    const usage = await query.getContextUsage();
-    return usage.totalTokens;
-  } catch (error) {
-    logger.error("Failed to fetch context usage from SDK:", error);
-    return null;
-  }
 }
 
 /** Cross-session cache of authoritative context windows, keyed by
@@ -10636,9 +10610,6 @@ async function fetchContextUsedTokens(query: Query, logger: Logger): Promise<num
  *  has run the control request is not serviced (it stalls ~15s, and serializes
  *  ahead of an awaited `setModel` — issues #886/#880, regressed in 0.59.0), so
  *  it can neither beat the first `result` nor be issued cheaply before one.
- *  Resumed sessions are the exception — their report IS serviced pre-turn, and
- *  the session/load path seeds (but does not cache) the window from the same
- *  response that restores the live model, see `readResumedLiveModel`.
  *  Cleared on `logout`: 1M-context entitlement can differ per account/tier, so
  *  windows learned under one login must not seed sessions under the next. */
 const contextWindowCache = new Map<string, number>();

--- a/src/fork-session.ts
+++ b/src/fork-session.ts
@@ -50,6 +50,7 @@ function forkPoint(meta: unknown): ForkPoint | undefined {
   return {
     messageId,
     ...(messageFingerprint ? { messageFingerprint } : {}),
+    // AIR computes this with count(...) over the visible prefix, so it is 1-based.
     ...(typeof messageOccurrence === "number" &&
     Number.isSafeInteger(messageOccurrence) &&
     messageOccurrence > 0
@@ -86,7 +87,14 @@ function assistantGroups(
 ) {
   const groups = new Map<string, { uuid?: string; text: string }>();
   for (const entry of entries) {
-    if (entry.type !== "assistant" || entry.isSidechain === true) continue;
+    if (
+      entry.type !== "assistant" ||
+      entry.isSidechain === true ||
+      entry.parent_tool_use_id != null ||
+      entry.parent_agent_id != null
+    ) {
+      continue;
+    }
     const messageId = messageIdForGrouping(entry);
     if (!messageId) continue;
     const group = groups.get(messageId) ?? { text: "" };
@@ -95,6 +103,44 @@ function assistantGroups(
     groups.set(messageId, group);
   }
   return groups;
+}
+
+function fingerprint(text: string): string {
+  return `sha256:${createHash("sha256").update(text).digest("hex")}`;
+}
+
+function fingerprintOccurrenceOnBranch(
+  targetUuid: string,
+  expectedFingerprint: string,
+  entries: SessionStoreEntry[],
+  groups: ReturnType<typeof assistantGroups>,
+  messageIdForGrouping: ForkSessionDependencies["messageIdForGrouping"],
+): number {
+  const entriesByUuid = new Map(
+    entries.flatMap((entry) => (typeof entry.uuid === "string" ? [[entry.uuid, entry]] : [])),
+  );
+  const seenGroups = new Set<string>();
+  let occurrence = 0;
+  let cursor: string | undefined = targetUuid;
+  while (cursor) {
+    const entry = entriesByUuid.get(cursor);
+    if (!entry) break;
+    if (
+      entry.type === "assistant" &&
+      entry.isSidechain !== true &&
+      entry.parent_tool_use_id == null &&
+      entry.parent_agent_id == null
+    ) {
+      const messageId = messageIdForGrouping(entry);
+      if (messageId && !seenGroups.has(messageId)) {
+        seenGroups.add(messageId);
+        const group = groups.get(messageId);
+        if (group && fingerprint(group.text) === expectedFingerprint) occurrence++;
+      }
+    }
+    cursor = typeof entry.parentUuid === "string" ? entry.parentUuid : undefined;
+  }
+  return occurrence;
 }
 
 function resolveFromFullHistory(
@@ -108,14 +154,25 @@ function resolveFromFullHistory(
   if (exact) return exact;
   if (!point.messageFingerprint || !point.messageOccurrence) return undefined;
 
-  let occurrence = 0;
-  for (const group of groups.values()) {
-    const fingerprint = `sha256:${createHash("sha256").update(group.text).digest("hex")}`;
-    if (fingerprint !== point.messageFingerprint) continue;
-    occurrence++;
-    if (occurrence === point.messageOccurrence) return group.uuid;
-  }
-  return undefined;
+  const fingerprintMatches = [...groups.values()].filter(
+    (group) => group.uuid && fingerprint(group.text) === point.messageFingerprint,
+  );
+  // If only one persisted message has this content, the fingerprint already
+  // identifies it even when an older client supplied an incompatible index.
+  if (fingerprintMatches.length === 1) return fingerprintMatches[0]?.uuid;
+
+  const occurrenceMatches = fingerprintMatches.filter(
+    (group) =>
+      group.uuid &&
+      fingerprintOccurrenceOnBranch(
+        group.uuid,
+        point.messageFingerprint!,
+        entries,
+        groups,
+        messageIdForGrouping,
+      ) === point.messageOccurrence,
+  );
+  return occurrenceMatches.length === 1 ? occurrenceMatches[0]?.uuid : undefined;
 }
 
 export async function forkSession(
@@ -143,8 +200,10 @@ export async function forkSession(
     candidateIds
       .map(
         (candidateId) =>
-          history?.find((message) => dependencies.messageIdForGrouping(message) === candidateId)
-            ?.uuid,
+          history
+            ?.slice()
+            .reverse()
+            .find((message) => dependencies.messageIdForGrouping(message) === candidateId)?.uuid,
       )
       .find(Boolean);
   const fullHistoryUuid = messageUuid

--- a/src/fork-session.ts
+++ b/src/fork-session.ts
@@ -2,7 +2,13 @@ import { ForkSessionRequest, ForkSessionResponse, RequestError } from "@agentcli
 import {
   forkSession as forkClaudeSession,
   getSessionMessages,
+  importSessionToStore,
+  type SessionStore,
+  type SessionStoreEntry,
 } from "@anthropic-ai/claude-agent-sdk";
+import { createHash } from "node:crypto";
+import { assistantMessageText } from "./session-failure-extension.js";
+import { SessionTiming } from "./session-timing.js";
 
 type ForkSessionMeta = {
   [key: string]: unknown;
@@ -11,6 +17,8 @@ type ForkSessionMeta = {
       fork?: {
         version?: number;
         messageId?: string;
+        messageFingerprint?: string;
+        messageOccurrence?: number;
       };
     };
   };
@@ -18,6 +26,7 @@ type ForkSessionMeta = {
 
 type ForkSessionDependencies = {
   liveMessageIdToUuid?: ReadonlyMap<string, string>;
+  logger?: { log: (...args: unknown[]) => void };
   messageIdForGrouping: (message: {
     type?: string;
     uuid?: string | null;
@@ -25,11 +34,28 @@ type ForkSessionDependencies = {
   }) => string | undefined;
 };
 
-function forkPointMessageId(meta: unknown): string | undefined {
+type ForkPoint = {
+  messageId: string;
+  messageFingerprint?: string;
+  messageOccurrence?: number;
+};
+
+function forkPoint(meta: unknown): ForkPoint | undefined {
   const fork = (meta as ForkSessionMeta | null | undefined)?.jetbrains?.air?.fork;
   if (fork?.version !== 1) return undefined;
   const messageId = fork.messageId?.trim();
-  return messageId || undefined;
+  if (!messageId) return undefined;
+  const messageFingerprint = fork.messageFingerprint?.trim();
+  const messageOccurrence = fork.messageOccurrence;
+  return {
+    messageId,
+    ...(messageFingerprint ? { messageFingerprint } : {}),
+    ...(typeof messageOccurrence === "number" &&
+    Number.isSafeInteger(messageOccurrence) &&
+    messageOccurrence > 0
+      ? { messageOccurrence }
+      : {}),
+  };
 }
 
 function forkPointMessageIdCandidates(messageId: string): string[] {
@@ -38,23 +64,80 @@ function forkPointMessageIdCandidates(messageId: string): string[] {
   return protocolMessageId === messageId ? [messageId] : [messageId, protocolMessageId];
 }
 
+async function loadFullSessionHistory(
+  sessionId: string,
+  cwd: string,
+): Promise<SessionStoreEntry[]> {
+  // getSessionMessages returns only the active parentUuid chain. The import keeps inactive branches that AIR can still reference.
+  const entries: SessionStoreEntry[] = [];
+  const store: SessionStore = {
+    append: async (_key, batch) => {
+      entries.push(...batch);
+    },
+    load: async () => null,
+  };
+  await importSessionToStore(sessionId, store, { dir: cwd, includeSubagents: false });
+  return entries;
+}
+
+function assistantGroups(
+  entries: SessionStoreEntry[],
+  messageIdForGrouping: ForkSessionDependencies["messageIdForGrouping"],
+) {
+  const groups = new Map<string, { uuid?: string; text: string }>();
+  for (const entry of entries) {
+    if (entry.type !== "assistant" || entry.isSidechain === true) continue;
+    const messageId = messageIdForGrouping(entry);
+    if (!messageId) continue;
+    const group = groups.get(messageId) ?? { text: "" };
+    if (typeof entry.uuid === "string" && entry.uuid.length > 0) group.uuid = entry.uuid;
+    group.text += assistantMessageText(entry.message) ?? "";
+    groups.set(messageId, group);
+  }
+  return groups;
+}
+
+function resolveFromFullHistory(
+  entries: SessionStoreEntry[],
+  candidates: string[],
+  point: ForkPoint,
+  messageIdForGrouping: ForkSessionDependencies["messageIdForGrouping"],
+): string | undefined {
+  const groups = assistantGroups(entries, messageIdForGrouping);
+  const exact = candidates.map((candidate) => groups.get(candidate)?.uuid).find(Boolean);
+  if (exact) return exact;
+  if (!point.messageFingerprint || !point.messageOccurrence) return undefined;
+
+  let occurrence = 0;
+  for (const group of groups.values()) {
+    const fingerprint = `sha256:${createHash("sha256").update(group.text).digest("hex")}`;
+    if (fingerprint !== point.messageFingerprint) continue;
+    occurrence++;
+    if (occurrence === point.messageOccurrence) return group.uuid;
+  }
+  return undefined;
+}
+
 export async function forkSession(
   params: ForkSessionRequest,
   dependencies: ForkSessionDependencies,
 ): Promise<ForkSessionResponse> {
-  const messageId = forkPointMessageId(params._meta);
-  if (!messageId) {
+  const timing = new SessionTiming(dependencies.logger, "fork", params.sessionId);
+  const point = forkPoint(params._meta);
+  if (!point) {
     const forked = await forkClaudeSession(params.sessionId, { dir: params.cwd });
+    timing.phase("sdk-fork", " resolution=latest");
     return { sessionId: forked.sessionId };
   }
 
-  const candidateIds = forkPointMessageIdCandidates(messageId);
+  const candidateIds = forkPointMessageIdCandidates(point.messageId);
   const liveUuid = candidateIds
     .map((candidateId) => dependencies.liveMessageIdToUuid?.get(candidateId))
     .find(Boolean);
   const history = liveUuid
     ? undefined
     : await getSessionMessages(params.sessionId, { dir: params.cwd });
+  timing.phase("active-history", ` resolution=${liveUuid ? "live" : "pending"}`);
   const messageUuid =
     liveUuid ??
     candidateIds
@@ -64,17 +147,30 @@ export async function forkSession(
             ?.uuid,
       )
       .find(Boolean);
+  const fullHistoryUuid = messageUuid
+    ? undefined
+    : resolveFromFullHistory(
+        await loadFullSessionHistory(params.sessionId, params.cwd),
+        candidateIds,
+        point,
+        dependencies.messageIdForGrouping,
+      );
+  timing.phase(
+    "full-history",
+    ` resolution=${liveUuid ? "live" : messageUuid ? "active" : fullHistoryUuid ? "full" : "missing"}`,
+  );
 
-  if (!messageUuid) {
+  if (!messageUuid && !fullHistoryUuid) {
     throw RequestError.invalidParams(
-      { messageId },
-      `Fork point message ${messageId} was not found in session ${params.sessionId}`,
+      { messageId: point.messageId },
+      `Fork point message ${point.messageId} was not found in session ${params.sessionId}`,
     );
   }
 
   const forked = await forkClaudeSession(params.sessionId, {
     dir: params.cwd,
-    upToMessageId: messageUuid,
+    upToMessageId: messageUuid ?? fullHistoryUuid,
   });
+  timing.phase("sdk-fork");
   return { sessionId: forked.sessionId };
 }

--- a/src/resumed-session.ts
+++ b/src/resumed-session.ts
@@ -1,0 +1,38 @@
+import { getSessionMessages, type SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+import { SessionTiming } from "./session-timing.js";
+
+type ResumeLogger = {
+  log: (...args: unknown[]) => void;
+};
+
+/** Return the concrete model recorded by the last real assistant response.
+ * Claude Code restores a resumed query from this same transcript field.
+ * Synthetic assistant records use angle-bracket placeholders and do not
+ * describe a model the resumed query can run. */
+export function resumedModelFromTranscript(messages: SessionMessage[]): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const entry = messages[index];
+    if (entry?.type !== "assistant" || !entry.message || typeof entry.message !== "object") {
+      continue;
+    }
+    const model = (entry.message as { model?: unknown }).model;
+    if (typeof model === "string" && model.trim().length > 0 && !/^<[^>]+>$/.test(model.trim())) {
+      return model.trim();
+    }
+  }
+  return undefined;
+}
+
+/** Read the resume model from the local transcript without starting a Claude
+ * control request. This is intentionally on the load critical path. */
+export async function readResumedModelHint(
+  sessionId: string,
+  cwd: string,
+  logger?: ResumeLogger,
+): Promise<string | undefined> {
+  const timing = new SessionTiming(logger, "models", sessionId);
+  const messages = await getSessionMessages(sessionId, { dir: cwd });
+  const model = resumedModelFromTranscript(messages);
+  timing.phase("read-transcript", ` messages=${messages.length} model=${model ?? "unknown"}`);
+  return model;
+}

--- a/src/resumed-session.ts
+++ b/src/resumed-session.ts
@@ -3,6 +3,12 @@ import { SessionTiming } from "./session-timing.js";
 
 type ResumeLogger = {
   log: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+};
+
+export type ResumedSessionSnapshot = {
+  messages?: SessionMessage[];
+  model?: string;
 };
 
 /** Return the concrete model recorded by the last real assistant response.
@@ -12,7 +18,13 @@ type ResumeLogger = {
 export function resumedModelFromTranscript(messages: SessionMessage[]): string | undefined {
   for (let index = messages.length - 1; index >= 0; index--) {
     const entry = messages[index];
-    if (entry?.type !== "assistant" || !entry.message || typeof entry.message !== "object") {
+    if (
+      entry?.type !== "assistant" ||
+      entry.parent_tool_use_id != null ||
+      entry.parent_agent_id != null ||
+      !entry.message ||
+      typeof entry.message !== "object"
+    ) {
       continue;
     }
     const model = (entry.message as { model?: unknown }).model;
@@ -25,14 +37,22 @@ export function resumedModelFromTranscript(messages: SessionMessage[]): string |
 
 /** Read the resume model from the local transcript without starting a Claude
  * control request. This is intentionally on the load critical path. */
-export async function readResumedModelHint(
+export async function readResumedSession(
   sessionId: string,
-  cwd: string,
   logger?: ResumeLogger,
-): Promise<string | undefined> {
+): Promise<ResumedSessionSnapshot> {
   const timing = new SessionTiming(logger, "models", sessionId);
-  const messages = await getSessionMessages(sessionId, { dir: cwd });
-  const model = resumedModelFromTranscript(messages);
-  timing.phase("read-transcript", ` messages=${messages.length} model=${model ?? "unknown"}`);
-  return model;
+  try {
+    // Deliberately search all project directories, matching replaySessionHistory.
+    // A client may reopen a session from a worktree or normalized path that is
+    // different from the directory under which Claude persisted the transcript.
+    const messages = await getSessionMessages(sessionId);
+    const model = resumedModelFromTranscript(messages);
+    timing.phase("read-transcript", ` messages=${messages.length} model=${model ?? "unknown"}`);
+    return { messages, model };
+  } catch (error) {
+    timing.phase("read-transcript", " outcome=error");
+    logger?.error(`Failed to read transcript for resumed session ${sessionId}:`, error);
+    return {};
+  }
 }

--- a/src/session-timing.ts
+++ b/src/session-timing.ts
@@ -4,14 +4,18 @@ type TimingLogger = {
 
 /** Small phase timer for session lifecycle diagnostics. */
 export class SessionTiming {
-  private readonly startedAt = performance.now();
-  private phaseStartedAt = this.startedAt;
+  private readonly startedAt: number;
+  private phaseStartedAt: number;
 
   constructor(
     private readonly logger: TimingLogger | undefined,
     private readonly operation: string,
     private readonly sessionId: string,
-  ) {}
+    startedAt = performance.now(),
+  ) {
+    this.startedAt = startedAt;
+    this.phaseStartedAt = startedAt;
+  }
 
   phase(name: string, detail = ""): void {
     const finishedAt = performance.now();

--- a/src/session-timing.ts
+++ b/src/session-timing.ts
@@ -1,0 +1,23 @@
+type TimingLogger = {
+  log: (...args: unknown[]) => void;
+};
+
+/** Small phase timer for session lifecycle diagnostics. */
+export class SessionTiming {
+  private readonly startedAt = performance.now();
+  private phaseStartedAt = this.startedAt;
+
+  constructor(
+    private readonly logger: TimingLogger | undefined,
+    private readonly operation: string,
+    private readonly sessionId: string,
+  ) {}
+
+  phase(name: string, detail = ""): void {
+    const finishedAt = performance.now();
+    this.logger?.log(
+      `[session/${this.operation}] sessionId=${this.sessionId} phase=${name} durationMs=${Math.round(finishedAt - this.phaseStartedAt)} totalMs=${Math.round(finishedAt - this.startedAt)}${detail}`,
+    );
+    this.phaseStartedAt = finishedAt;
+  }
+}

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -8409,6 +8409,12 @@ describe("logout", () => {
 });
 
 describe("session/fork", () => {
+  beforeEach(() => {
+    vi.mocked(forkSession).mockClear();
+    vi.mocked(getSessionMessages).mockClear();
+    vi.mocked(importSessionToStore).mockClear();
+  });
+
   it("forks the latest turn in the requested workspace", async () => {
     const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
@@ -8429,6 +8435,18 @@ describe("session/fork", () => {
     const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
     vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "assistant-thinking-uuid",
+        session_id: "source-id",
+        message: {
+          id: "msg_123",
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "hidden" }],
+        },
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+      },
       {
         type: "assistant",
         uuid: "assistant-uuid",
@@ -8452,6 +8470,7 @@ describe("session/fork", () => {
 
     expect(response.sessionId).toBe("fork-id");
     expect(getSessionMessages).toHaveBeenCalledWith("source-id", { dir: "/workspace" });
+    expect(importSessionToStore).not.toHaveBeenCalled();
     expect(forkSession).toHaveBeenCalledWith("source-id", {
       dir: "/workspace",
       upToMessageId: "assistant-uuid",
@@ -8499,6 +8518,14 @@ describe("session/fork", () => {
           },
         },
         {
+          type: "user",
+          uuid: "inactive-user-uuid",
+          parentUuid: "earlier-duplicate-uuid",
+          isSidechain: false,
+          sessionId: "source-id",
+          message: { role: "user", content: "regenerate" },
+        },
+        {
           type: "assistant",
           uuid: "inactive-thinking-uuid",
           parentUuid: "inactive-user-uuid",
@@ -8515,6 +8542,18 @@ describe("session/fork", () => {
           uuid: "inactive-assistant-uuid",
           parentUuid: "inactive-thinking-uuid",
           isSidechain: false,
+          sessionId: "source-id",
+          message: {
+            id: "persisted-message-id",
+            role: "assistant",
+            content: [{ type: "text", text: targetText }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "nested-assistant-uuid",
+          parentUuid: "nested-user-uuid",
+          isSidechain: true,
           sessionId: "source-id",
           message: {
             id: "persisted-message-id",

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -56,12 +56,13 @@ import {
   forkSession,
   getSessionInfo,
   getSessionMessages,
+  importSessionToStore,
   PermissionUpdate,
   query,
   SDKAssistantMessage,
   type SDKControlGetUsageResponse,
 } from "@anthropic-ai/claude-agent-sdk";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { readFile } from "node:fs/promises";
 import {
   mockSessionState,
@@ -83,6 +84,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
     deleteSession: vi.fn(),
     forkSession: vi.fn(),
     getSessionInfo: vi.fn(),
+    importSessionToStore: vi.fn(actual.importSessionToStore),
     // Delegates to the real implementation so integration tests that read
     // actual transcripts keep working; unit tests override per-call with
     // `mockResolvedValueOnce`.
@@ -8455,6 +8457,116 @@ describe("session/fork", () => {
       upToMessageId: "assistant-uuid",
     });
   });
+
+  it.each([
+    {
+      resolution: "its ACP message id",
+      messageId: "persisted-message-id:segment:0",
+      messageOccurrence: 1,
+    },
+    {
+      resolution: "its fingerprint occurrence",
+      messageId: "stale-air-message-id:segment:0",
+      messageOccurrence: 2,
+    },
+  ])("forks at an inactive persisted branch by $resolution", async (forkPoint) => {
+    const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
+    const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+    const targetText = "Answer from the branch that is no longer active.";
+    const targetFingerprint = `sha256:${createHash("sha256").update(targetText).digest("hex")}`;
+    vi.mocked(getSessionMessages).mockResolvedValueOnce([
+      {
+        type: "assistant",
+        uuid: "active-assistant-uuid",
+        session_id: "source-id",
+        message: { id: "active-message-id", role: "assistant", content: [] },
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+      },
+    ]);
+    vi.mocked(importSessionToStore).mockImplementationOnce(async (_sessionId, store) => {
+      await store.append({ projectKey: "-workspace", sessionId: "source-id" }, [
+        {
+          type: "assistant",
+          uuid: "earlier-duplicate-uuid",
+          parentUuid: "earlier-user-uuid",
+          isSidechain: false,
+          sessionId: "source-id",
+          message: {
+            id: "earlier-duplicate-message-id",
+            role: "assistant",
+            content: [{ type: "text", text: targetText }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "inactive-thinking-uuid",
+          parentUuid: "inactive-user-uuid",
+          isSidechain: false,
+          sessionId: "source-id",
+          message: {
+            id: "persisted-message-id",
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "Hidden reasoning" }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "inactive-assistant-uuid",
+          parentUuid: "inactive-thinking-uuid",
+          isSidechain: false,
+          sessionId: "source-id",
+          message: {
+            id: "persisted-message-id",
+            role: "assistant",
+            content: [{ type: "text", text: targetText }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "active-assistant-uuid",
+          parentUuid: "active-user-uuid",
+          isSidechain: false,
+          sessionId: "source-id",
+          message: {
+            id: "active-message-id",
+            role: "assistant",
+            content: [{ type: "text", text: "Answer from the active branch." }],
+          },
+        },
+      ]);
+    });
+    vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
+
+    const response = await agent.unstable_forkSession({
+      sessionId: "source-id",
+      cwd: "/workspace",
+      additionalDirectories: [],
+      mcpServers: [],
+      _meta: {
+        jetbrains: {
+          air: {
+            fork: {
+              version: 1,
+              messageId: forkPoint.messageId,
+              messageFingerprint: targetFingerprint,
+              messageOccurrence: forkPoint.messageOccurrence,
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.sessionId).toBe("fork-id");
+    expect(importSessionToStore).toHaveBeenLastCalledWith("source-id", expect.any(Object), {
+      dir: "/workspace",
+      includeSubagents: false,
+    });
+    expect(forkSession).toHaveBeenLastCalledWith("source-id", {
+      dir: "/workspace",
+      upToMessageId: "inactive-assistant-uuid",
+    });
+  });
 });
 
 describe("session/close", () => {
@@ -9785,7 +9897,7 @@ describe("usage_update computation", () => {
     expect(usageUpdate.update.size).toBe(1000000);
   });
 
-  it("compact_boundary uses authoritative getContextUsage for used, keeps session window for size", async () => {
+  it("compact_boundary uses post_tokens without waiting for getContextUsage", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     // No trailing idle: an idle with no preceding result now fails the turn as
     // abandoned (issue #825), and a real compaction turn always produces a
@@ -9809,18 +9921,18 @@ describe("usage_update computation", () => {
     // compaction — compaction frees occupancy, it doesn't change the window,
     // so the handler must not overwrite it from this response.
     session.contextWindowSize = 1000000;
-    (session.query as any).getContextUsage = vi
-      .fn()
-      .mockResolvedValue({ totalTokens: 12345, rawMaxTokens: 200000 });
+    const getContextUsage = vi.fn(() => new Promise<never>(() => {}));
+    (session.query as any).getContextUsage = getContextUsage;
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
     const usageUpdate = updates.find((u: any) => u.update?.sessionUpdate === "usage_update");
     expect(usageUpdate).toBeDefined();
     expect(usageUpdate.update.used).toBe(12345);
-    // size stays at the session's learned window, NOT getContextUsage's value.
+    // size stays at the session's learned window; compaction changes occupancy only.
     expect(usageUpdate.update.size).toBe(1000000);
     expect(session.contextWindowSize).toBe(1000000);
+    expect(getContextUsage).not.toHaveBeenCalled();
     expect(updates.map((notification) => notification.update)).toContainEqual({
       sessionUpdate: "tool_call",
       toolCallId: "compact-boundary",
@@ -9846,7 +9958,7 @@ describe("usage_update computation", () => {
     });
   });
 
-  it("compact_boundary falls back to used:0 when getContextUsage fails", async () => {
+  it("compact_boundary falls back to used:0 when post_tokens is unavailable", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     // No trailing idle — see the sibling test above (issue #825).
     injectSession(agent, [
@@ -9854,7 +9966,8 @@ describe("usage_update computation", () => {
     ]);
     const session = agent.sessions["test-session"];
     session.contextWindowSize = 200000;
-    (session.query as any).getContextUsage = vi.fn().mockRejectedValue(new Error("boom"));
+    const getContextUsage = vi.fn(() => new Promise<never>(() => {}));
+    (session.query as any).getContextUsage = getContextUsage;
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
 
@@ -9863,6 +9976,7 @@ describe("usage_update computation", () => {
     expect(usageUpdate.update.used).toBe(0);
     expect(usageUpdate.update.size).toBe(200000);
     expect(session.contextWindowSize).toBe(200000);
+    expect(getContextUsage).not.toHaveBeenCalled();
   });
 
   it("caches the turn's authoritative window under the resolved id and serves it on a later switch, with no getContextUsage IPC", async () => {

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 
 let capturedOptions: Options | undefined;
 let contextUsageResult: (() => Promise<{ rawMaxTokens: number; model?: string }>) | undefined;
+let sessionMessages: Record<string, unknown>[];
 let initModels: Record<string, unknown>[] | undefined;
 let setModelImpl: ((model: string) => Promise<void>) | undefined;
 let mcpServerStatusResult: () => Promise<Array<{ name: string; status: string }>>;
@@ -48,6 +49,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
         mcpAuthenticate: (serverName: string) => mcpAuthenticateImpl(serverName),
       });
     },
+    getSessionMessages: vi.fn(async () => sessionMessages),
   };
 });
 
@@ -75,6 +77,7 @@ describe("createSession options merging", () => {
   beforeEach(async () => {
     capturedOptions = undefined;
     contextUsageResult = undefined;
+    sessionMessages = [];
     initModels = undefined;
     setModelImpl = undefined;
     mcpServerStatusResult = async () => [];
@@ -769,25 +772,50 @@ describe("createSession options merging", () => {
       expect(sessionFor(response.sessionId).contextWindowAuthoritative).toBe(false);
     });
 
-    it("session/load seeds the window from the resumed session's getContextUsage report", async () => {
-      // Resumed sessions get getContextUsage serviced pre-turn (issue #845 uses
-      // it to restore the live model), and the same response carries the
-      // authoritative window (`rawMaxTokens`). After a process restart the
-      // module cache is empty and text inference misses natively-1M aliases, so
-      // discarding this in-hand value would replay the issue-#596 flicker on
-      // every reload — the flagship scenario. 888_000 can only come from the
-      // report: inference on the mock model yields null → 200_000 default.
-      contextUsageResult = async () => ({ rawMaxTokens: 888_000, model: "claude-sonnet-4-6" });
+    it("session/load restores the transcript model without waiting for getContextUsage", async () => {
+      // getContextUsage is a live CLI control request. On a real, large resumed
+      // session it can take tens of seconds before returning, so it must stay
+      // off the load critical path. Claude restores from this same last
+      // assistant model field, which is available through a local transcript
+      // read in milliseconds.
+      const ctxSpy = vi.fn(() => new Promise<never>(() => {}));
+      contextUsageResult = ctxSpy;
+      initModels = [
+        {
+          value: "default",
+          displayName: "Default",
+          description: "Default model",
+          resolvedModel: "claude-sonnet-4-6",
+        },
+        {
+          value: "haiku",
+          displayName: "Haiku",
+          description: "Fast",
+          resolvedModel: "claude-haiku-4-5",
+        },
+      ];
+      sessionMessages = [
+        {
+          type: "assistant",
+          uuid: "assistant-uuid",
+          session_id: "resumed-model-probe",
+          parent_tool_use_id: null,
+          parent_agent_id: null,
+          message: { model: "claude-haiku-4-5", role: "assistant", content: [] },
+        },
+      ];
 
-      await (
-        agent as unknown as {
-          createSession: (params: object, opts: { resume?: string }) => Promise<unknown>;
-        }
-      ).createSession({ cwd: process.cwd(), mcpServers: [] }, { resume: "resumed-window-probe" });
+      const response = await agent.loadSession({
+        sessionId: "resumed-model-probe",
+        cwd: process.cwd(),
+        mcpServers: [],
+      });
 
-      const session = sessionFor("resumed-window-probe");
-      expect(session.contextWindowSize).toBe(888_000);
-      expect(session.contextWindowAuthoritative).toBe(true);
+      expect(response.configOptions?.find((option) => option.id === "model")?.currentValue).toBe(
+        "haiku",
+      );
+      expect(ctxSpy).not.toHaveBeenCalled();
+      expect(sessionFor("resumed-model-probe").contextWindowAuthoritative).toBe(false);
     });
 
     it("scopes providerCacheKey by per-session env routing", async () => {

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -837,6 +837,46 @@ describe("createSession options merging", () => {
       ).resolves.toMatchObject({ sessionId: "unreadable-resume-probe" });
     });
 
+    it("restores the transcript model for direct session/new resume metadata", async () => {
+      initModels = [
+        {
+          value: "default",
+          displayName: "Default",
+          description: "Default model",
+          resolvedModel: "claude-sonnet-4-6",
+        },
+        {
+          value: "haiku",
+          displayName: "Haiku",
+          description: "Fast",
+          resolvedModel: "claude-haiku-4-5",
+        },
+      ];
+      sessionMessages = [
+        {
+          type: "assistant",
+          uuid: "assistant-uuid",
+          session_id: "direct-resume-probe",
+          parent_tool_use_id: null,
+          parent_agent_id: null,
+          message: { model: "claude-haiku-4-5", role: "assistant", content: [] },
+        },
+      ];
+
+      const response = await agent.newSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+        _meta: { claudeCode: { options: { resume: "direct-resume-probe" } } },
+      });
+
+      expect(response.sessionId).toBe("direct-resume-probe");
+      expect(response.configOptions?.find((option) => option.id === "model")?.currentValue).toBe(
+        "haiku",
+      );
+      expect(getSessionMessages).toHaveBeenCalledOnce();
+      expect(getSessionMessages).toHaveBeenCalledWith("direct-resume-probe");
+    });
+
     it("scopes providerCacheKey by per-session env routing", async () => {
       // The context-window cache key must distinguish backends exactly as the
       // CLI will see them: a session routed to a proxy via _meta env shares a

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -5,7 +5,7 @@ import {
   SessionNotification,
 } from "@agentclientprotocol/sdk";
 import type { ClientCapabilities } from "@agentclientprotocol/sdk";
-import type { Options } from "@anthropic-ai/claude-agent-sdk";
+import { getSessionMessages, type Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -14,6 +14,7 @@ import * as path from "node:path";
 let capturedOptions: Options | undefined;
 let contextUsageResult: (() => Promise<{ rawMaxTokens: number; model?: string }>) | undefined;
 let sessionMessages: Record<string, unknown>[];
+let sessionMessagesResult: () => Promise<Record<string, unknown>[]>;
 let initModels: Record<string, unknown>[] | undefined;
 let setModelImpl: ((model: string) => Promise<void>) | undefined;
 let mcpServerStatusResult: () => Promise<Array<{ name: string; status: string }>>;
@@ -49,7 +50,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", async () => {
         mcpAuthenticate: (serverName: string) => mcpAuthenticateImpl(serverName),
       });
     },
-    getSessionMessages: vi.fn(async () => sessionMessages),
+    getSessionMessages: vi.fn(() => sessionMessagesResult()),
   };
 });
 
@@ -78,6 +79,8 @@ describe("createSession options merging", () => {
     capturedOptions = undefined;
     contextUsageResult = undefined;
     sessionMessages = [];
+    sessionMessagesResult = async () => sessionMessages;
+    vi.mocked(getSessionMessages).mockClear();
     initModels = undefined;
     setModelImpl = undefined;
     mcpServerStatusResult = async () => [];
@@ -816,6 +819,22 @@ describe("createSession options merging", () => {
       );
       expect(ctxSpy).not.toHaveBeenCalled();
       expect(sessionFor("resumed-model-probe").contextWindowAuthoritative).toBe(false);
+      expect(getSessionMessages).toHaveBeenCalledTimes(1);
+      expect(getSessionMessages).toHaveBeenCalledWith("resumed-model-probe");
+    });
+
+    it("resume remains best-effort when the transcript hint cannot be read", async () => {
+      sessionMessagesResult = async () => {
+        throw new Error("unreadable transcript");
+      };
+
+      await expect(
+        agent.resumeSession({
+          sessionId: "unreadable-resume-probe",
+          cwd: process.cwd(),
+          mcpServers: [],
+        }),
+      ).resolves.toMatchObject({ sessionId: "unreadable-resume-probe" });
     });
 
     it("scopes providerCacheKey by per-session env routing", async () => {

--- a/src/tests/resumed-session.test.ts
+++ b/src/tests/resumed-session.test.ts
@@ -2,13 +2,18 @@ import { describe, expect, it } from "vitest";
 import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
 import { resumedModelFromTranscript } from "../resumed-session.js";
 
-function assistant(model: unknown): SessionMessage {
+function assistant(
+  model: unknown,
+  nesting: Pick<SessionMessage, "parent_tool_use_id" | "parent_agent_id"> = {
+    parent_tool_use_id: null,
+    parent_agent_id: null,
+  },
+): SessionMessage {
   return {
     type: "assistant",
     uuid: crypto.randomUUID(),
     session_id: "session-id",
-    parent_tool_use_id: null,
-    parent_agent_id: null,
+    ...nesting,
     message: { model },
   };
 }
@@ -24,6 +29,18 @@ describe("resumedModelFromTranscript", () => {
     expect(resumedModelFromTranscript([assistant("claude-opus-5"), assistant("<synthetic>")])).toBe(
       "claude-opus-5",
     );
+  });
+
+  it("skips nested assistant records that can use a different model", () => {
+    expect(
+      resumedModelFromTranscript([
+        assistant("claude-opus-5"),
+        assistant("claude-haiku-4-5", {
+          parent_tool_use_id: "task-tool-use",
+          parent_agent_id: null,
+        }),
+      ]),
+    ).toBe("claude-opus-5");
   });
 
   it("returns undefined when the transcript has no real assistant model", () => {

--- a/src/tests/resumed-session.test.ts
+++ b/src/tests/resumed-session.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+import { resumedModelFromTranscript } from "../resumed-session.js";
+
+function assistant(model: unknown): SessionMessage {
+  return {
+    type: "assistant",
+    uuid: crypto.randomUUID(),
+    session_id: "session-id",
+    parent_tool_use_id: null,
+    parent_agent_id: null,
+    message: { model },
+  };
+}
+
+describe("resumedModelFromTranscript", () => {
+  it("returns the last real assistant model", () => {
+    expect(
+      resumedModelFromTranscript([assistant("claude-sonnet-5"), assistant("claude-opus-5")]),
+    ).toBe("claude-opus-5");
+  });
+
+  it("skips synthetic assistant records after the real response", () => {
+    expect(resumedModelFromTranscript([assistant("claude-opus-5"), assistant("<synthetic>")])).toBe(
+      "claude-opus-5",
+    );
+  });
+
+  it("returns undefined when the transcript has no real assistant model", () => {
+    expect(resumedModelFromTranscript([assistant("<synthetic>")])).toBeUndefined();
+  });
+});

--- a/src/tests/session-timing.test.ts
+++ b/src/tests/session-timing.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionTiming } from "../session-timing.js";
+
+describe("SessionTiming", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("includes work completed before construction when given a start time", () => {
+    vi.spyOn(performance, "now").mockReturnValue(175);
+    const log = vi.fn();
+
+    new SessionTiming({ log }, "create", "session-id", 100).phase("validate-cwd");
+
+    expect(log).toHaveBeenCalledWith(
+      "[session/create] sessionId=session-id phase=validate-cwd durationMs=75 totalMs=75",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- resolve AIR fork points from the complete persisted transcript when the target is outside the active parent chain
- support message fingerprints and repeated assistant content when resolving persisted fork points
- restore resumed models from the same local assistant transcript record Claude Code uses
- remove all automatic `getContextUsage` control requests; use `compact_metadata.post_tokens` after compaction
- add structured timing logs for fork, load, replay, and session creation phases

## Performance

Cold-loading the reproduced 69-message forked session dropped from 20–29 seconds to 1.9 seconds. Transcript model lookup took 5 ms and replay took 14 ms; the remaining time was SDK initialization.

## Tests

- `env -u ANTHROPIC_BASE_URL npm run test:run` (1230 passed, 27 skipped)
- `npm run build`
- `npm run lint`
- Prettier check for all changed files
- real ACP cold-load probe against the reproduced forked session
