### PR TITLE
fix: activate forked sessions

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2156,11 +2156,29 @@ export class ClaudeAcpAgent {
 
   async unstable_forkSession(params: ForkSessionRequest): Promise<ForkSessionResponse> {
     if (this.providerUpdate) await this.providerUpdate;
-    return forkSession(params, {
+    const forked = await forkSession(params, {
       liveMessageIdToUuid: this.sessions[params.sessionId]?.messageIdToUuid,
       logger: this.logger,
       messageIdForGrouping,
     });
+
+    const response = await this.createSession(
+      { ...params, mcpServers: params.mcpServers ?? [] },
+      { resume: forked.sessionId },
+    );
+
+    // Match session/new and session/load: the fork result is immediately usable
+    // by clients that prompt the returned session id without an extra load/resume.
+    setTimeout(() => {
+      this.sendAvailableCommandsUpdate(forked.sessionId);
+      startMcpAuthentication(this, forked.sessionId, params.mcpServers ?? []);
+    }, 0);
+
+    return {
+      sessionId: forked.sessionId,
+      modes: response.modes,
+      configOptions: response.configOptions,
+    };
   }
 
   async resumeSession(params: ResumeSessionRequest): Promise<ResumeSessionResponse> {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -8411,6 +8411,18 @@ describe("logout", () => {
 });
 
 describe("session/fork", () => {
+  function mockForkActivation(agent: ClaudeAcpAgent, sessionId = "fork-id") {
+    const modes = { currentModeId: "default", availableModes: [] };
+    const configOptions: never[] = [];
+    const createSession = vi
+      .spyOn(
+        agent as unknown as { createSession: (...args: unknown[]) => Promise<unknown> },
+        "createSession",
+      )
+      .mockResolvedValueOnce({ sessionId, modes, configOptions });
+    return { createSession, modes, configOptions };
+  }
+
   beforeEach(() => {
     vi.mocked(forkSession).mockClear();
     vi.mocked(getSessionMessages).mockClear();
@@ -8421,6 +8433,7 @@ describe("session/fork", () => {
     const client = { sessionUpdate: async () => {} } as unknown as AcpClient;
     const agent = new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
     vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
+    const { createSession, modes, configOptions } = mockForkActivation(agent);
 
     const response = await agent.unstable_forkSession({
       sessionId: "source-id",
@@ -8430,7 +8443,13 @@ describe("session/fork", () => {
     });
 
     expect(response.sessionId).toBe("fork-id");
+    expect(response.modes).toBe(modes);
+    expect(response.configOptions).toBe(configOptions);
     expect(forkSession).toHaveBeenCalledWith("source-id", { dir: "/workspace" });
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "source-id", cwd: "/workspace" }),
+      { resume: "fork-id" },
+    );
   });
 
   it("forks at an AIR message id through the current SDK", async () => {
@@ -8459,6 +8478,7 @@ describe("session/fork", () => {
       },
     ]);
     vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
+    const { createSession, modes, configOptions } = mockForkActivation(agent);
     const meta = {
       jetbrains: { air: { fork: { version: 1, messageId: "msg_123:segment:0" } } },
     };
@@ -8471,12 +8491,18 @@ describe("session/fork", () => {
     });
 
     expect(response.sessionId).toBe("fork-id");
+    expect(response.modes).toBe(modes);
+    expect(response.configOptions).toBe(configOptions);
     expect(getSessionMessages).toHaveBeenCalledWith("source-id", { dir: "/workspace" });
     expect(importSessionToStore).not.toHaveBeenCalled();
     expect(forkSession).toHaveBeenCalledWith("source-id", {
       dir: "/workspace",
       upToMessageId: "assistant-uuid",
     });
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "source-id", cwd: "/workspace" }),
+      { resume: "fork-id" },
+    );
   });
 
   it.each([
@@ -8578,6 +8604,7 @@ describe("session/fork", () => {
       ]);
     });
     vi.mocked(forkSession).mockResolvedValueOnce({ sessionId: "fork-id" });
+    const { createSession, modes, configOptions } = mockForkActivation(agent);
 
     const response = await agent.unstable_forkSession({
       sessionId: "source-id",
@@ -8599,6 +8626,8 @@ describe("session/fork", () => {
     });
 
     expect(response.sessionId).toBe("fork-id");
+    expect(response.modes).toBe(modes);
+    expect(response.configOptions).toBe(configOptions);
     expect(importSessionToStore).toHaveBeenLastCalledWith("source-id", expect.any(Object), {
       dir: "/workspace",
       includeSubagents: false,
@@ -8607,6 +8636,10 @@ describe("session/fork", () => {
       dir: "/workspace",
       upToMessageId: "inactive-assistant-uuid",
     });
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "source-id", cwd: "/workspace" }),
+      { resume: "fork-id" },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Keep `session/fork` using the SDK fork path, then resume the newly forked id through the adapter's normal session creation path.
- Return the forked session's initial `modes` and `configOptions`, matching the existing `session/new`/RFD shape so clients can prompt the returned id immediately.
- Extend the `session/fork` regressions to prove fork activation occurs for latest-turn, active-message, and inactive-branch forks.

Fixes #1110

## Test Plan
- `npm run test:run -- src/tests/acp-agent.test.ts -t 'session/fork'`
- `npm run build`
- `npm run check`
- `git diff --check`

## Duplicate check
- Searched open PRs for `"Session not found" "session/fork"`; no existing PR directly covers #1110.
- Reviewed adjacent open fork PRs (#1026 and #1108); they cover fork history replay / `newSession` fork metadata, not making `session/fork` return a live adapter session.

Note: Claude Code delegation was unavailable in this cron shell because `claude auth status --text` reports `Not logged in. Run claude auth login to authenticate.`; implementation and validation were performed directly with local tests.
