### PR TITLE
fix: restore an MCP tool result's resource_link blocks from tool_use_result

### DIFF
--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -1701,6 +1701,70 @@ describe("Bash terminal output", () => {
   });
 });
 
+describe("MCP tool results with resource links", () => {
+  const mcpToolUse = { id: "toolu_mcp", name: "mcp__slick__show_surface" };
+  const link = {
+    uri: "slick://surface?slot=plot&revision=7",
+    name: "plot",
+    title: "Surface: plot",
+    description: "Interactive output",
+    mimeType: "text/html",
+  };
+  // What the CLI hands the model: each resource_link rewritten as a line,
+  // the other blocks untouched.
+  const toolResult: ToolResultBlockParam = {
+    type: "tool_result",
+    tool_use_id: "toolu_mcp",
+    content: [
+      { type: "text", text: `[Resource link: plot] ${link.uri} (Interactive output)` },
+      { type: "text", text: "shown inline as plot (rendition 7)" },
+    ],
+  };
+
+  it("restores each link in place of the line the CLI made from it", () => {
+    const update = toolUpdateFromToolResult(toolResult, mcpToolUse, false, {
+      content: toolResult.content,
+      resourceLinks: [link],
+    });
+    expect(update.content).toEqual([
+      { type: "content", content: { type: "resource_link", ...link, size: undefined } },
+      { type: "content", content: { type: "text", text: "shown inline as plot (rendition 7)" } },
+    ]);
+  });
+
+  it("appends a link whose line is not in the content, keeping the text", () => {
+    const update = toolUpdateFromToolResult(toolResult, mcpToolUse, false, {
+      content: toolResult.content,
+      resourceLinks: [{ ...link, name: "renamed" }],
+    });
+    expect(update.content?.map((c) => c.type === "content" && c.content.type)).toEqual([
+      "text",
+      "text",
+      "resource_link",
+    ]);
+  });
+
+  it("renders the raw text when tool_use_result carries no links", () => {
+    for (const toolUseResult of [undefined, toolResult.content, { resourceLinks: "no" }]) {
+      const update = toolUpdateFromToolResult(toolResult, mcpToolUse, false, toolUseResult);
+      expect(update.content?.map((c) => c.type === "content" && c.content.type)).toEqual([
+        "text",
+        "text",
+      ]);
+    }
+  });
+
+  it("drops a link without a string uri and name rather than render it half-formed", () => {
+    const update = toolUpdateFromToolResult(toolResult, mcpToolUse, false, {
+      resourceLinks: [{ uri: 42, name: "plot" }, "plot", null, link],
+    });
+    const restored = update.content?.filter(
+      (c) => c.type === "content" && c.content.type === "resource_link",
+    );
+    expect(restored).toHaveLength(1);
+  });
+});
+
 describe("toolInfoFromToolUse - ExitPlanMode", () => {
   it("should include plan text in content when input.plan is provided", () => {
     const toolUse = {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5,7 +5,7 @@ import {
   ToolCallLocation,
   ToolKind,
 } from "@agentclientprotocol/sdk";
-import { HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import { HookCallback, SDKMcpResourceLink } from "@anthropic-ai/claude-agent-sdk";
 import {
   AgentInput,
   AgentOutput,
@@ -87,7 +87,15 @@ type ToolResultContent =
   | BetaTextEditorCodeExecutionViewResultBlock
   | BetaTextEditorCodeExecutionCreateResultBlock
   | BetaTextEditorCodeExecutionStrReplaceResultBlock
-  | BetaTextEditorCodeExecutionToolResultError;
+  | BetaTextEditorCodeExecutionToolResultError
+  | RestoredResourceLink;
+
+/**
+ * A `resource_link` an MCP tool returned, put back in place of the text line
+ * the CLI rewrote it into (see restoreResourceLinks). Never arrives in a
+ * tool_result's content from the SDK itself.
+ */
+type RestoredResourceLink = { type: "resource_link" } & SDKMcpResourceLink;
 
 interface ToolInfo {
   title: string;
@@ -964,9 +972,71 @@ export function toolUpdateFromToolResult(
     }
 
     default: {
+      // An MCP tool's `resource_link` result blocks never reach the
+      // tool_result: the CLI rewrites each into a `[Resource link: NAME] URI`
+      // text line for the model and keeps the originals on the message-level
+      // `tool_use_result.resourceLinks` (CLI 2.1.2xx). Put them back so a
+      // client renders the resource instead of parsing the line. Absent
+      // (older CLIs, replayed sessions), the raw text renders as before.
+      const links = mcpResourceLinks(
+        structuredResult<{ resourceLinks?: unknown }>(toolUseResult)?.resourceLinks,
+      );
+      if (links.length > 0) {
+        return toAcpContentUpdate(
+          restoreResourceLinks(toolResult.content, links),
+          "is_error" in toolResult ? toolResult.is_error : false,
+        );
+      }
       return rawContentUpdate();
     }
   }
+}
+
+/** The CLI-owned raw links of an MCP tool result, guarded field by field:
+ *  the value is untyped on the wire. Anything without a string uri and name
+ *  is dropped rather than rendered half-formed. */
+function mcpResourceLinks(value: unknown): SDKMcpResourceLink[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (link): link is SDKMcpResourceLink =>
+      typeof link === "object" &&
+      link !== null &&
+      typeof (link as SDKMcpResourceLink).uri === "string" &&
+      typeof (link as SDKMcpResourceLink).name === "string",
+  );
+}
+
+/** Rebuild an MCP tool result's content with its links restored: each text
+ *  line the CLI made from a link (`[Resource link: NAME] URI`, optionally
+ *  followed by the description) becomes that link again, in place, and any
+ *  link whose line is not found is appended — so a changed line format
+ *  degrades to the link AND its text, never to neither. */
+function restoreResourceLinks(content: unknown, links: SDKMcpResourceLink[]): unknown[] {
+  const blocks: unknown[] = Array.isArray(content)
+    ? content
+    : typeof content === "string" && content.length > 0
+      ? [{ type: "text", text: content }]
+      : typeof content === "object" && content !== null
+        ? [content]
+        : [];
+  const pending = [...links];
+  const restored = blocks.map((block) => {
+    const text =
+      typeof block === "object" &&
+      block !== null &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+        ? (block as { text: string }).text
+        : undefined;
+    if (text === undefined) return block;
+    const i = pending.findIndex((link) =>
+      text.startsWith(`[Resource link: ${link.name}] ${link.uri}`),
+    );
+    if (i < 0) return block;
+    const [link] = pending.splice(i, 1);
+    return { type: "resource_link", ...link } satisfies RestoredResourceLink;
+  });
+  return [...restored, ...pending.map((link) => ({ type: "resource_link", ...link }))];
 }
 
 /** One display format for a web-search hit, shared by the structured
@@ -1031,6 +1101,16 @@ function toAcpContentBlock(content: ToolResultContent, isError: boolean): Conten
       return {
         type: "text" as const,
         text: isError ? `\`\`\`\n${content.text}\n\`\`\`` : content.text,
+      };
+    case "resource_link":
+      return {
+        type: "resource_link" as const,
+        uri: content.uri,
+        name: content.name,
+        title: content.title,
+        description: content.description,
+        mimeType: content.mimeType,
+        size: content.size,
       };
     case "image":
       if (content.source.type === "base64") {


### PR DESCRIPTION
## Problem

An MCP tool that returns `resource_link` content blocks never gets them to the ACP client. The CLI rewrites each link into a `[Resource link: NAME] URI (description)` text line for the model, and `toolUpdateFromToolResult`'s default (MCP) case renders from that model-facing `tool_result.content`, so the `tool_call_update` on the wire carries only text:

```json
{"type":"content","content":{"type":"text","text":"[Resource link: plot] slick://surface?slot=plot&revision=7 (Interactive output)"}}
```

A client that anchors a rendered resource to the call that produced it (that is what slick does with `show_surface`) has nothing to match on, short of parsing the CLI's line.

The CLI keeps the originals for exactly this purpose. On Claude Code 2.1.261 an MCP tool's message-level `tool_use_result` is:

```json
{"content":[{"type":"text","text":"[Resource link: plot] slick://surface?… (Interactive output)"},{"type":"text","text":"shown inline as plot (rendition 7)"}],
 "resourceLinks":[{"uri":"slick://surface?…","name":"plot","title":"Surface: plot","description":"Interactive output","mimeType":"text/html"}]}
```

(SDK 0.3.257's `SDKMcpResourceLink` documents the field: "CLI-owned … collected from the raw result before the CLI rewrites each into the `[Resource link: NAME] URI` text line the model reads — so a host renders the files without parsing that line.")

## Fix

In the default case, read `tool_use_result.resourceLinks` through the existing `structuredResult` guard and rebuild the content: each rewritten line becomes its link again, in place, as an ACP `resource_link` block; a link whose line is not found is appended, so a changed line format degrades to link-and-text rather than to neither. Entries without a string `uri` and `name` are dropped. Without the field (older CLIs, replayed sessions) the raw text renders exactly as before.

The same wire now carries:

```json
{"type":"content","content":{"type":"resource_link","uri":"slick://surface?slot=plot&revision=7","name":"plot","title":"Surface: plot","description":"Interactive output","mimeType":"text/html"}}
{"type":"content","content":{"type":"text","text":"shown inline as plot (rendition 7)"}}
```

Not covered here: `task_notification.resource_links` for a backgrounded MCP task, which arrives on a different message.

## Tests

Four cases in `tools.test.ts`: restored in place, appended when the line is absent, raw text when the field is absent or malformed, half-formed entries dropped. `npm run check` and `npm run test:run` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
