### PR TITLE
fix: preserve fork metadata in newSession

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2115,9 +2115,10 @@ export class ClaudeAcpAgent {
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
+    const options = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options;
     const response = await this.createSession(params, {
-      // Revisit these meta values once we support resume
-      resume: (params._meta as NewSessionMeta | undefined)?.claudeCode?.options?.resume,
+      resume: options?.resume,
+      forkSession: options?.forkSession,
     });
     // Needs to happen after we return the session
     setTimeout(() => {
@@ -7707,7 +7708,7 @@ export class ClaudeAcpAgent {
 
     // We want to create a new session id unless it is resume,
     // but not resume + forkSession.
-    let sessionId;
+    let sessionId: string;
     if (creationOpts.publicSessionId) {
       sessionId = creationOpts.publicSessionId;
     } else if (creationOpts.forkSession) {
@@ -8074,7 +8075,7 @@ export class ClaudeAcpAgent {
     // `_meta.claudeCode.options.additionalDirectories` (SDK pass-through).
     options.additionalDirectories = additionalDirectories;
 
-    if (creationOpts?.resume === undefined || creationOpts?.forkSession) {
+    if (creationOpts?.resume === undefined) {
       // Set our own session id if not resuming an existing session.
       options.sessionId = creationOpts.publicSessionId ? randomUUID() : sessionId;
     }
@@ -8107,6 +8108,11 @@ export class ClaudeAcpAgent {
           throw RequestError.resourceNotFound(sessionId);
         }
         throw error;
+      }
+      const initializedSessionId = (initializationResult as { session_id?: unknown }).session_id;
+      if (creationOpts.forkSession && typeof initializedSessionId === "string") {
+        // Claude mints the provider child id for --resume + --fork-session.
+        sessionId = initializedSessionId;
       }
       timing.phase("sdk-initialize");
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -334,6 +334,42 @@ describe("task plan lifecycle", () => {
   });
 });
 
+describe("Claude fork session metadata", () => {
+  it("forwards forkSession while preserving the SDK persistence option", async () => {
+    const agent = new ClaudeAcpAgent({ sessionUpdate: async () => {} } as unknown as AcpClient, {
+      log: () => {},
+      error: () => {},
+    });
+    const createSession = vi
+      .spyOn(
+        agent as unknown as {
+          createSession: (...args: unknown[]) => Promise<unknown>;
+        },
+        "createSession",
+      )
+      .mockResolvedValue({ sessionId: "child-session" });
+
+    await agent.newSession({
+      cwd: process.cwd(),
+      mcpServers: [],
+      _meta: {
+        claudeCode: {
+          options: {
+            resume: "parent-session",
+            forkSession: true,
+            persistSession: false,
+          },
+        },
+      },
+    } as any);
+
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({ cwd: process.cwd() }), {
+      resume: "parent-session",
+      forkSession: true,
+    });
+  });
+});
+
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration", () => {
   let child: ReturnType<typeof spawn>;
 


### PR DESCRIPTION
Fixes #1107.

`newSession()` currently forwards `resume` from `_meta.claudeCode.options` but drops `forkSession`, so the documented SDK `resume + forkSession` path is not reached. This patch:

- forwards `forkSession` into `createSession()`;
- avoids setting a caller-owned `options.sessionId` for additive forks, allowing Claude to mint the provider child id;
- adopts the `session_id` reported by initialization as the child session key;
- adds a regression test covering metadata forwarding while retaining `persistSession: false` in the SDK options.

The source-level change is intentionally in `src/`; generated `dist/` output is not edited. `npm run test:run -- src/tests/acp-agent.test.ts` passes (485 passed, 9 skipped), and `npm run check` plus `npm run build` pass.
