### PR TITLE
fix: tolerate managed settings startup failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { resolveSettings } from "@anthropic-ai/claude-agent-sdk";
 import { claudeCliPath, runAcp } from "./acp-agent.js";
+import { applyManagedPolicyEnv } from "./managed-policy-env.js";
 import packageJson from "../package.json" with { type: "json" };
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
@@ -43,21 +43,19 @@ if (process.argv.includes("--cli")) {
   console.log(packageJson.version);
   process.exit(0);
 } else {
-  // Apply env vars from the managed-policy tier before any SDK call so the
-  // SDK subprocess inherits them. Going through resolveSettings (vs. a raw
-  // read of managed-settings.json) also picks up MDM sources on macOS and
-  // HKLM/HKCU on Windows.
-  const policy = await resolveSettings({ settingSources: [] });
-  for (const [key, value] of Object.entries(policy.effective.env ?? {})) {
-    process.env[key] = value;
-  }
-
-  // stdout is used to send messages to the client
-  // we redirect everything else to stderr to make sure it doesn't interfere with ACP
+  // stdout is used to send messages to the client; redirect diagnostics before
+  // managed settings are read so startup warnings cannot corrupt ACP framing.
   console.log = console.error;
   console.info = console.error;
   console.warn = console.error;
   console.debug = console.error;
+
+  // Apply env vars from the managed-policy tier before any SDK call so the
+  // SDK subprocess inherits them. Going through resolveSettings (vs. a raw
+  // read of managed-settings.json) also picks up MDM sources on macOS and
+  // HKLM/HKCU on Windows. If this best-effort lookup fails, continue startup
+  // with the existing process environment so the ACP server can still answer.
+  await applyManagedPolicyEnv();
 
   process.on("unhandledRejection", (reason, promise) => {
     console.error("Unhandled Rejection at:", promise, "reason:", reason);

--- a/src/managed-policy-env.ts
+++ b/src/managed-policy-env.ts
@@ -1,0 +1,27 @@
+import { resolveSettings } from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Apply managed-policy environment variables before starting the ACP runtime.
+ *
+ * A managed-settings lookup is a startup convenience, not a hard requirement for
+ * accepting the ACP connection. If the SDK cannot read policy settings because
+ * of a transient filesystem/registry failure, continue with the current process
+ * environment instead of exiting before initialization.
+ */
+export async function applyManagedPolicyEnv(
+  logError: (message: string, error: unknown) => void = console.error,
+): Promise<void> {
+  try {
+    const policy = await resolveSettings({ settingSources: [] });
+    for (const [key, value] of Object.entries(policy.effective.env ?? {})) {
+      if (typeof value === "string") {
+        process.env[key] = value;
+      }
+    }
+  } catch (error) {
+    logError(
+      "Unable to resolve managed Claude settings; continuing without managed policy environment.",
+      error,
+    );
+  }
+}

--- a/src/tests/managed-policy-env.test.ts
+++ b/src/tests/managed-policy-env.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSettings } from "@anthropic-ai/claude-agent-sdk";
+
+import { applyManagedPolicyEnv } from "../managed-policy-env.js";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
+  return {
+    ...actual,
+    resolveSettings: vi.fn(),
+  };
+});
+
+describe("applyManagedPolicyEnv", () => {
+  afterEach(() => {
+    vi.mocked(resolveSettings).mockReset();
+    delete process.env.CLAUDE_AGENT_ACP_POLICY_TEST;
+  });
+
+  it("applies managed policy environment variables", async () => {
+    vi.mocked(resolveSettings).mockResolvedValue({
+      effective: { env: { CLAUDE_AGENT_ACP_POLICY_TEST: "from-policy" } },
+    } as unknown as Awaited<ReturnType<typeof resolveSettings>>);
+
+    await applyManagedPolicyEnv();
+
+    expect(process.env.CLAUDE_AGENT_ACP_POLICY_TEST).toBe("from-policy");
+    expect(resolveSettings).toHaveBeenCalledWith({ settingSources: [] });
+  });
+
+  it("continues startup when managed settings cannot be resolved", async () => {
+    const error = new Error("transient settings read failure");
+    const logError = vi.fn();
+    vi.mocked(resolveSettings).mockRejectedValue(error);
+
+    await expect(applyManagedPolicyEnv(logError)).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledWith(
+      "Unable to resolve managed Claude settings; continuing without managed policy environment.",
+      error,
+    );
+    expect(process.env.CLAUDE_AGENT_ACP_POLICY_TEST).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #1124.
- Moves managed-policy env loading into a best-effort startup helper.
- Redirects diagnostics to stderr before the managed settings lookup so fallback warnings cannot corrupt ACP stdout framing.
- Adds focused coverage for both applying managed env values and continuing when `resolveSettings()` rejects.

## Test Plan
- `npm run check` — passed
- `npm run build` — passed
- `npm run test:run -- src/tests/managed-policy-env.test.ts` — passed (2 tests)
- `npm run test:run` — blocked by pre-existing/unrelated failures in this root cron environment:
  - `src/tests/resolve-permission-mode.test.ts` expects `bypassPermissions`, but running as root intentionally falls back to `default`.
  - `src/tests/session-config-options.test.ts` hook timeout in full-suite run.

Duplicate check:
- `gh pr list --repo agentclientprotocol/claude-agent-acp --state open --limit 100 ...` showed no open PR matching `resolveSettings`, transient startup, or #1124.
