### PR TITLE
feat: allow disabling session title generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ tool-call representation and child interactions stay on the root session. Client
 historical `_meta["subagent-transcript"]` capability or `forwardSubagentText` session option retain
 the flattened child transcript behavior.
 
+## Session title generation
+
+Set `ACP_DISABLE_TITLE_GENERATION=1` in the adapter process environment to skip its
+extra model request for a session title. This applies to every session handled by
+the process and is useful for background jobs, CI, and clients that manage titles
+themselves. Unset or other values retain automatic generation. Existing titles
+and stored summary fallbacks are still published through `session_info_update`.
+
+This adapter-specific option controls the adapter's explicit `generateSessionTitle`
+request. Claude Code's native `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` setting does not
+suppress that explicit request.
+
 ## Contribution Policy
 
 This project does not require a Contributor License Agreement (CLA). Instead, contributions are accepted under the following terms:

--- a/src/session-titles.ts
+++ b/src/session-titles.ts
@@ -192,6 +192,7 @@ export class SessionTitles {
   /** Whether to ask the SDK for a generated title now: once per session, on a
    *  live query, with enough collected text for the generator to work with. */
   private canRequest(session: Session): boolean {
+    if (process.env.ACP_DISABLE_TITLE_GENERATION === "1") return false;
     if (this.settled || session.queryClosed || session.cancelled) {
       return false;
     }

--- a/src/tests/session-titles.test.ts
+++ b/src/tests/session-titles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { ClaudeAcpAgent, type AcpClient } from "../acp-agent.js";
@@ -46,7 +46,9 @@ describe("SDK title generation contract", () => {
 describe("session titles at turn-end", () => {
   beforeEach(() => {
     vi.mocked(getSessionInfo).mockReset();
+    vi.stubEnv("ACP_DISABLE_TITLE_GENERATION", undefined);
   });
+  afterEach(() => vi.unstubAllEnvs());
 
   /** Collect every `session_info_update` an agent pushes. */
   function titleRecorder() {
@@ -149,7 +151,8 @@ describe("session titles at turn-end", () => {
     expect(titles()).toEqual(["Stable title"]);
   });
 
-  it("generates a title at turn-end instead of publishing the raw prompt", async () => {
+  it.each([undefined, "0"])("generates a title when the switch is %s", async (value) => {
+    vi.stubEnv("ACP_DISABLE_TITLE_GENERATION", value);
     const { client, titles } = titleRecorder();
     const agent = newAgent(client);
 
@@ -182,6 +185,39 @@ describe("session titles at turn-end", () => {
     // The raw prompt was never published — only the generated title.
     expect(titles()).toEqual(["Explain add() in hello.py"]);
   });
+
+  it.each(["missing", "summary", "custom"])(
+    "skips title generation when disabled and session metadata is %s",
+    async (metadata) => {
+      vi.stubEnv("ACP_DISABLE_TITLE_GENERATION", "1");
+      vi.mocked(getSessionInfo).mockResolvedValue(
+        metadata === "missing"
+          ? undefined
+          : {
+              sessionId: "test-session",
+              summary: LONG_PROMPT,
+              lastModified: 1_700_000_000_000,
+              ...(metadata === "custom" ? { customTitle: "My review" } : {}),
+            },
+      );
+      const { client, titles } = titleRecorder();
+      const agent = newAgent(client);
+      const input = new Pushable<any>();
+      const { query, generateSessionTitle } = wrapTitleQuery(oneTurn(input), "Unwanted title");
+      agent.sessions["test-session"] = mockSessionState({ query, input }, agent);
+
+      await agent.prompt({
+        sessionId: "test-session",
+        prompt: [{ type: "text", text: LONG_PROMPT }],
+      });
+      await agent.sessions["test-session"]?.consumer;
+
+      expect(generateSessionTitle).not.toHaveBeenCalled();
+      expect(titles()).toEqual(
+        metadata === "missing" ? [] : [metadata === "custom" ? "My review" : LONG_PROMPT],
+      );
+    },
+  );
 
   it("adopts a stored title and never generates over it", async () => {
     const { client, titles } = titleRecorder();


### PR DESCRIPTION
Headless jobs and clients that own their session titles currently trigger an additional model call through the adapter's explicit `generateSessionTitle()` request. This adds `ACP_DISABLE_TITLE_GENERATION=1` to skip that request for every session handled by the adapter process. Unset or other values keep the existing behavior; stored titles and summary fallbacks still publish through `session_info_update`.

Claude Code's native `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` flag does not suppress this explicit SDK control request. The adapter needs its own opt-out, including when a temporary session has no persisted metadata. This addresses the headless/CI concern raised in #861 without changing title generation by default.

Validation:
- The new opt-out tests fail on the unmodified implementation and pass with the change.
- Title tests: 14 passed, including unset/`0`, disabled with no session metadata, and preservation of stored titles and summary fallbacks.
- `npm run check` and `npm run build`: passed.
- Full suite: 1,236 passed, 27 skipped, 2 failures. The `ignores PostModelSwitch reports for the adapter's own setModel calls` failure also reproduces on unmodified upstream commit `3e23c5b` (expected `claude-sonnet-4-6`, received `claude-opus-4-8`). A file-change audit test hit its 5-second timeout; rerunning that file together with the title tests passed all 20 tests.
- Live-provider integration tests were not run.
