### PR TITLE
fix: apply changed execution limits when resuming sessions

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1123,14 +1123,22 @@ function disarmForceCancel(session: Session): void {
 
 /** Compute a stable fingerprint of the session-defining params so we can
  *  detect when a loadSession/resumeSession call requires tearing down and
- *  recreating the underlying Query process.  MCP servers are sorted by name
- *  so that ordering differences don't trigger unnecessary recreations. */
+ *  recreating the underlying Query process. Execution limits are Query options,
+ *  so a warm resume must not silently keep the previous values. MCP servers
+ *  are sorted by name so ordering differences don't trigger recreations. */
 function computeSessionFingerprint(params: {
   cwd: string;
   mcpServers?: NewSessionRequest["mcpServers"];
+  _meta?: NewSessionRequest["_meta"];
 }): string {
   const servers = [...(params.mcpServers ?? [])].sort((a, b) => a.name.localeCompare(b.name));
-  return JSON.stringify({ cwd: params.cwd, mcpServers: servers });
+  const options = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options;
+  return JSON.stringify({
+    cwd: params.cwd,
+    mcpServers: servers,
+    maxTurns: options?.maxTurns,
+    maxBudgetUsd: options?.maxBudgetUsd,
+  });
 }
 
 export type SDKMessageFilter = {

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -96,6 +96,48 @@ describe("createSession options merging", () => {
     agent = new ClaudeAcpAgent(createMockClient());
   });
 
+  for (const method of ["resumeSession", "loadSession"] as const) {
+    for (const limit of ["maxTurns", "maxBudgetUsd"] as const) {
+      it(`${method} applies added, tightened and removed ${limit} to the SDK query`, async () => {
+        const cwd = process.cwd();
+        const { sessionId } = await agent.newSession({ cwd, mcpServers: [] });
+
+        for (const value of [10, 1, undefined]) {
+          const previousOptions = capturedOptions;
+          await agent[method]({
+            sessionId,
+            cwd,
+            mcpServers: [],
+            _meta: { claudeCode: { options: { [limit]: value } } },
+          });
+
+          expect(capturedOptions).not.toBe(previousOptions);
+          expect(capturedOptions?.[limit]).toBe(value);
+          expect(capturedOptions?.resume).toBe(sessionId);
+        }
+      });
+    }
+
+    it(`${method} reuses the SDK query when execution limits are unchanged`, async () => {
+      const cwd = process.cwd();
+      const { sessionId } = await agent.newSession({
+        cwd,
+        mcpServers: [],
+        _meta: { claudeCode: { options: { maxTurns: 10, maxBudgetUsd: 1 } } },
+      });
+      const previousOptions = capturedOptions;
+
+      await agent[method]({
+        sessionId,
+        cwd,
+        mcpServers: [],
+        _meta: { claudeCode: { options: { maxBudgetUsd: 1, maxTurns: 10 } } },
+      });
+
+      expect(capturedOptions).toBe(previousOptions);
+    });
+  }
+
   it("merges user-provided disallowedTools with ACP internal list", async () => {
     await agent.newSession({
       cwd: process.cwd(),


### PR DESCRIPTION
A warm `session/resume` or `session/load` currently ignores changed `maxTurns` and `maxBudgetUsd`: the session fingerprint compares only cwd and MCP servers, so the SDK query retains its old options. A client can request a tighter limit and receive success while the old limit remains active.

Include these two SDK execution limits in the session fingerprint. Adding, changing or removing a limit recreates the query with the supplied options and the same session ID. Identical limits reuse the existing query; object key order does not trigger recreation. Budget accounting across recreated SDK processes remains the client's responsibility.

Validation:
- Four regression cases failed before the fix; six new cases cover both methods, both limits, tightening/removal, and unchanged reuse.
- `npm run check` and `npm run build` passed.
- Focused suites: 551 passed, 9 skipped.
- Full suite with `--maxWorkers=2`: 1,240 passed, 27 skipped. An initial unrestricted run hit one existing provider-switch test's 5s timeout and macOS `EMFILE` watcher errors; bounding workers passed without changing tests or timeouts.

Prepared while integrating typed runtime limits in BinaryBourbon/fountain#1732. No live SDK budget-enforcement claim is made by these adapter tests.
