### PR TITLE
fix: bound steered turn settlement

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -678,6 +678,10 @@ type Turn = {
   /** What a steered turn settles with once its steered work has run: the outcome
    *  of its latest result, so its usage covers every cycle the turn ran. */
   steeredSettle?: PromptResponse;
+  /** Backstop armed when a steered turn has an outcome but is waiting for an
+   *  echo that may never replay. Mirrors cancel's bounded-hang protection for
+   *  the steering lane. */
+  steeredSettleTimer?: ReturnType<typeof setTimeout>;
   carriedUsage?: AccumulatedUsage;
   /** `carriedUsage`'s per-model counterpart, so a turn that survives a
    *  clear-context restart keeps the `_meta.quota` rows it earned pre-restart. */
@@ -1144,6 +1148,13 @@ function disarmForceCancel(session: Session): void {
   if (session.forceCancelTimer) {
     clearTimeout(session.forceCancelTimer);
     session.forceCancelTimer = undefined;
+  }
+}
+
+function disarmSteeredSettle(turn: Turn): void {
+  if (turn.steeredSettleTimer) {
+    clearTimeout(turn.steeredSettleTimer);
+    delete turn.steeredSettleTimer;
   }
 }
 
@@ -3674,6 +3685,7 @@ export class ClaudeAcpAgent {
       this.finishFileChangeAudit(session, turn, auditReason);
       // Captured before the settled flip below (isHeldOpen tests !settled).
       const wasHeld = isHeldOpen(turn);
+      disarmSteeredSettle(turn);
       turn.settled = true;
       turn.usageMarkdownAbort?.abort();
       disarmForceCancel(session);
@@ -4248,37 +4260,59 @@ export class ClaudeAcpAgent {
                       session.owedTrailingIdles--;
                     }
                     settleDeferredIfDrained();
+                  } else if (isSteering(session.activeTurn)) {
+                    // A steered turn settles here, not at a result: this idle is
+                    // the only signal spanning the interrupted and steered cycles
+                    // (see Turn.steeredEchoes). An idle before any result was
+                    // recorded means the answer is still ahead — swallow it, and
+                    // never let it reach the #825 fail below, which would reject
+                    // a prompt about to answer.
+                    //
+                    // Once a result HAS been recorded, the turn has an outcome to
+                    // deliver. Do not let stale trailing-idle debt consume that
+                    // only settling signal. If the SDK has not replayed all steer
+                    // echoes yet, arm a bounded backstop instead of parking the
+                    // session/prompt indefinitely (issue #1114).
+                    // Plain Turn so the fields can be cleared below; isSteering
+                    // narrows steeredEchoes to non-optional.
+                    const steered: Turn = session.activeTurn;
+                    const settleSteered = (reason: "idle" | "backstop") => {
+                      if (!isSteering(steered) || steered.steeredSettle === undefined) return;
+                      const turn: Turn = steered;
+                      if (reason === "backstop" && turn.steeredEchoes?.size !== 0) {
+                        this.logger.error(
+                          `Session ${params.sessionId}: settling steered turn despite ` +
+                            `${turn.steeredEchoes?.size ?? 0} undrained steered echo(es) ` +
+                            `(issue #1114)`,
+                        );
+                      }
+                      disarmSteeredSettle(turn);
+                      // Via the subagent gate, not settleActive: a steered turn
+                      // can also have spawned background subagents, which own it
+                      // from here (settles now if none is live, holds otherwise).
+                      turn.deferredSettle = turn.steeredSettle;
+                      delete turn.steeredEchoes;
+                      delete turn.steeredSettle;
+                      settleDeferredIfDrained();
+                    };
+                    if (steered.steeredSettle !== undefined) {
+                      if (steered.steeredEchoes?.size === 0) {
+                        settleSteered("idle");
+                      } else if (!steered.steeredSettleTimer) {
+                        steered.steeredSettleTimer = setTimeout(
+                          () => settleSteered("backstop"),
+                          DEFAULT_FORCE_CANCEL_GRACE_MS,
+                        );
+                        steered.steeredSettleTimer.unref?.();
+                      }
+                    }
                   } else if (session.owedTrailingIdles > 0) {
                     // Absorb a settled turn's trailing idle. Also covers a
                     // cancel that landed between a turn's counted result and
                     // this lagged idle (no active turn to settle): the idle
                     // still belongs to that settled turn, and skipping the
                     // decrement would leak the debt permanently.
-                    // Deliberately BEFORE the steer lane below: an owed idle
-                    // belongs to an earlier turn, and reading it as the steered
-                    // sequence's turn-over signal would settle a turn whose
-                    // steered cycle is still running. Steered results owe none.
                     session.owedTrailingIdles--;
-                  } else if (isSteering(session.activeTurn)) {
-                    // A steered turn settles here, not at a result: this idle is
-                    // the only signal spanning the interrupted and steered cycles
-                    // (see Turn.steeredEchoes). An idle before the steered echo,
-                    // or before any result was recorded, means the answer is
-                    // still ahead — swallow it, and never let it reach the #825
-                    // fail below, which would reject a prompt about to answer.
-                    //
-                    // Plain Turn so the fields can be cleared below; isSteering
-                    // narrows steeredEchoes to non-optional.
-                    const steered: Turn = session.activeTurn;
-                    if (steered.steeredEchoes?.size === 0 && steered.steeredSettle !== undefined) {
-                      // Via the subagent gate, not settleActive: a steered turn
-                      // can also have spawned background subagents, which own it
-                      // from here (settles now if none is live, holds otherwise).
-                      steered.deferredSettle = steered.steeredSettle;
-                      steered.steeredEchoes = undefined;
-                      steered.steeredSettle = undefined;
-                      settleDeferredIfDrained();
-                    }
                   } else if (
                     !session.cancelled &&
                     session.activeTurn &&

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -15819,6 +15819,46 @@ describe("turn steering (_session/steering)", () => {
     expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
   });
 
+  it("settles a steered turn when its result arrives but the steered echo never drains", async () => {
+    const agent = createMockAgent();
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => (releaseResult = resolve));
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const original = await iter.next();
+        yield userEcho(original.value);
+        await iter.next(); // steered input is accepted but never echoed back.
+        await resultGate;
+        yield createResultMessage();
+        yield idleMessage();
+      }
+      return messageGenerator();
+    });
+
+    const turn = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "start" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    await expect(
+      agent.steer({ sessionId: "test-session", prompt: [{ type: "text", text: "also handle X" }] }),
+    ).resolves.toEqual({ outcome: "injected" });
+    // Model the stale-idle-debt candidate from #1114: the steered result must
+    // still arm the bounded fallback instead of parking behind old trailer debt.
+    agent.sessions["test-session"].owedTrailingIdles = 1;
+
+    vi.useFakeTimers();
+    try {
+      releaseResult();
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(turn).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(agent.sessions["test-session"].turnQueue).toHaveLength(0);
+  });
+
   it("does not fail the turn on the SDK diagnostic result emitted before a steered echo", async () => {
     const agent = createMockAgent();
     injectGeneratorSession(agent, (input) => {


### PR DESCRIPTION
## Summary
- Add a bounded steering settlement backstop for turns that have recorded a terminal result but are still waiting for undrained steered echoes.
- Give the steering idle lane priority over stale trailing-idle debt once an outcome exists, so the only settlement signal cannot be consumed by older debt.
- Add regression coverage for the #1114 missing-echo/stale-idle-debt hang while preserving existing pre-echo idle behavior.

Fixes #1114

## Test Plan
- `npm run test:run -- src/tests/acp-agent.test.ts -t 'steered turn|priority'` — passed (11 passed, 483 skipped)
- `npm run test:run -- src/tests/acp-agent.test.ts` — passed (485 passed, 9 skipped)
- `npm run build` — passed
- `npm run check` — passed (`eslint src --ext .ts` + `prettier --check .`)
- `git diff --check origin/main..HEAD` — passed

Note: Claude Code delegation was unavailable in this cron shell because `claude auth status --text` reports `Not logged in. Run claude auth login to authenticate.`; implementation and validation were performed directly with local tests.
