### PR TITLE
fix: honor host opt-out for allowDangerouslySkipPermissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -605,6 +605,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -623,6 +626,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -641,6 +647,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -659,6 +668,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,6 +689,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,6 +710,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2571,6 +2589,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2593,6 +2614,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2615,6 +2639,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2637,6 +2664,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -605,9 +605,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,9 +623,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -647,9 +641,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -668,9 +659,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -689,9 +677,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -710,9 +695,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2589,9 +2571,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2614,9 +2593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2639,9 +2615,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2664,9 +2637,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -161,7 +161,10 @@ import {
 import { forkSession } from "./fork-session.js";
 import { readResumedSession, type ResumedSessionSnapshot } from "./resumed-session.js";
 import { SessionTiming } from "./session-timing.js";
-import { ALLOW_BYPASS, resolvePermissionMode } from "./permissions/modes.js";
+import {
+  resolveAllowDangerouslySkipPermissions,
+  resolvePermissionMode,
+} from "./permissions/modes.js";
 import { normalizeDurablePermissionChangeSet } from "./permissions/normalization.js";
 import { buildClaudePermissionOptions } from "./permissions/options.js";
 import { buildClaudePermissionPresentation } from "./permissions/presentation.js";
@@ -1163,10 +1166,14 @@ export type NewSessionMeta = {
      * Those parameters will not be forwarded because they are managed by ACP:
      *   - cwd
      *   - includePartialMessages
-     *   - allowDangerouslySkipPermissions
      *   - permissionMode
      *   - canUseTool
      *   - executable
+     * `allowDangerouslySkipPermissions` may be set to `false` to opt out of
+     * requesting the bypass capability (`--allow-dangerously-skip-permissions`).
+     * When omitted, the adapter enables it on non-root sessions. Setting it to
+     * `true` does not override root/sandbox policy. Opting out is separate from
+     * entering `bypassPermissions` mode.
      * The `agent` parameter is also ignored: main-thread agent selection is not
      * part of this adapter's ACP contract.
      * Those parameters will be used and updated to work with ACP:
@@ -7865,14 +7872,24 @@ export class ClaudeAcpAgent {
       }
     }
 
+    // Extract options from _meta if provided
+    const sessionMeta = params._meta as NewSessionMeta | undefined;
+    const allowDangerouslySkipPermissions = resolveAllowDangerouslySkipPermissions(
+      sessionMeta?.claudeCode?.options?.allowDangerouslySkipPermissions,
+    );
+
     const permissionMode = resolvePermissionMode(
       settingsManager.getSettings().permissions?.defaultMode,
       this.logger,
     );
-    const initialPermissionMode = creationOpts.permissionMode ?? permissionMode;
+    let initialPermissionMode = creationOpts.permissionMode ?? permissionMode;
+    if (initialPermissionMode === "bypassPermissions" && !allowDangerouslySkipPermissions) {
+      this.logger.error(
+        "Ignoring bypassPermissions: allowDangerouslySkipPermissions was disabled by the host.",
+      );
+      initialPermissionMode = "default";
+    }
 
-    // Extract options from _meta if provided
-    const sessionMeta = params._meta as NewSessionMeta | undefined;
     const userProvidedOptions = sessionMeta?.claudeCode?.options
       ? { ...sessionMeta.claudeCode.options }
       : undefined;
@@ -8018,9 +8035,9 @@ export class ClaudeAcpAgent {
           ? { [FILE_CHANGE_AUDIT_SERVER_NAME]: fileChangeAuditSupport.mcpServer }
           : {}),
       },
-      // If we want bypassPermissions to be an option, we have to allow it here.
-      // But it doesn't work in root mode, so we only activate it if it will work.
-      allowDangerouslySkipPermissions: ALLOW_BYPASS,
+      // Request bypass capability unless the host explicitly opted out. Root
+      // sessions still cannot enable it (see resolveAllowDangerouslySkipPermissions).
+      allowDangerouslySkipPermissions,
       permissionMode: initialPermissionMode,
       canUseTool: this.canUseTool(sessionId),
       // Forward MCP elicitation requests onto ACP elicitation. Only attached
@@ -8282,6 +8299,7 @@ export class ClaudeAcpAgent {
         requestedMode: initialPermissionMode,
         currentModelInfo,
         currentModelId: models.currentModelId,
+        allowBypassCapability: allowDangerouslySkipPermissions,
       });
       timing.phase("modes");
 

--- a/src/permissions/modes.ts
+++ b/src/permissions/modes.ts
@@ -8,6 +8,13 @@ interface PermissionModeLogger {
 const IS_ROOT = (process.geteuid?.() ?? process.getuid?.()) === 0;
 export const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
 
+/** Host opt-out for --allow-dangerously-skip-permissions. Explicit false wins;
+ *  omitted (or true) keeps today's adapter default. */
+export function resolveAllowDangerouslySkipPermissions(hostValue?: boolean): boolean {
+  if (hostValue === false) return false;
+  return ALLOW_BYPASS;
+}
+
 const PERMISSION_MODE_ALIASES: Record<string, PermissionMode> = {
   // Settings use user-facing, case-insensitive spellings while the SDK uses
   // camel-cased wire values. Keep legacy shorthand accepted by Claude Code too.

--- a/src/session-mode.ts
+++ b/src/session-mode.ts
@@ -49,6 +49,8 @@ type InitializeSessionModeParams = {
   requestedMode: PermissionMode;
   currentModelInfo?: ModelInfo;
   currentModelId: string;
+  /** When false, bypassPermissions is omitted from the mode catalog. */
+  allowBypassCapability?: boolean;
 };
 
 /** Owns session-mode policy and the ACP/SDK synchronization it requires. */
@@ -60,11 +62,12 @@ export class SessionModeManager<S extends SessionMode> {
     requestedMode,
     currentModelInfo,
     currentModelId,
+    allowBypassCapability = ALLOW_BYPASS,
   }: InitializeSessionModeParams): Promise<{
     modes: SessionModeState;
     autoModeFallbackWarningPending: boolean;
   }> {
-    const availableModes = this.buildAvailableModes();
+    const availableModes = this.buildAvailableModes(allowBypassCapability);
     let effectiveMode = requestedMode;
     let autoModeFallbackWarningPending = false;
 
@@ -281,7 +284,7 @@ export class SessionModeManager<S extends SessionMode> {
     }
   }
 
-  private buildAvailableModes(): SessionModeState["availableModes"] {
+  private buildAvailableModes(allowBypassCapability: boolean): SessionModeState["availableModes"] {
     const modes: SessionModeState["availableModes"] = [
       {
         id: "default",
@@ -308,7 +311,7 @@ export class SessionModeManager<S extends SessionMode> {
         _meta: { kind: "auto_review" },
       },
     ];
-    if (ALLOW_BYPASS) {
+    if (allowBypassCapability) {
       modes.push({
         id: "bypassPermissions",
         name: "Bypass permissions",

--- a/src/tests/create-session-options.test.ts
+++ b/src/tests/create-session-options.test.ts
@@ -7,6 +7,7 @@ import {
 import type { ClientCapabilities } from "@agentclientprotocol/sdk";
 import { getSessionMessages, type Options } from "@anthropic-ai/claude-agent-sdk";
 import type { AcpClient, ClaudeAcpAgent as ClaudeAcpAgentType } from "../acp-agent.js";
+import { ALLOW_BYPASS } from "../permissions/modes.js";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -94,6 +95,81 @@ describe("createSession options merging", () => {
     ClaudeAcpAgent = acpAgent.ClaudeAcpAgent;
 
     agent = new ClaudeAcpAgent(createMockClient());
+  });
+
+  describe("allowDangerouslySkipPermissions", () => {
+    it("requests bypass capability by default", async () => {
+      await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      expect(capturedOptions!.allowDangerouslySkipPermissions).toBe(ALLOW_BYPASS);
+    });
+
+    it("honors explicit allowDangerouslySkipPermissions: false", async () => {
+      const response = await agent.newSession({
+        cwd: process.cwd(),
+        mcpServers: [],
+        _meta: {
+          claudeCode: {
+            options: { allowDangerouslySkipPermissions: false },
+          },
+        },
+      });
+
+      expect(capturedOptions!.allowDangerouslySkipPermissions).toBe(false);
+      expect(response.modes.availableModes.map((mode) => mode.id)).not.toContain(
+        "bypassPermissions",
+      );
+    });
+
+    it("still offers bypassPermissions when capability is not opted out", async () => {
+      if (!ALLOW_BYPASS) return;
+
+      const response = await agent.newSession({ cwd: process.cwd(), mcpServers: [] });
+
+      expect(capturedOptions!.allowDangerouslySkipPermissions).toBe(true);
+      expect(response.modes.availableModes.map((mode) => mode.id)).toContain("bypassPermissions");
+    });
+
+    it("clamps bypassPermissions default mode when the host opts out", async () => {
+      const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-acp-bypass-opt-out-"));
+      const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = configDir;
+      fs.writeFileSync(
+        path.join(configDir, "settings.json"),
+        JSON.stringify({ permissions: { defaultMode: "bypassPermissions" } }),
+      );
+
+      vi.resetModules();
+      const acpAgent = await import("../acp-agent.js");
+      const localAgent = new acpAgent.ClaudeAcpAgent(createMockClient());
+      const errorSpy = vi.fn();
+      (localAgent as any).logger = { log: () => {}, error: errorSpy };
+
+      try {
+        const response = await localAgent.newSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+          _meta: {
+            claudeCode: {
+              options: { allowDangerouslySkipPermissions: false },
+            },
+          },
+        });
+
+        expect(capturedOptions!.permissionMode).toBe("default");
+        expect(response.modes.currentModeId).toBe("default");
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("allowDangerouslySkipPermissions was disabled"),
+        );
+      } finally {
+        if (originalClaudeConfigDir !== undefined) {
+          process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+        } else {
+          delete process.env.CLAUDE_CONFIG_DIR;
+        }
+        fs.rmSync(configDir, { recursive: true, force: true });
+      }
+    });
   });
 
   it("merges user-provided disallowedTools with ACP internal list", async () => {

--- a/src/tests/resolve-permission-mode.test.ts
+++ b/src/tests/resolve-permission-mode.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Logger } from "../acp-agent.js";
-import { resolvePermissionMode } from "../permissions/modes.js";
+import {
+  ALLOW_BYPASS,
+  resolveAllowDangerouslySkipPermissions,
+  resolvePermissionMode,
+} from "../permissions/modes.js";
 
 function mockLogger() {
   const error = vi.fn<(...args: any[]) => void>();
@@ -8,6 +12,18 @@ function mockLogger() {
   const logger: Logger = { log, error };
   return { logger, error, log };
 }
+
+describe("resolveAllowDangerouslySkipPermissions", () => {
+  it("returns false when the host explicitly opts out", () => {
+    expect(resolveAllowDangerouslySkipPermissions(false)).toBe(false);
+  });
+
+  it("defaults to ALLOW_BYPASS when omitted or true", () => {
+    expect(resolveAllowDangerouslySkipPermissions()).toBe(ALLOW_BYPASS);
+    expect(resolveAllowDangerouslySkipPermissions(undefined)).toBe(ALLOW_BYPASS);
+    expect(resolveAllowDangerouslySkipPermissions(true)).toBe(ALLOW_BYPASS);
+  });
+});
 
 describe("resolvePermissionMode", () => {
   it("returns 'default' when no mode is provided", () => {

--- a/src/tests/session-mode.test.ts
+++ b/src/tests/session-mode.test.ts
@@ -122,6 +122,19 @@ describe("session mode", () => {
     ).rejects.toThrow("start a new session");
   });
 
+  it("omits bypassPermissions from the catalog when bypass capability is disabled", async () => {
+    const setPermissionMode = vi.fn();
+    const { manager } = createManager(undefined);
+    const result = await manager.initialize({
+      query: { setPermissionMode },
+      requestedMode: "default",
+      currentModelId: "opus",
+      allowBypassCapability: false,
+    });
+
+    expect(result.modes.availableModes.map((mode) => mode.id)).not.toContain("bypassPermissions");
+  });
+
   it("initializes the stable mode catalog and falls unsupported Auto back", async () => {
     const setPermissionMode = vi.fn();
     const { manager, notifications } = createManager(undefined);


### PR DESCRIPTION
## Summary

Closes #1119.

Hosts that never use `bypassPermissions` can opt out of requesting the bypass capability on `session/new`. When `_meta.claudeCode.options.allowDangerouslySkipPermissions` is explicitly `false`, the adapter no longer forces `--allow-dangerously-skip-permissions` onto the Claude CLI.

## API

- **Opt out:** set `_meta.claudeCode.options.allowDangerouslySkipPermissions: false`
- **Default (unchanged):** when omitted (or `true`), behavior matches today — the adapter requests the capability on non-root sessions via `ALLOW_BYPASS`
- **Separate concerns:** opting out does not enter `bypassPermissions` mode; it only suppresses the capability flag. When opted out, `bypassPermissions` is also removed from the session mode catalog and clamped if configured as the default mode.

## Changes

- Added `resolveAllowDangerouslySkipPermissions()` in `permissions/modes.ts`
- Updated `NewSessionMeta` docs to document the opt-out (previously listed as always ignored)
- `SessionModeManager.initialize()` accepts `allowBypassCapability` to hide bypass mode when opted out

## Testing

- `npm run check` — pass
- `npm run test:run` — 1308 passed, 27 skipped