### PR TITLE
fix: suppress cancelled turn tool starts

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -5419,6 +5419,7 @@ export class ClaudeAcpAgent {
                 emittedToolCalls: session.emittedToolCalls,
                 messageId: currentStreamMessageId,
                 streamedToolInputs,
+                suppressToolStarts: session.cancelled,
               },
             )) {
               // sendUpdate records delivery; a subagent stream's chunks carry
@@ -10369,6 +10370,7 @@ export function streamEventToAcpNotifications(
     emittedToolCalls?: Set<string>;
     messageId?: string;
     streamedToolInputs?: StreamedToolInputCache;
+    suppressToolStarts?: boolean;
   },
 ): SessionNotification[] {
   const event = message.event;
@@ -10385,6 +10387,19 @@ export function streamEventToAcpNotifications(
   switch (event.type) {
     case "content_block_start": {
       const block = event.content_block;
+      // A cancelled turn's consolidated message path is dropped at the
+      // `session.cancelled` guard below. Apply the same fence to streamed
+      // tool-use starts: late SDK stream events after `session/cancel` otherwise
+      // open ACP tool calls whose matching tool_result terminals are never
+      // forwarded, poisoning clients that track open tools (#1061).
+      if (
+        options?.suppressToolStarts &&
+        (block.type === "tool_use" ||
+          block.type === "server_tool_use" ||
+          block.type === "mcp_tool_use")
+      ) {
+        return [];
+      }
       if (
         streamedToolInputs &&
         (block.type === "tool_use" ||

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -13,7 +13,13 @@ import {
   BetaBashCodeExecutionResultBlock,
   BetaBashCodeExecutionToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
-import { AcpClient, toAcpNotifications, ToolUseCache, Logger } from "../acp-agent.js";
+import {
+  AcpClient,
+  toAcpNotifications,
+  streamEventToAcpNotifications,
+  ToolUseCache,
+  Logger,
+} from "../acp-agent.js";
 import {
   toolUpdateFromToolResult,
   createPostToolUseHook,
@@ -54,6 +60,44 @@ describe("PostToolUse callback ownership", () => {
 
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
+  });
+});
+
+describe("cancelled stream events", () => {
+  const mockClient = {} as AcpClient;
+  const mockLogger: Logger = { log: () => {}, error: () => {} };
+
+  it("drops late streamed tool starts after session cancel", () => {
+    const toolUseCache: ToolUseCache = {};
+    const emittedToolCalls = new Set<string>();
+
+    const notifications = streamEventToAcpNotifications(
+      {
+        type: "stream_event",
+        session_id: "provider-session",
+        uuid: "provider-message",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "toolu_cancelled",
+            name: "Bash",
+            input: { command: "sleep 10" },
+          },
+        },
+      } as any,
+      "session-1",
+      toolUseCache,
+      mockClient,
+      mockLogger,
+      { emittedToolCalls, suppressToolStarts: true },
+    );
+
+    expect(notifications).toEqual([]);
+    expect(toolUseCache).toEqual({});
+    expect(emittedToolCalls.has("toolu_cancelled")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- suppress late streamed tool-use starts once a turn has been cancelled
- keep cancelled stream events from populating `toolUseCache` / `emittedToolCalls` when their terminal tool_result path is already fenced off
- add regression coverage for the post-cancel stream_event ghost-tool-call case

Closes #1061

## Test Plan
- `npm test -- src/tests/tools.test.ts --run`
- `npm run build`
- `npm run check`
- `git diff --check`
